### PR TITLE
Add auth service provider

### DIFF
--- a/lib/features/auth/auth_providers.dart
+++ b/lib/features/auth/auth_providers.dart
@@ -1,0 +1,7 @@
+// lib/features/auth/auth_providers.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'application/auth_service.dart';
+
+final authServiceProvider = Provider<AuthService>((ref) {
+  return AuthService();
+});


### PR DESCRIPTION
## Summary
- define `authServiceProvider` using Riverpod

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643c7f3a848323a9e713a78cb63eae