### PR TITLE
Add AuthFailure domain model

### DIFF
--- a/lib/features/auth/domain/auth_failure.dart
+++ b/lib/features/auth/domain/auth_failure.dart
@@ -1,0 +1,9 @@
+// lib/features/auth/domain/auth_failure.dart
+class AuthFailure {
+  final String message;
+
+  AuthFailure._(this.message);
+
+  factory AuthFailure.cancelledByUser() => AuthFailure._('Cancelled by user');
+  factory AuthFailure.serverError(String details) => AuthFailure._('Server error: $details');
+}


### PR DESCRIPTION
## Summary
- implement `AuthFailure` domain model with message, factory constructors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643ca7150083239791e43856ade0b5