### PR TITLE
Remove auth_providers file

### DIFF
--- a/lib/features/auth/auth_providers.dart
+++ b/lib/features/auth/auth_providers.dart
@@ -1,7 +1,0 @@
-// lib/features/auth/auth_providers.dart
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'application/auth_service.dart';
-
-final authServiceProvider = Provider<AuthService>((ref) {
-  return AuthService();
-});

--- a/lib/features/auth/presentation/auth_screen.dart
+++ b/lib/features/auth/presentation/auth_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../application/auth_service.dart';   // ← KEEP
-// import '../auth_providers.dart';          // ← REMOVE (file was deleted)
 import '../domain/auth_failure.dart';
 
 /// Simple authentication screen with a Google sign-in button.


### PR DESCRIPTION
## Summary
- delete deprecated `auth_providers.dart`
- clean up `AuthScreen` imports

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686444a16a548323b66e0fe3c23ff931