### PR TITLE
Add backend token verification

### DIFF
--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'package:asora/features/auth/application/auth_service.dart';
+import 'package:asora/features/auth/domain/auth_failure.dart';
+
+class FakeSecureStorage implements FlutterSecureStorage {
+  final Map<String, String?> _data = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    MacOsOptions? macOsOptions,
+    WebOptions? webOptions,
+    WindowsOptions? windowsOptions,
+  }) async {
+    _data[key] = value;
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    MacOsOptions? macOsOptions,
+    WebOptions? webOptions,
+    WindowsOptions? windowsOptions,
+  }) async {
+    return _data[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    MacOsOptions? macOsOptions,
+    WebOptions? webOptions,
+    WindowsOptions? windowsOptions,
+  }) async {
+    _data.remove(key);
+  }
+
+  @override
+  Future<void> deleteAll({
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    MacOsOptions? macOsOptions,
+    WebOptions? webOptions,
+    WindowsOptions? windowsOptions,
+  }) async {
+    _data.clear();
+  }
+}
+
+void main() {
+  test('verifyTokenWithBackend stores token on success', () async {
+    final client = MockClient((request) async {
+      expect(jsonDecode(request.body)['token'], equals('id123'));
+      return http.Response(jsonEncode({'sessionToken': 'abc'}), 200);
+    });
+    final storage = FakeSecureStorage();
+    final service = AuthService(
+      secureStorage: storage,
+      httpClient: client,
+      authUrl: 'https://example.com',
+    );
+
+    final token = await service.verifyTokenWithBackend('id123');
+
+    expect(token, equals('abc'));
+    expect(await storage.read(key: 'sessionToken'), equals('abc'));
+  });
+
+  test('verifyTokenWithBackend throws AuthFailure on error', () async {
+    final client = MockClient((request) async {
+      return http.Response('error', 500);
+    });
+    final service = AuthService(
+      secureStorage: FakeSecureStorage(),
+      httpClient: client,
+      authUrl: 'https://example.com',
+    );
+
+    expect(
+      () => service.verifyTokenWithBackend('bad'),
+      throwsA(isA<AuthFailure>()),
+    );
+  });
+}
+


### PR DESCRIPTION
## Summary
- send Google idToken to backend for verification and store session token
- expose session token helpers and update sign out
- add unit tests for token verification logic

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686445a8c664832384ec0c4403f85f7e