### PR TITLE
Alias engagement stats and add mapping tests

### DIFF
--- a/functions/feed/__tests__/mapPostForRanking.test.ts
+++ b/functions/feed/__tests__/mapPostForRanking.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { mapPostForRanking } from '../postMapper';
+
+// Verify engagement score calculation
+// likes + (comments * 2) + (shares * 3)
+test('calculates engagement score correctly', () => {
+  const post = {
+    id: '1',
+    authorId: 'author',
+    createdAt: new Date(),
+    likesCount: 5,
+    commentsCount: 2,
+    sharesCount: 1,
+    author: { reputationScore: 80 }
+  };
+
+  const result = mapPostForRanking(post);
+  assert.equal(result.engagementScore, 5 + 2 * 2 + 1 * 3);
+});
+
+// Ensure date handling works with string timestamps
+test('handles string timestamps safely', () => {
+  const timestamp = '2024-01-01T00:00:00.000Z';
+  const post = {
+    id: '2',
+    authorId: 'author',
+    createdAt: timestamp,
+    likesCount: 0,
+    commentsCount: 0,
+    sharesCount: 0,
+    author: { reputationScore: 10 }
+  };
+
+  const result = mapPostForRanking(post);
+  assert.equal(result.createdAt, new Date(timestamp).toISOString());
+});

--- a/functions/feed/postMapper.ts
+++ b/functions/feed/postMapper.ts
@@ -1,0 +1,14 @@
+import { PostForRanking } from '../shared/ranking';
+
+export function mapPostForRanking(post: any): PostForRanking {
+  return {
+    id: post.id,
+    authorId: post.authorId,
+    createdAt: new Date(post.createdAt).toISOString(),
+    engagementScore:
+      (post.likesCount || 0) +
+      (post.commentsCount || 0) * 2 +
+      (post.sharesCount || 0) * 3,
+    authorReputation: post.author?.reputationScore || 50
+  };
+}


### PR DESCRIPTION
## Summary
- Alias Cosmos engagement metrics (likes, comments, shares) as top-level fields in feed query
- Safely map post timestamps and compute engagement score via new post mapper
- Cover post mapping with tests for engagement score and ISO date handling

## Testing
- `npm test` *(fails: Error: no test specified)*
- `NODE_PATH=/workspace/Asora/node_modules:/tmp/test-dist node --test /tmp/test-dist/feed/__tests__/mapPostForRanking.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ba832061c83238ddaf676ff45b3d6