### PR TITLE
Handle NaN pagination parameters

### DIFF
--- a/functions/__tests__/feed.ranking.test.ts
+++ b/functions/__tests__/feed.ranking.test.ts
@@ -294,17 +294,19 @@ describe('Feed Ranking System', () => {
         { page: '0', limit: '20', expectedPage: 1, expectedLimit: undefined },
         { page: '1', limit: '0', expectedPage: undefined, expectedLimit: 20 },
         { page: '1', limit: '200', expectedPage: undefined, expectedLimit: 20 }, // Max limit enforcement
-        { page: 'invalid', limit: '20', expectedPage: 1, expectedLimit: undefined }
+        { page: 'abc', limit: '20', expectedPage: 1, expectedLimit: undefined },
+        { page: '1', limit: 'abc', expectedPage: undefined, expectedLimit: 20 },
+        { page: 'abc', limit: 'xyz', expectedPage: 1, expectedLimit: 20 }
       ];
 
       testCases.forEach(({ page, limit, expectedPage, expectedLimit }) => {
         const url = new URL(`https://api.asora.com/feed/get?page=${page}&limit=${limit}`);
         const parsedPage = parseInt(url.searchParams.get('page') || '1');
         const parsedLimit = parseInt(url.searchParams.get('limit') || '20');
-        
-        const finalPage = isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
-        const finalLimit = isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 100 ? 20 : parsedLimit;
-        
+
+        const finalPage = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
+        const finalLimit = Number.isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 100 ? 20 : parsedLimit;
+
         if (expectedPage !== undefined) expect(finalPage).toBe(expectedPage);
         if (expectedLimit !== undefined) expect(finalLimit).toBe(expectedLimit);
       });

--- a/functions/feed/get.ts
+++ b/functions/feed/get.ts
@@ -267,9 +267,11 @@ export async function getFeedInternal(request: HttpRequest, context: InvocationC
   try {
     // Parse query parameters
     const url = new URL(request.url);
+    const parsedPage = parseInt(url.searchParams.get('page') || '1');
+    const parsedLimit = parseInt(url.searchParams.get('limit') || '20');
     const query: FeedQuery = {
-      page: parseInt(url.searchParams.get('page') || '1'),
-      limit: parseInt(url.searchParams.get('limit') || '20'),
+      page: Number.isNaN(parsedPage) ? 1 : parsedPage,
+      limit: Number.isNaN(parsedLimit) ? 20 : parsedLimit,
       type: (url.searchParams.get('type') as FeedQuery['type']) || 'trending',
       filter: (url.searchParams.get('filter') as FeedQuery['filter']) || 'safe'
     };


### PR DESCRIPTION
## Summary
- Default `page` and `limit` to safe values when parsing non-numeric query params
- Extend pagination validation tests to cover malformed inputs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx jest functions/__tests__/feed.ranking.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_689ba8504fac8323a0b4e371a80724d9