### PR TITLE
Refactor userInfo JWT handling and add token metadata test

### DIFF
--- a/functions/__tests__/userinfo.token.test.ts
+++ b/functions/__tests__/userinfo.token.test.ts
@@ -1,0 +1,61 @@
+import { HttpRequest } from '@azure/functions';
+import jwt from 'jsonwebtoken';
+import { userInfo } from '../auth/userinfo';
+import { getUserContext } from '../shared/auth';
+import { getContainer } from '../shared/cosmosClient';
+
+jest.mock('../shared/auth');
+jest.mock('../shared/cosmosClient');
+
+const mockGetUserContext = getUserContext as jest.MockedFunction<typeof getUserContext>;
+const mockGetContainer = getContainer as jest.MockedFunction<typeof getContainer>;
+
+const createRequest = (token: string): HttpRequest => ({
+  method: 'GET',
+  url: 'http://test',
+  headers: {
+    get: (name: string) => {
+      if (name.toLowerCase() === 'authorization') {
+        return `Bearer ${token}`;
+      }
+      return undefined;
+    }
+  }
+} as any);
+
+const mockContext = {
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn()
+};
+
+describe('userInfo token metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('extracts issuedAt and expiresAt from JWT', async () => {
+    const token = jwt.sign({ sub: 'user123' }, 'secret', { expiresIn: '1h' });
+    const decoded: any = jwt.decode(token);
+    const expected = {
+      issuedAt: new Date(decoded.iat * 1000).toISOString(),
+      expiresAt: new Date(decoded.exp * 1000).toISOString()
+    };
+
+    mockGetUserContext.mockReturnValue({ userId: 'user123', email: 'test@example.com' });
+
+    const mockUser = {
+      id: 'user123',
+      email: 'test@example.com',
+      created_at: new Date().toISOString()
+    };
+    const container = { item: jest.fn().mockReturnThis(), read: jest.fn().mockResolvedValue({ resource: mockUser }) };
+    mockGetContainer.mockReturnValue(container as any);
+
+    const request = createRequest(token);
+    const response = await userInfo(request, mockContext as any);
+
+    expect(response.status).toBe(200);
+    expect(response.jsonBody.tokenInfo).toEqual(expected);
+  });
+});

--- a/functions/auth/userinfo.ts
+++ b/functions/auth/userinfo.ts
@@ -16,6 +16,7 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { getUserContext } from '../shared/auth';
 import { getContainer } from '../shared/cosmosClient';
+import jwt from 'jsonwebtoken';
 
 export async function userInfo(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
     try {
@@ -80,17 +81,12 @@ export async function userInfo(request: HttpRequest, context: InvocationContext)
             
             let tokenInfo = {};
             if (token) {
-                try {
-                    const jwt = require('jsonwebtoken');
-                    const decoded = jwt.decode(token) as any;
-                    if (decoded) {
-                        tokenInfo = {
-                            issuedAt: new Date(decoded.iat * 1000).toISOString(),
-                            expiresAt: new Date(decoded.exp * 1000).toISOString()
-                        };
-                    }
-                } catch (tokenError) {
-                    // Token info is optional, continue without it
+                const decoded = jwt.decode(token) as any;
+                if (decoded) {
+                    tokenInfo = {
+                        issuedAt: new Date(decoded.iat * 1000).toISOString(),
+                        expiresAt: new Date(decoded.exp * 1000).toISOString()
+                    };
                 }
             }
 

--- a/functions/shared/__tests__/telemetry.test.ts
+++ b/functions/shared/__tests__/telemetry.test.ts
@@ -176,9 +176,14 @@ describe('Telemetry System', () => {
     it('should stop and track metrics', () => {
       const timer = new PerformanceTimer('tracked-operation', mockContext);
       const properties = { operation_type: 'test' };
-      
+
+      const start = Date.now();
+      while (Date.now() - start < 5) {
+        // wait to ensure measurable duration
+      }
+
       const duration = timer.stopAndTrack(properties);
-      
+
       expect(duration).toBeGreaterThan(0);
       expect(mockContext.debug).toHaveBeenCalledWith(
         expect.stringContaining('Timer stopped: tracked-operation')


### PR DESCRIPTION
## Summary
- refactor auth/userinfo to use static `jwt` import and direct decode
- add unit test covering JWT metadata extraction
- stabilize telemetry test timing

## Testing
- `cd functions && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ba874e8508323859f34a923c3d5a2