### PR TITLE
ci: add Terraform infra workflow and dependencies

### DIFF
--- a/.github/workflows/deploy-functionapp-fixed.yml
+++ b/.github/workflows/deploy-functionapp-fixed.yml
@@ -31,8 +31,15 @@ env:
   FUNCTIONS_WORKER_RUNTIME: 'node'
 
 jobs:
+  infra:
+    uses: ./.github/workflows/infra.yml
+    with:
+      environment: ${{ github.event.inputs.environment }}
+    secrets: inherit
+
   build-and-deploy:
     runs-on: ubuntu-latest
+    needs: infra
     environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || null }}
     
     steps:

--- a/.github/workflows/deploy-functionapp.yml
+++ b/.github/workflows/deploy-functionapp.yml
@@ -30,9 +30,16 @@ env:
   WORKING_DIR: 'functions'
 
 jobs:
+  infra:
+    uses: ./.github/workflows/infra.yml
+    with:
+      environment: ${{ inputs.environment }}
+    secrets: inherit
+
   deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
+    needs: infra
     environment: ${{ inputs.environment }}
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,63 @@
+# ASORA TERRAFORM INFRASTRUCTURE WORKFLOW
+# Provisions Azure resources with Terraform using OIDC authentication
+
+name: Provision Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'development'
+        type: choice
+        options:
+          - development
+          - staging
+          - production
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TF_WORKING_DIR: infra
+
+jobs:
+  terraform:
+    name: Terraform init/plan/apply
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      ARM_USE_OIDC: true
+      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      TF_VAR_environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform init
+        run: terraform -chdir=$TF_WORKING_DIR init
+
+      - name: Terraform plan
+        run: terraform -chdir=$TF_WORKING_DIR plan -input=false
+
+      - name: Terraform apply
+        run: terraform -chdir=$TF_WORKING_DIR apply -auto-approve -input=false


### PR DESCRIPTION
## Summary
- add reusable Terraform infrastructure workflow with OIDC auth
- require function app deploy workflows to run after infrastructure provisioning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0e06e084832389918c2fc03ce6f9