### PR TITLE
Lock Function App runtime to Node 20 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,18 @@ jobs:
           echo "DEPLOY_ENV=development" >> $GITHUB_ENV
           echo "AZURE_RESOURCE_GROUP=asora-psql-flex" >> $GITHUB_ENV
 
+      - name: Configure Function App for Node 20
+        run: |
+          echo "Configuring Function App runtime and app settings for Node 20..."
+          az functionapp config appsettings set \
+            --name "$AZURE_FUNCTIONAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --settings FUNCTIONS_EXTENSION_VERSION=~4 FUNCTIONS_WORKER_RUNTIME=node WEBSITE_NODE_DEFAULT_VERSION=~20
+          az functionapp config set \
+            --name "$AZURE_FUNCTIONAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --linux-fx-version "Node|20"
+
       - name: Build functions
         working-directory: functions
         env:
@@ -330,6 +342,18 @@ jobs:
           echo "DEPLOY_ENV=staging" >> $GITHUB_ENV
           echo "AZURE_RESOURCE_GROUP=asora-staging" >> $GITHUB_ENV
 
+      - name: Configure Function App for Node 20
+        run: |
+          echo "Configuring Function App runtime and app settings for Node 20..."
+          az functionapp config appsettings set \
+            --name "$AZURE_FUNCTIONAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --settings FUNCTIONS_EXTENSION_VERSION=~4 FUNCTIONS_WORKER_RUNTIME=node WEBSITE_NODE_DEFAULT_VERSION=~20
+          az functionapp config set \
+            --name "$AZURE_FUNCTIONAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --linux-fx-version "Node|20"
+
       - name: Build functions
         working-directory: functions
         env:
@@ -422,6 +446,18 @@ jobs:
           echo "AZURE_FUNCTIONAPP_NAME=asora-function-production" >> $GITHUB_ENV
           echo "DEPLOY_ENV=production" >> $GITHUB_ENV
           echo "AZURE_RESOURCE_GROUP=asora-production" >> $GITHUB_ENV
+
+      - name: Configure Function App for Node 20
+        run: |
+          echo "Configuring Function App runtime and app settings for Node 20..."
+          az functionapp config appsettings set \
+            --name "$AZURE_FUNCTIONAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --settings FUNCTIONS_EXTENSION_VERSION=~4 FUNCTIONS_WORKER_RUNTIME=node WEBSITE_NODE_DEFAULT_VERSION=~20
+          az functionapp config set \
+            --name "$AZURE_FUNCTIONAPP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --linux-fx-version "Node|20"
 
       - name: Build functions
         working-directory: functions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,16 +238,10 @@ jobs:
           echo "AZURE_RESOURCE_GROUP=asora-psql-flex" >> $GITHUB_ENV
 
       - name: Configure Function App for Node 20
-        run: |
-          echo "Configuring Function App runtime and app settings for Node 20..."
-          az functionapp config appsettings set \
-            --name "$AZURE_FUNCTIONAPP_NAME" \
-            --resource-group "$AZURE_RESOURCE_GROUP" \
-            --settings FUNCTIONS_EXTENSION_VERSION=~4 FUNCTIONS_WORKER_RUNTIME=node WEBSITE_NODE_DEFAULT_VERSION=~20
-          az functionapp config set \
-            --name "$AZURE_FUNCTIONAPP_NAME" \
-            --resource-group "$AZURE_RESOURCE_GROUP" \
-            --linux-fx-version "Node|20"
+        uses: ./.github/actions/configure-node20-functionapp
+        with:
+          functionapp-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          resource-group: ${{ env.AZURE_RESOURCE_GROUP }}
 
       - name: Build functions
         working-directory: functions


### PR DESCRIPTION
## Summary
- ensure CI deploy jobs configure Azure Functions runtime to Node 20 by setting WEBSITE_NODE_DEFAULT_VERSION and linuxFxVersion

## Testing
- `npm --prefix functions run test:with-no-tests`


------
https://chatgpt.com/codex/tasks/task_e_68ac3bd311e48323acd56a11c0d482c7