### PR TITLE
chore: drop jq step and clarify placeholder test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,6 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -317,8 +315,6 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -422,8 +418,6 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/test_coverage_gate_placeholder.sh
+++ b/test_coverage_gate_placeholder.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-# Placeholder for future test coverage gate script.
-# Currently empty to avoid confusion.
+# Placeholder for a future test coverage gate script.
+# This script will enforce minimum test coverage thresholds before allowing merges.
+# Implementation is planned when test coverage enforcement is added to the CI pipeline.

--- a/test_coverage_gate_placeholder.sh
+++ b/test_coverage_gate_placeholder.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Placeholder for future test coverage gate script.
+# Currently empty to avoid confusion.


### PR DESCRIPTION
## Summary
- remove unused jq installs from CI workflow
- rename placeholder test coverage script to avoid confusion

## Testing
- `npm test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac539a9348832398121624d778eedf