### PR TITLE
chore: harden deployment health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,11 +265,17 @@ jobs:
       - name: Health check
         run: |
           URL="${{ steps.url.outputs.app_url }}/api/health"
-          code=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
-          echo "Health HTTP: $code"
-          if [ "$code" = "000" ]; then
-            echo "::warning::App not yet responding"
-          fi
+          for i in {1..10}; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+            echo "Attempt $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              echo "Health check succeeded"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Health check failed"
+          exit 1
 
       - name: Emit deployment summary
         run: |
@@ -368,11 +374,17 @@ jobs:
       - name: Health check
         run: |
           URL="${{ steps.url.outputs.app_url }}/api/health"
-          code=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
-          echo "Health HTTP: $code"
-          if [ "$code" = "000" ]; then
-            echo "::warning::App not yet responding"
-          fi
+          for i in {1..10}; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+            echo "Attempt $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              echo "Health check succeeded"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Health check failed"
+          exit 1
 
       - name: Emit deployment summary
         run: |
@@ -471,11 +483,17 @@ jobs:
       - name: Health check
         run: |
           URL="${{ steps.url.outputs.app_url }}/api/health"
-          code=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
-          echo "Health HTTP: $code"
-          if [ "$code" = "000" ]; then
-            echo "::warning::App not yet responding"
-          fi
+          for i in {1..10}; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || echo "000")
+            echo "Attempt $i: HTTP $code"
+            if [ "$code" = "200" ]; then
+              echo "Health check succeeded"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Health check failed"
+          exit 1
 
       - name: Emit deployment summary
         run: |


### PR DESCRIPTION
## Summary
- poll function app health endpoint during deployment
- fail deploy when health endpoint never returns 200

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint-check`


------
https://chatgpt.com/codex/tasks/task_e_68ac5e123e9c8323804401041800d6d5