### PR TITLE
Add production environment review gate

### DIFF
--- a/.github/environments/production.yml
+++ b/.github/environments/production.yml
@@ -1,0 +1,4 @@
+name: production
+reviewers:
+  users:
+    - octocat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,7 @@ jobs:
   deploy-production:
     name: Deploy to Azure (production)
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 25
     needs: [ flutter-test, functions-test ]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- define `production` environment requiring manual reviewers
- gate deploy-production job on the `production` environment

## Testing
- `npm test` *(fails: Missing script "test"?)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c44f82883238c6eb376294d0794