### PR TITLE
Add Application Insights telemetry check after deploy health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,21 @@ jobs:
           echo "::error::Health check failed"
           exit 1
 
+      - name: Application Insights telemetry check
+        env:
+          APP_INSIGHTS_APP_ID: ${{ secrets.APP_INSIGHTS_APP_ID }}
+          APP_INSIGHTS_API_KEY: ${{ secrets.APP_INSIGHTS_API_KEY }}
+        run: |
+          set -e
+          echo "Querying Application Insights telemetry..."
+          az monitor app-insights query \
+            --app "$APP_INSIGHTS_APP_ID" \
+            --analytics-query "availabilityResults | take 1" \
+            --api-key "$APP_INSIGHTS_API_KEY" \
+            --output none
+          echo "Telemetry query succeeded."
+          echo "Dashboard: https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents"
+
       - name: Emit deployment summary
         run: |
           echo "Environment: $DEPLOY_ENV"
@@ -411,6 +426,21 @@ jobs:
           done
           echo "::error::Health check failed"
           exit 1
+
+      - name: Application Insights telemetry check
+        env:
+          APP_INSIGHTS_APP_ID: ${{ secrets.APP_INSIGHTS_APP_ID }}
+          APP_INSIGHTS_API_KEY: ${{ secrets.APP_INSIGHTS_API_KEY }}
+        run: |
+          set -e
+          echo "Querying Application Insights telemetry..."
+          az monitor app-insights query \
+            --app "$APP_INSIGHTS_APP_ID" \
+            --analytics-query "availabilityResults | take 1" \
+            --api-key "$APP_INSIGHTS_API_KEY" \
+            --output none
+          echo "Telemetry query succeeded."
+          echo "Dashboard: https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents"
 
       - name: Emit deployment summary
         run: |
@@ -542,6 +572,21 @@ jobs:
           done
           echo "::error::Health check failed"
           exit 1
+
+      - name: Application Insights telemetry check
+        env:
+          APP_INSIGHTS_APP_ID: ${{ secrets.APP_INSIGHTS_APP_ID }}
+          APP_INSIGHTS_API_KEY: ${{ secrets.APP_INSIGHTS_API_KEY }}
+        run: |
+          set -e
+          echo "Querying Application Insights telemetry..."
+          az monitor app-insights query \
+            --app "$APP_INSIGHTS_APP_ID" \
+            --analytics-query "availabilityResults | take 1" \
+            --api-key "$APP_INSIGHTS_API_KEY" \
+            --output none
+          echo "Telemetry query succeeded."
+          echo "Dashboard: https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents"
 
       - name: Emit deployment summary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,19 +283,10 @@ jobs:
           exit 1
 
       - name: Application Insights telemetry check
-        env:
-          APP_INSIGHTS_APP_ID: ${{ secrets.APP_INSIGHTS_APP_ID }}
-          APP_INSIGHTS_API_KEY: ${{ secrets.APP_INSIGHTS_API_KEY }}
-        run: |
-          set -e
-          echo "Querying Application Insights telemetry..."
-          az monitor app-insights query \
-            --app "$APP_INSIGHTS_APP_ID" \
-            --analytics-query "availabilityResults | take 1" \
-            --api-key "$APP_INSIGHTS_API_KEY" \
-            --output none
-          echo "Telemetry query succeeded."
-          echo "Dashboard: https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents"
+        uses: ./.github/actions/appinsights-telemetry-check
+        with:
+          app_insights_app_id: ${{ secrets.APP_INSIGHTS_APP_ID }}
+          app_insights_api_key: ${{ secrets.APP_INSIGHTS_API_KEY }}
 
       - name: Emit deployment summary
         run: |


### PR DESCRIPTION
## Summary
- query Application Insights after health checks in dev, staging, and production deploy jobs
- surface link to Azure portal telemetry dashboards

## Testing
- `npm run lint-functions`


------
https://chatgpt.com/codex/tasks/task_e_68ac7a30c8c88323b38c92bce31026af