### PR TITLE
chore: grant write permissions for deploy workflow

### DIFF
--- a/.github/workflows/deploy-functions-flex.yml
+++ b/.github/workflows/deploy-functions-flex.yml
@@ -6,7 +6,8 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
+  pull-requests: write
 
 env:
   AZURE_FUNCTIONAPP_NAME: asora-function-flex
@@ -176,6 +177,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ github.token }}
           script: |
             const rate = `${{ steps.monitor.outputs.rate }}` || 'n/a';
             const sha = context.sha;


### PR DESCRIPTION
## Summary
- ensure deploy workflow can comment on commits and PRs
- explicitly use the default GitHub token for commit comments

## Testing
- `npm run lint-check` *(fails: ESLint errors)*
- `npm test` *(fails: Missing script)*
- `act -n -j deploy -W .github/workflows/deploy-functions-flex.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06fb4c3a483238867adea0f13b502