### PR TITLE
fix e2e script path in workflow

### DIFF
--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -45,7 +45,7 @@ jobs:
           COSMOS_DATABASE_NAME: asora
           FUNCTION_KEY: ${{ env.FUNCTION_KEY }}
         run: |
-          node scripts/e2e-itest.js
+          node ../scripts/e2e-itest.js
       - name: Upload E2E report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- fix e2e workflow script path to reference root scripts directory

## Testing
- `npm run lint-functions` *(fails: command sh -c eslint "**/*.{ts,js}" --fix)*
- `npm run test-functions`

------
https://chatgpt.com/codex/tasks/task_e_68c06fb9febc8323bc8c6bf3149c93ad