### PR TITLE
fix: handle canary fallback and streamline tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,14 +64,8 @@ jobs:
             { if (keep) print $0 }
           ' coverage/lcov.info > coverage/lcov.filtered.info
           mv coverage/lcov.filtered.info coverage/lcov.info
-      - name: Enforce Flutter coverage >= 80%
-        run: |
-          set -euo pipefail
-          if [ ! -f coverage/lcov.info ]; then
-            echo "Flutter coverage file missing: coverage/lcov.info" >&2
-            exit 1
-          fi
-          awk -F, '/^DA:/{total++; if ($2>0) hit++} END { if (total==0) { print "No coverage data (DA lines) found"; exit 1 } cov=100*hit/total; printf "Flutter line coverage: %.2f%%\n", cov; if (cov < 85) { print "Coverage below 85% threshold"; exit 1 } }' coverage/lcov.info
+      - name: Enforce Flutter coverage >= 85%
+        run: bash scripts/check_flutter_coverage.sh 85
       - name: Upload Flutter coverage
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy-functions-flex.yml
+++ b/.github/workflows/deploy-functions-flex.yml
@@ -116,11 +116,15 @@ jobs:
               retry az functionapp config appsettings set -g "$RG" -n "$APP" --slot canary \
                 --settings APPLICATIONINSIGHTS_ROLE_NAME="${APP}-canary" -o none
               CANARY_MODE="slot"
-            elif [[ -n "$CANARY_APP" ]] && exists_app "$RG" "$CANARY_APP"; then
-              set_node20 "$RG" "$CANARY_APP"
-              retry az functionapp config appsettings set -g "$RG" -n "$CANARY_APP" \
-                --settings APPLICATIONINSIGHTS_ROLE_NAME="$CANARY_APP" -o none
-              CANARY_MODE="separate-app"
+            elif [[ -n "$CANARY_APP" ]]; then
+              if exists_app "$RG" "$CANARY_APP"; then
+                set_node20 "$RG" "$CANARY_APP"
+                retry az functionapp config appsettings set -g "$RG" -n "$CANARY_APP" \
+                  --settings APPLICATIONINSIGHTS_ROLE_NAME="$CANARY_APP" -o none
+                CANARY_MODE="separate-app"
+              else
+                CANARY_MODE="absent"
+              fi
             else
               CANARY_MODE="absent"
             fi

--- a/lib/features/core/utils/date_formatter.dart
+++ b/lib/features/core/utils/date_formatter.dart
@@ -8,9 +8,12 @@ library;
 
 class DateFormatter {
   /// Format a DateTime as relative time (e.g., "2 hours ago", "Just now")
-  static String formatRelative(DateTime dateTime) {
-    final now = DateTime.now();
-    final difference = now.difference(dateTime);
+  static String formatRelative(
+    DateTime dateTime, {
+    DateTime? now,
+  }) {
+    final current = now ?? DateTime.now();
+    final difference = current.difference(dateTime);
 
     if (difference.inDays > 365) {
       final years = (difference.inDays / 365).floor();

--- a/scripts/check_flutter_coverage.sh
+++ b/scripts/check_flutter_coverage.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THRESHOLD=${1:-85}
+LCOV_FILE=${2:-coverage/lcov.info}
+
+if [ ! -f "$LCOV_FILE" ]; then
+  echo "Flutter coverage file missing: $LCOV_FILE" >&2
+  exit 1
+fi
+
+awk -F, -v threshold="$THRESHOLD" '
+  /^DA:/ { total++; if ($2>0) hit++ }
+  END {
+    if (total==0) { print "No coverage data (DA lines) found"; exit 1 }
+    cov=100*hit/total;
+    printf "Flutter line coverage: %.2f%%\n", cov;
+    if (cov < threshold) {
+      printf "Coverage below %d%% threshold\n", threshold;
+      exit 1;
+    }
+  }
+' "$LCOV_FILE"
+

--- a/test/features/auth/application/oauth2_service_test.dart
+++ b/test/features/auth/application/oauth2_service_test.dart
@@ -493,7 +493,7 @@ Map<String, dynamic> _decodeJWTPayload(String token) {
 String _generateTestRandomString(int length) {
   const chars =
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
-  final random = Random.secure();
+  final random = Random(42);
   return List.generate(
     length,
     (index) => chars[random.nextInt(chars.length)],

--- a/test/features/core/utils/date_formatter_test.dart
+++ b/test/features/core/utils/date_formatter_test.dart
@@ -19,147 +19,37 @@ void main() {
     group('formatRelative Tests', () {
       test('should return "Just now" for recent times', () {
         final recentTime = now.subtract(const Duration(seconds: 30));
-
-        // Mock DateTime.now() by overriding the calculation
-        final difference = now.difference(recentTime);
-        String result;
-
-        if (difference.inDays > 365) {
-          final years = (difference.inDays / 365).floor();
-          result = '${years}y ago';
-        } else if (difference.inDays > 30) {
-          final months = (difference.inDays / 30).floor();
-          result = '${months}mo ago';
-        } else if (difference.inDays > 0) {
-          result = '${difference.inDays}d ago';
-        } else if (difference.inHours > 0) {
-          result = '${difference.inHours}h ago';
-        } else if (difference.inMinutes > 0) {
-          result = '${difference.inMinutes}m ago';
-        } else {
-          result = 'Just now';
-        }
-
+        final result = DateFormatter.formatRelative(recentTime, now: now);
         expect(result, equals('Just now'));
       });
 
       test('should format minutes correctly', () {
         final minutesAgo = now.subtract(const Duration(minutes: 5));
-        final difference = now.difference(minutesAgo);
-
-        String result;
-        if (difference.inDays > 365) {
-          final years = (difference.inDays / 365).floor();
-          result = '${years}y ago';
-        } else if (difference.inDays > 30) {
-          final months = (difference.inDays / 30).floor();
-          result = '${months}mo ago';
-        } else if (difference.inDays > 0) {
-          result = '${difference.inDays}d ago';
-        } else if (difference.inHours > 0) {
-          result = '${difference.inHours}h ago';
-        } else if (difference.inMinutes > 0) {
-          result = '${difference.inMinutes}m ago';
-        } else {
-          result = 'Just now';
-        }
-
+        final result = DateFormatter.formatRelative(minutesAgo, now: now);
         expect(result, equals('5m ago'));
       });
 
       test('should format hours correctly', () {
         final hoursAgo = now.subtract(const Duration(hours: 3));
-        final difference = now.difference(hoursAgo);
-
-        String result;
-        if (difference.inDays > 365) {
-          final years = (difference.inDays / 365).floor();
-          result = '${years}y ago';
-        } else if (difference.inDays > 30) {
-          final months = (difference.inDays / 30).floor();
-          result = '${months}mo ago';
-        } else if (difference.inDays > 0) {
-          result = '${difference.inDays}d ago';
-        } else if (difference.inHours > 0) {
-          result = '${difference.inHours}h ago';
-        } else if (difference.inMinutes > 0) {
-          result = '${difference.inMinutes}m ago';
-        } else {
-          result = 'Just now';
-        }
-
+        final result = DateFormatter.formatRelative(hoursAgo, now: now);
         expect(result, equals('3h ago'));
       });
 
       test('should format days correctly', () {
         final daysAgo = now.subtract(const Duration(days: 5));
-        final difference = now.difference(daysAgo);
-
-        String result;
-        if (difference.inDays > 365) {
-          final years = (difference.inDays / 365).floor();
-          result = '${years}y ago';
-        } else if (difference.inDays > 30) {
-          final months = (difference.inDays / 30).floor();
-          result = '${months}mo ago';
-        } else if (difference.inDays > 0) {
-          result = '${difference.inDays}d ago';
-        } else if (difference.inHours > 0) {
-          result = '${difference.inHours}h ago';
-        } else if (difference.inMinutes > 0) {
-          result = '${difference.inMinutes}m ago';
-        } else {
-          result = 'Just now';
-        }
-
+        final result = DateFormatter.formatRelative(daysAgo, now: now);
         expect(result, equals('5d ago'));
       });
 
       test('should format months correctly', () {
         final monthsAgo = now.subtract(const Duration(days: 60));
-        final difference = now.difference(monthsAgo);
-
-        String result;
-        if (difference.inDays > 365) {
-          final years = (difference.inDays / 365).floor();
-          result = '${years}y ago';
-        } else if (difference.inDays > 30) {
-          final months = (difference.inDays / 30).floor();
-          result = '${months}mo ago';
-        } else if (difference.inDays > 0) {
-          result = '${difference.inDays}d ago';
-        } else if (difference.inHours > 0) {
-          result = '${difference.inHours}h ago';
-        } else if (difference.inMinutes > 0) {
-          result = '${difference.inMinutes}m ago';
-        } else {
-          result = 'Just now';
-        }
-
+        final result = DateFormatter.formatRelative(monthsAgo, now: now);
         expect(result, equals('2mo ago'));
       });
 
       test('should format years correctly', () {
         final yearsAgo = now.subtract(const Duration(days: 400));
-        final difference = now.difference(yearsAgo);
-
-        String result;
-        if (difference.inDays > 365) {
-          final years = (difference.inDays / 365).floor();
-          result = '${years}y ago';
-        } else if (difference.inDays > 30) {
-          final months = (difference.inDays / 30).floor();
-          result = '${months}mo ago';
-        } else if (difference.inDays > 0) {
-          result = '${difference.inDays}d ago';
-        } else if (difference.inHours > 0) {
-          result = '${difference.inHours}h ago';
-        } else if (difference.inMinutes > 0) {
-          result = '${difference.inMinutes}m ago';
-        } else {
-          result = 'Just now';
-        }
-
+        final result = DateFormatter.formatRelative(yearsAgo, now: now);
         expect(result, equals('1y ago'));
       });
 


### PR DESCRIPTION
## Summary
- avoid failing deployment when optional canary app is absent
- simplify date formatter tests and allow injecting current time
- use deterministic randomness and move coverage gate into script

## Testing
- `flutter test test/features/core/utils/date_formatter_test.dart test/features/auth/application/oauth2_service_test.dart` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c1de4c86688323b82136d33a43cddd