### PR TITLE
fix: rename function app to asora-function-dev

### DIFF
--- a/.github/workflows/deploy-functions-flex.yml
+++ b/.github/workflows/deploy-functions-flex.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   AZURE_FUNCTIONAPP_NAME: asora-function-dev
-  AZURE_FUNCTIONAPP_CANARY_NAME: ""
+  AZURE_FUNCTIONAPP_CANARY_NAME: asora-function-dev-canary
   AZURE_RESOURCE_GROUP: asora-psql-flex
   AZURE_APPINSIGHTS_NAME: asora-ai-flex
   AZURE_FD_PROFILE: asora-frontdoor

--- a/.github/workflows/deploy-functions-flex.yml
+++ b/.github/workflows/deploy-functions-flex.yml
@@ -86,7 +86,17 @@ jobs:
             set_node20() {
               local rg="$1" app="$2" slot_opt="${3:-}"
               if [[ "$(plan_kind "$rg" "$app")" == *linux* ]]; then
-                retry az functionapp config set -g "$rg" -n "$app" $slot_opt --linux-fx-version "node|20" -o none || true
+                # Only tolerate readonly linuxFxVersion errors, fail otherwise
+                {
+                  err_output=$(retry az functionapp config set -g "$rg" -n "$app" $slot_opt --linux-fx-version "node|20" -o none 2>&1)
+                } || {
+                  if [[ "$err_output" == *"The property 'linuxFxVersion' is read-only"* ]]; then
+                    echo "Warning: linuxFxVersion is readonly, skipping set."
+                  else
+                    echo "::error::Failed to set linuxFxVersion: $err_output"
+                    exit 1
+                  fi
+                }
               else
                 retry az functionapp config appsettings set -g "$rg" -n "$app" $slot_opt --settings WEBSITE_NODE_DEFAULT_VERSION=~20 -o none
               fi

--- a/.github/workflows/deploy-functions-flex.yml
+++ b/.github/workflows/deploy-functions-flex.yml
@@ -10,8 +10,8 @@ permissions:
   pull-requests: write
 
 env:
-  AZURE_FUNCTIONAPP_NAME: asora-function-flex
-  AZURE_FUNCTIONAPP_CANARY_NAME: asora-function-flex-canary
+  AZURE_FUNCTIONAPP_NAME: asora-function-dev
+  AZURE_FUNCTIONAPP_CANARY_NAME: ""
   AZURE_RESOURCE_GROUP: asora-psql-flex
   AZURE_APPINSIGHTS_NAME: asora-ai-flex
   AZURE_FD_PROFILE: asora-frontdoor
@@ -86,7 +86,7 @@ jobs:
             set_node20() {
               local rg="$1" app="$2" slot_opt="${3:-}"
               if [[ "$(plan_kind "$rg" "$app")" == *linux* ]]; then
-                retry az functionapp config set -g "$rg" -n "$app" $slot_opt --linux-fx-version "node|20" -o none
+                retry az functionapp config set -g "$rg" -n "$app" $slot_opt --linux-fx-version "node|20" -o none || true
               else
                 retry az functionapp config appsettings set -g "$rg" -n "$app" $slot_opt --settings WEBSITE_NODE_DEFAULT_VERSION=~20 -o none
               fi

--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get Function key
         id: funcKey
         run: |
-          key=$(az functionapp keys list -g asora-psql-flex -n asora-function-flex --query "masterKey" -o tsv)
+          key=$(az functionapp keys list -g asora-psql-flex -n asora-function-dev --query "masterKey" -o tsv)
           echo "FUNCTION_KEY=$key" >> $GITHUB_ENV
       - name: Install Functions deps
         working-directory: functions
@@ -40,7 +40,7 @@ jobs:
       - name: Run E2E script
         working-directory: functions
         env:
-          FUNCTION_BASE_URL: https://asora-function-flex.azurewebsites.net
+          FUNCTION_BASE_URL: https://asora-function-dev.azurewebsites.net
           COSMOS_CONNECTION_STRING: ${{ secrets.COSMOS_CONNECTION_STRING }}
           COSMOS_DATABASE_NAME: asora
           FUNCTION_KEY: ${{ env.FUNCTION_KEY }}

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ az cosmosdb sql container update -g asora-psql-flex -a asora-cosmos-dev -d asora
 ### Performance Monitoring
 ```bash
 # Feed metrics (requires PowerShell - install PowerShell Core or use Windows PowerShell)
-powershell.exe -File .\scripts\feed-metrics.ps1 -BaseUrl 'https://asora-function-flex.azurewebsites.net' -Count 20 -AuthToken '<jwt>'
+powershell.exe -File .\scripts\feed-metrics.ps1 -BaseUrl 'https://asora-function-dev.azurewebsites.net' -Count 20 -AuthToken '<jwt>'
 
 # Alternative with PowerShell Core (if installed):
-# pwsh ./scripts/feed-metrics.ps1 -BaseUrl 'https://asora-function-flex.azurewebsites.net' -Count 20 -AuthToken '<jwt>'
+# pwsh ./scripts/feed-metrics.ps1 -BaseUrl 'https://asora-function-dev.azurewebsites.net' -Count 20 -AuthToken '<jwt>'
 ```
 
 ### Deployment Validation

--- a/RELEASES/CANARY_ROLLOUT_PLAN.md
+++ b/RELEASES/CANARY_ROLLOUT_PLAN.md
@@ -1,7 +1,7 @@
 Canary Rollout Plan (Front Door, Flex Consumption)
 
 Scope
-- Apps: asora-function-flex (prod), asora-function-flex-canary (canary)
+- Apps: asora-function-dev (prod), asora-function-dev-canary (canary)
 - Traffic split via Azure Front Door origin weights (90/10)
 - Monitor App Insights requests failure rate for canary for 10 minutes
 - Rollback if failureRate > 1%
@@ -12,7 +12,7 @@ Prereqs
 
 Steps
 1) Deploy to CANARY:
-   - Publish `functions/` to `asora-function-flex-canary` via Functions Action (OneDeploy)
+   - Publish `functions/` to `asora-function-dev-canary` via Functions Action (OneDeploy)
 2) Shift traffic:
    - Set Front Door origin weights: prod=90, canary=10
 3) Monitor (10 min):

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: Minimal specification for P1 endpoints exposed by the Functions app.
 servers:
-  - url: https://asora-function-flex.azurewebsites.net
+  - url: https://asora-function-dev.azurewebsites.net
     description: Flex Consumption (prod)
 security:
   - bearerAuth: []

--- a/lib/core/security/cert_pinning.dart
+++ b/lib/core/security/cert_pinning.dart
@@ -27,7 +27,7 @@ const bool kEnableCertPinning = bool.fromEnvironment(
 // - Document pin extraction in docs/SECURITY_MOBILE_SOP.md
 const Map<String, List<String>> kPinnedDomains = {
   // Flex app host (prod/dev)
-  'asora-function-flex.azurewebsites.net': [
+  'asora-function-dev.azurewebsites.net': [
     'sha256/REPLACE_WITH_SPKI_PIN',       // Primary (leaf SPKI)
     'sha256/REPLACE_WITH_ROLLOVER_PIN',   // Rollover (leaf SPKI)
   ],

--- a/observability/appinsights-canary-failure.kql
+++ b/observability/appinsights-canary-failure.kql
@@ -1,5 +1,5 @@
 // Failure rate for CANARY Function App over last 10 minutes
-let app = 'asora-function-flex-canary';
+let app = 'asora-function-dev-canary';
 requests
 | where timestamp > ago(10m)
 | where cloud_RoleName == app

--- a/observability/appinsights-feed-p95.kql
+++ b/observability/appinsights-feed-p95.kql
@@ -1,7 +1,7 @@
 // Feed p95 latency and RU by endpoint
 union traces, requests
 | where timestamp > ago(7d)
-| where cloud_RoleName == "asora-function-flex"
+| where cloud_RoleName == "asora-function-dev"
 | extend endpoint = iff(isnotempty(name), name, tostring(customDimensions["endpoint"]))
 | extend ru = toreal(customDimensions["requestCharge"])
 | extend qdur = toint(customDimensions["queryDurationMs"])

--- a/observability/appinsights-profile-moderation.kql
+++ b/observability/appinsights-profile-moderation.kql
@@ -1,7 +1,7 @@
 // Profile moderation latency and decisions
 union traces, requests
 | where timestamp > ago(24h)
-| where cloud_RoleName endswith '-flex' or cloud_RoleName =~ 'asora-function-flex'
+| where cloud_RoleName endswith '-flex' or cloud_RoleName =~ 'asora-function-dev'
 | where message has 'Text moderation' or tostring(customDimensions['component']) == 'moderation/text'
 | extend decision = tostring(customDimensions['decision'])
 | extend score = todouble(customDimensions['score'])

--- a/scripts/admin-export.js
+++ b/scripts/admin-export.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 async function main() {
-  const baseUrl = process.env.FUNCTION_BASE_URL || 'https://asora-function-flex.azurewebsites.net';
+  const baseUrl = process.env.FUNCTION_BASE_URL || 'https://asora-function-dev.azurewebsites.net';
   const userId = process.argv[2];
   const outDir = process.argv[3] || '.';
   if (!userId) {

--- a/scripts/canary-setup.sh
+++ b/scripts/canary-setup.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 
 RG=${RG:-asora-psql-flex}
 REGION=${REGION:-northeurope}
-APP=${APP:-asora-function-flex}
-CANARY=${CANARY:-asora-function-flex-canary}
+APP=${APP:-asora-function-dev}
+CANARY=${CANARY:-asora-function-dev-canary}
 AI=${AI:-asora-ai-flex}
 FD_PROFILE=${FD_PROFILE:-asora-frontdoor}
 FD_ENDPOINT=${FD_ENDPOINT:-asora-frontdoor-endpoint}

--- a/scripts/feed-metrics.ps1
+++ b/scripts/feed-metrics.ps1
@@ -7,7 +7,7 @@ param(
 $ErrorActionPreference = 'Stop'
 
 if (-not $PSBoundParameters.ContainsKey('BaseUrl') -or [string]::IsNullOrEmpty($BaseUrl)) {
-  $BaseUrl = 'https://asora-function-flex.azurewebsites.net'
+  $BaseUrl = 'https://asora-function-dev.azurewebsites.net'
 }
 if (-not $PSBoundParameters.ContainsKey('Count') -or $Count -le 0) {
   $Count = 20

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="${FUNCTION_BASE_URL:-https://asora-function-flex.azurewebsites.net}"
+BASE_URL="${FUNCTION_BASE_URL:-https://asora-function-dev.azurewebsites.net}"
 OUT_DIR="smoke"
 THRESHOLD_SEC="0.5"
 

--- a/test/core/security/cert_pinning_test.dart
+++ b/test/core/security/cert_pinning_test.dart
@@ -7,14 +7,14 @@ void main() {
   group('Certificate Pinning Configuration Tests', () {
     test('Pinned domains contain flex host', () {
       expect(
-        kPinnedDomains.containsKey('asora-function-flex.azurewebsites.net'),
+        kPinnedDomains.containsKey('asora-function-dev.azurewebsites.net'),
         true,
       );
     });
 
     test('No placeholder pins in flex host set', () {
       final pins =
-          kPinnedDomains['asora-function-flex.azurewebsites.net'] ?? [];
+          kPinnedDomains['asora-function-dev.azurewebsites.net'] ?? [];
       final requireRealPins =
           Platform.environment['ASORA_REQUIRE_REAL_PINS'] == 'true';
       if (requireRealPins) {
@@ -124,7 +124,7 @@ void main() {
       'isPinValidationError detects connection errors for pinned domains',
       () {
         final requestOptions = RequestOptions(
-          path: 'https://asora-function-flex.azurewebsites.net/api/test',
+          path: 'https://asora-function-dev.azurewebsites.net/api/test',
         );
 
         final connectionError = DioException(


### PR DESCRIPTION
## Summary
- point workflows and scripts at `asora-function-dev`
- clear unused canary app name
- tolerate readonly linuxFxVersion when forcing Node 20

## Testing
- `az functionapp show -g asora-psql-flex -n asora-function-dev --only-show-errors` *(fails: command not found)*
- `az functionapp function list -g asora-psql-flex -n asora-function-dev -o table` *(fails: command not found)*
- `curl -sS -D - https://asora-function-dev.azurewebsites.net/api/health -o /dev/null` *(fails: CONNECT tunnel failed, response 403)*
- `dart test test/core/security/cert_pinning_test.dart` *(fails: command not found)*
- `act -n` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c26e600ad0832391839f9c8b316ed4