### PR TITLE
Fix OAuth2 random string test

### DIFF
--- a/test/features/auth/application/oauth2_service_test.dart
+++ b/test/features/auth/application/oauth2_service_test.dart
@@ -493,11 +493,10 @@ Map<String, dynamic> _decodeJWTPayload(String token) {
 String _generateTestRandomString(int length) {
   const chars =
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
-  // Use a fixed seed for deterministic output in tests only.
-  // Do NOT copy this pattern to production code.
-  final random = Random(42);
+  // Use cryptographically secure randomness to mimic production behavior.
+  final random = Random.secure();
   return List.generate(
     length,
-    (index) => chars[random.nextInt(chars.length)],
+    (_) => chars[random.nextInt(chars.length)],
   ).join();
 }


### PR DESCRIPTION
## Summary
- use secure randomness in test helper to ensure generated strings differ

## Testing
- `flutter test --coverage --reporter=compact` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c288d063888323b169da21f6a4ac07