### PR TITLE
test: add auth service edge case tests

### DIFF
--- a/lib/features/auth/application/auth_service.dart
+++ b/lib/features/auth/application/auth_service.dart
@@ -8,6 +8,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
 
 import '../domain/auth_failure.dart';
 import '../domain/user.dart';
@@ -54,6 +55,9 @@ GoogleSignIn _buildGoogleSignIn() {
       throw UnsupportedError('Unsupported platform');
   }
 }
+
+@visibleForTesting
+GoogleSignIn buildGoogleSignInForTest() => _buildGoogleSignIn();
 
 class AuthService {
   AuthService({

--- a/test/features/auth/application/auth_service_test.dart
+++ b/test/features/auth/application/auth_service_test.dart
@@ -292,6 +292,41 @@ void main() {
         },
       );
 
+      test(
+        'should throw AuthFailure.serverError for missing user in response',
+        () async {
+          // Arrange
+          final responseBody = {
+            'token': testToken,
+            // Missing user key
+          };
+
+          mockHttpClient.setResponse('$testAuthUrl/authEmail', responseBody);
+
+          // Act & Assert
+          expect(
+            () => authService.loginWithEmail(testEmail, testPassword),
+            throwsA(isA<AuthFailure>()),
+          );
+        },
+      );
+
+      test(
+        'should throw AuthFailure.serverError for non-200 status code',
+        () async {
+          // Arrange
+          mockHttpClient.setResponse('$testAuthUrl/authEmail', {
+            'error': 'Not found',
+          }, statusCode: 404);
+
+          // Act & Assert
+          expect(
+            () => authService.loginWithEmail(testEmail, testPassword),
+            throwsA(isA<AuthFailure>()),
+          );
+        },
+      );
+
       test('should throw AuthFailure.serverError for network error', () async {
         // Arrange
         mockHttpClient.setException(

--- a/test/features/auth/application/build_google_signin_test.dart
+++ b/test/features/auth/application/build_google_signin_test.dart
@@ -1,0 +1,43 @@
+// test/features/auth/application/build_google_signin_test.dart
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride, TargetPlatform;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:asora/features/auth/application/auth_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('_buildGoogleSignIn', () {
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('builds Android configuration', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      final signIn = buildGoogleSignInForTest();
+
+      expect(signIn.clientId, 'android-client-id-not-set');
+      expect(signIn.serverClientId, 'web-client-id-not-set');
+      expect(signIn.scopes, containsAll(['email', 'profile', 'openid']));
+    });
+
+    test('builds desktop configuration', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+
+      final signIn = buildGoogleSignInForTest();
+
+      expect(signIn.clientId, 'desktop-client-id-not-set');
+      expect(signIn.serverClientId, 'web-client-id-not-set');
+      expect(signIn.scopes, containsAll(['email', 'profile', 'openid']));
+    });
+
+    test('throws UnsupportedError for unsupported platform', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      expect(() => buildGoogleSignInForTest(), throwsUnsupportedError);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add test-only GoogleSignIn builder and unit tests for supported and unsupported platforms
- cover AuthService.loginWithEmail error branches for missing user and non-200 responses

## Testing
- `flutter test --coverage` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c29630a2f8832380c10474d6822603