### PR TITLE
Add OAuth2 service flow tests

### DIFF
--- a/test/features/auth/application/oauth2_service_test.dart
+++ b/test/features/auth/application/oauth2_service_test.dart
@@ -10,9 +10,56 @@ library;
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';
 import 'dart:math';
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:mockito/mockito.dart';
 
 import 'package:asora/core/auth/pkce_helper.dart';
+import 'package:asora/core/auth/auth_session_manager.dart';
+import 'package:asora/features/auth/domain/auth_failure.dart';
 import 'package:asora/features/auth/application/oauth2_service.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockAuthSessionManager extends Mock implements AuthSessionManager {}
+
+class TestOAuth2Service extends OAuth2Service {
+  TestOAuth2Service({
+    required FlutterSecureStorage secureStorage,
+    required http.Client httpClient,
+    required AuthSessionManager sessionManager,
+    this.timeout = const Duration(minutes: 5),
+  }) : super(
+          secureStorage: secureStorage,
+          httpClient: httpClient,
+          sessionManager: sessionManager,
+        );
+
+  final Duration timeout;
+
+  @override
+  void _setupCallbackListener() {
+    // No-op in tests to avoid platform channels
+  }
+
+  @override
+  Future<String> _waitForAuthorizationCode() {
+    _authCompleter = Completer<String>();
+    Timer(timeout, () {
+      if (!_authCompleter!.isCompleted) {
+        _authCompleter!.completeError(
+          AuthFailure.platformError('Authorization timeout'),
+        );
+      }
+    });
+    return _authCompleter!.future;
+  }
+}
 
 void main() {
   group('OAuth2Config Tests', () {
@@ -397,6 +444,275 @@ void main() {
       expect(payload['sub'], equals('1234567890'));
       expect(payload['name'], equals('John Doe'));
       expect(payload['iat'], equals(1516239022));
+    });
+  });
+
+  group('OAuth2Service Flow Tests', () {
+    late MockFlutterSecureStorage storage;
+    late MockHttpClient client;
+    late MockAuthSessionManager sessionManager;
+    late Map<String, String> store;
+
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      storage = MockFlutterSecureStorage();
+      client = MockHttpClient();
+      sessionManager = MockAuthSessionManager();
+      store = {};
+
+      when(storage.write(key: anyNamed('key'), value: anyNamed('value')))
+          .thenAnswer((invocation) async {
+        store[invocation.namedArguments[#key] as String] =
+            invocation.namedArguments[#value] as String;
+      });
+      when(storage.read(key: anyNamed('key')))
+          .thenAnswer((invocation) async =>
+              store[invocation.namedArguments[#key] as String]);
+      when(storage.delete(key: anyNamed('key')))
+          .thenAnswer((invocation) async =>
+              store.remove(invocation.namedArguments[#key] as String));
+      when(storage.deleteAll()).thenAnswer((_) async => store.clear());
+
+      when(sessionManager.createSession(
+        state: anyNamed('state'),
+        nonce: anyNamed('nonce'),
+        codeChallenge: anyNamed('codeChallenge'),
+      )).thenAnswer((invocation) async {
+        final state = invocation.namedArguments[#state] as String;
+        final nonce = invocation.namedArguments[#nonce] as String;
+        final codeChallenge =
+            invocation.namedArguments[#codeChallenge] as String;
+        return AuthSessionState(
+          id: 'session123',
+          state: state,
+          nonce: nonce,
+          codeVerifier: '',
+          codeChallenge: codeChallenge,
+          createdAt: DateTime.now(),
+          ttl: const Duration(minutes: 10),
+        );
+      });
+      when(sessionManager.completeSession(any))
+          .thenAnswer((_) async {});
+    });
+
+    group('signInWithOAuth2', () {
+      test('returns user on success', () async {
+        const MethodChannel('plugins.flutter.io/url_launcher')
+            .setMockMethodCallHandler((_) async => true);
+
+        final tokenJson = {
+          'access_token': 'access123',
+          'refresh_token': 'refresh123',
+          'token_type': 'Bearer',
+          'expires_in': 3600,
+          'scope': 'openid email profile',
+          'user': {
+            'id': 'user1',
+            'email': 'test@example.com',
+            'role': 'user',
+            'tier': 'bronze',
+            'reputationScore': 0,
+            'createdAt': '2023-01-01T00:00:00.000Z',
+            'lastLoginAt': '2023-01-01T00:00:00.000Z',
+            'isTemporary': false,
+          },
+        };
+
+        when(client.post(any,
+                headers: anyNamed('headers'), body: anyNamed('body')))
+            .thenAnswer(
+          (_) async => http.Response(jsonEncode(tokenJson), 200),
+        );
+
+        final service = TestOAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+          timeout: const Duration(seconds: 1),
+        );
+
+        final future = service.signInWithOAuth2();
+        await Future.delayed(const Duration(milliseconds: 10));
+        service._handleCallback(
+          Uri.parse('asora://oauth/callback?code=abc&state=xyz'),
+        );
+        final user = await future;
+        expect(user.email, equals('test@example.com'));
+      });
+
+      test('throws AuthFailure on invalid token response', () async {
+        const MethodChannel('plugins.flutter.io/url_launcher')
+            .setMockMethodCallHandler((_) async => true);
+
+        when(client.post(any,
+                headers: anyNamed('headers'), body: anyNamed('body')))
+            .thenAnswer(
+          (_) async => http.Response('error', 400),
+        );
+
+        final service = TestOAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+          timeout: const Duration(seconds: 1),
+        );
+
+        final future = service.signInWithOAuth2();
+        await Future.delayed(const Duration(milliseconds: 10));
+        service._handleCallback(
+          Uri.parse('asora://oauth/callback?code=abc&state=xyz'),
+        );
+
+        await expectLater(future, throwsA(isA<AuthFailure>()));
+      });
+
+      test('throws AuthFailure on authorization timeout', () async {
+        const MethodChannel('plugins.flutter.io/url_launcher')
+            .setMockMethodCallHandler((_) async => true);
+
+        final service = TestOAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+          timeout: const Duration(milliseconds: 10),
+        );
+
+        await expectLater(
+          service.signInWithOAuth2(),
+          throwsA(isA<AuthFailure>()),
+        );
+      });
+    });
+
+    group('refreshToken', () {
+      test('returns user when refresh succeeds', () async {
+        store['oauth2_refresh_token'] = 'refresh123';
+
+        final tokenJson = {
+          'access_token': 'access123',
+          'refresh_token': 'refresh123',
+          'token_type': 'Bearer',
+          'expires_in': 3600,
+          'scope': 'openid email profile',
+          'user': {
+            'id': 'user1',
+            'email': 'test@example.com',
+            'role': 'user',
+            'tier': 'bronze',
+            'reputationScore': 0,
+            'createdAt': '2023-01-01T00:00:00.000Z',
+            'lastLoginAt': '2023-01-01T00:00:00.000Z',
+            'isTemporary': false,
+          },
+        };
+
+        when(client.post(any,
+                headers: anyNamed('headers'), body: anyNamed('body')))
+            .thenAnswer(
+          (_) async => http.Response(jsonEncode(tokenJson), 200),
+        );
+        when(client.get(any, headers: anyNamed('headers'))).thenAnswer(
+          (_) async => http.Response(jsonEncode(tokenJson['user']), 200),
+        );
+
+        final service = OAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+        );
+
+        final user = await service.refreshToken();
+        expect(user?.email, equals('test@example.com'));
+      });
+
+      test('returns null when refresh token missing', () async {
+        final service = OAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+        );
+
+        final user = await service.refreshToken();
+        expect(user, isNull);
+      });
+
+      test('returns null on invalid response', () async {
+        store['oauth2_refresh_token'] = 'refresh123';
+
+        when(client.post(any,
+                headers: anyNamed('headers'), body: anyNamed('body')))
+            .thenAnswer(
+          (_) async => http.Response('error', 400),
+        );
+
+        final service = OAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+        );
+
+        final user = await service.refreshToken();
+        expect(user, isNull);
+        expect(store.isEmpty, isTrue);
+      });
+    });
+
+    group('getUserInfo', () {
+      test('returns user when access token exists', () async {
+        store['oauth2_access_token'] = 'access123';
+        final userJson = {
+          'id': 'user1',
+          'email': 'test@example.com',
+          'role': 'user',
+          'tier': 'bronze',
+          'reputationScore': 0,
+          'createdAt': '2023-01-01T00:00:00.000Z',
+          'lastLoginAt': '2023-01-01T00:00:00.000Z',
+          'isTemporary': false,
+        };
+
+        when(client.get(any, headers: anyNamed('headers'))).thenAnswer(
+          (_) async => http.Response(jsonEncode(userJson), 200),
+        );
+
+        final service = OAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+        );
+
+        final user = await service.getUserInfo();
+        expect(user?.email, equals('test@example.com'));
+        expect(store['oauth2_user_data'], isNotNull);
+      });
+
+      test('returns null when access token missing', () async {
+        final service = OAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+        );
+
+        final user = await service.getUserInfo();
+        expect(user, isNull);
+      });
+
+      test('returns null on invalid response', () async {
+        store['oauth2_access_token'] = 'access123';
+        when(client.get(any, headers: anyNamed('headers'))).thenAnswer(
+          (_) async => http.Response('error', 401),
+        );
+
+        final service = OAuth2Service(
+          secureStorage: storage,
+          httpClient: client,
+          sessionManager: sessionManager,
+        );
+
+        final user = await service.getUserInfo();
+        expect(user, isNull);
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- add comprehensive tests for OAuth2 service sign-in, token refresh, and user info retrieval
- exercise success paths, invalid responses, missing tokens, and authorization timeout cases

## Testing
- `flutter test test/features/auth/application/oauth2_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bb1b2aa88323854df40afd5515db