### PR TITLE
Fix tests with OAuth2 exposure and safer integrity logging

### DIFF
--- a/lib/core/security/device_integrity.dart
+++ b/lib/core/security/device_integrity.dart
@@ -115,7 +115,9 @@ class DeviceIntegrityService {
 
       return result;
     } catch (e) {
-      debugPrint('🚨 Device integrity check failed: $e');
+      try {
+        debugPrint('🚨 Device integrity check failed: $e');
+      } catch (_) {}
 
       final errorResult = DeviceIntegrityInfo(
         status: DeviceIntegrityStatus.error,

--- a/lib/core/security/device_integrity.dart
+++ b/lib/core/security/device_integrity.dart
@@ -117,7 +117,9 @@ class DeviceIntegrityService {
     } catch (e) {
       try {
         debugPrint('🚨 Device integrity check failed: $e');
-      } catch (_) {}
+      } catch (logError) {
+        print('🚨 [FALLBACK] Logging failed: $logError');
+      }
 
       final errorResult = DeviceIntegrityInfo(
         status: DeviceIntegrityStatus.error,

--- a/lib/features/auth/application/oauth2_service.dart
+++ b/lib/features/auth/application/oauth2_service.dart
@@ -10,7 +10,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart'
-    show kIsWeb, defaultTargetPlatform, TargetPlatform;
+    show kIsWeb, defaultTargetPlatform, TargetPlatform, visibleForTesting;
 
 // Conditional import for dart:html (web only)
 // ignore: uri_does_not_exist
@@ -524,4 +524,12 @@ class OAuth2Service {
     _linkSubscription?.cancel();
     _httpClient.close();
   }
+
+  /// Expose callback handling for tests
+  @visibleForTesting
+  void handleCallback(Uri uri) => _handleCallback(uri);
+
+  /// Allow tests to inject a custom completer
+  @visibleForTesting
+  set authCompleter(Completer<String> completer) => _authCompleter = completer;
 }

--- a/test/core/auth/auth_session_manager_test.dart
+++ b/test/core/auth/auth_session_manager_test.dart
@@ -3,6 +3,32 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:asora/core/auth/auth_session_manager.dart';
 import 'package:flutter/services.dart';
 
+/// In-memory fake for flutter_secure_storage
+class _FakeSecureStore {
+  final Map<String, String> data = {};
+  Future<dynamic> handle(MethodCall call) async {
+    switch (call.method) {
+      case 'write':
+        data['${call.arguments['key']}'] = call.arguments['value'] as String? ?? '';
+        return null;
+      case 'read':
+        return data['${call.arguments['key']}'];
+      case 'delete':
+        data.remove('${call.arguments['key']}');
+        return null;
+      case 'readAll':
+        return Map<String, String>.from(data);
+      case 'deleteAll':
+        data.clear();
+        return null;
+      case 'containsKey':
+        return data.containsKey('${call.arguments['key']}');
+      default:
+        return null;
+    }
+  }
+}
+
 // Mock for FlutterSecureStorage
 class MockFlutterSecureStorage extends FlutterSecureStorage {
   final Map<String, String> _storage = {};

--- a/test/features/auth/domain/user_test.dart
+++ b/test/features/auth/domain/user_test.dart
@@ -47,7 +47,8 @@ void main() {
     });
 
     test('toJson handles null tokenExpires', () {
-      final user = User.fromJson(baseJson).copyWith(tokenExpires: null);
+      final jsonMap = Map<String, dynamic>.from(baseJson)..remove('tokenExpires');
+      final user = User.fromJson(jsonMap);
       final json = user.toJson();
       expect(json['tokenExpires'], isNull);
     });

--- a/test/features/auth/presentation/auth_screen_test.dart
+++ b/test/features/auth/presentation/auth_screen_test.dart
@@ -27,13 +27,16 @@ void main() {
     }
 
     testWidgets('shows success snackbar on successful login', (tester) async {
-      when(mockService.signInWithGoogle()).thenAnswer((_) async => 'token');
+      when(mockService.signInWithGoogle()).thenAnswer((_) async {
+        await Future.delayed(const Duration(milliseconds: 10));
+        return 'token';
+      });
 
       await pumpScreen(tester);
       await tester.tap(find.text('Sign in with Google'));
       await tester.pump();
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
       expect(find.byType(CircularProgressIndicator), findsNothing);
       await tester.pump(const Duration(milliseconds: 100));
       expect(find.text('Logged in successfully'), findsOneWidget);
@@ -41,14 +44,16 @@ void main() {
     });
 
     testWidgets('shows error snackbar on AuthFailure', (tester) async {
-      when(mockService.signInWithGoogle())
-          .thenAnswer((_) async => throw AuthFailure.serverError('failure'));
+      when(mockService.signInWithGoogle()).thenAnswer((_) async {
+        await Future.delayed(const Duration(milliseconds: 10));
+        throw AuthFailure.serverError('failure');
+      });
 
       await pumpScreen(tester);
       await tester.tap(find.text('Sign in with Google'));
       await tester.pump();
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
       expect(find.byType(CircularProgressIndicator), findsNothing);
       await tester.pump(const Duration(milliseconds: 100));
       expect(find.text('failure'), findsOneWidget);

--- a/test/features/moderation/review_queue_screen_test.dart
+++ b/test/features/moderation/review_queue_screen_test.dart
@@ -21,10 +21,10 @@ void main() {
   testWidgets('_loadMore appends paginated items', (tester) async {
     final svc = MockModerationService();
     when(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
+      accessToken: anyNamed<String>('accessToken'),
       page: 1,
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     )).thenAnswer((_) async => {
           'items': [
             {'id': '1', 'title': 'A'},
@@ -32,10 +32,10 @@ void main() {
           ]
         });
     when(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
+      accessToken: anyNamed<String>('accessToken'),
       page: 2,
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     )).thenAnswer((_) async => {
           'items': [
             {'id': '3', 'title': 'C'},
@@ -63,26 +63,26 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(ListTile), findsNWidgets(4));
     verify(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
+      accessToken: anyNamed<String>('accessToken'),
       page: 1,
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     )).called(1);
     verify(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
+      accessToken: anyNamed<String>('accessToken'),
       page: 2,
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     )).called(1);
   });
 
   testWidgets('action buttons call service methods', (tester) async {
     final svc = MockModerationService();
     when(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
-      page: anyNamed('page'),
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      accessToken: anyNamed<String>('accessToken'),
+      page: anyNamed<int>('page'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     )).thenAnswer((_) async => {
           'items': [
             {'id': '1', 'title': 'A'},
@@ -90,9 +90,9 @@ void main() {
             {'id': '3', 'title': 'C'},
           ]
         });
-    when(svc.approve(any, any)).thenAnswer((_) async {});
-    when(svc.reject(any, any)).thenAnswer((_) async {});
-    when(svc.escalate(any, any)).thenAnswer((_) async {});
+    when(svc.approve(any<String>(), any<String>())).thenAnswer((_) async {});
+    when(svc.reject(any<String>(), any<String>())).thenAnswer((_) async {});
+    when(svc.escalate(any<String>(), any<String>())).thenAnswer((_) async {});
 
     await tester.pumpWidget(MaterialApp(
       home: ReviewQueueScreen(
@@ -111,24 +111,24 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.check).first);
     await tester.pump();
-    verify(svc.approve('t', '1')).called(1);
 
     await tester.tap(find.byIcon(Icons.close).first);
     await tester.pump();
-    verify(svc.reject('t', '2')).called(1);
 
     await tester.tap(find.byIcon(Icons.outbound).first);
     await tester.pump();
+    verify(svc.approve('t', '1')).called(1);
+    verify(svc.reject('t', '2')).called(1);
     verify(svc.escalate('t', '3')).called(1);
   });
 
   testWidgets('autoLoad=false waits until refresh', (tester) async {
     final svc = MockModerationService();
     when(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
-      page: anyNamed('page'),
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      accessToken: anyNamed<String>('accessToken'),
+      page: anyNamed<int>('page'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     )).thenAnswer((_) async => {'items': []});
 
     await tester.pumpWidget(MaterialApp(
@@ -142,10 +142,10 @@ void main() {
     ));
 
     verifyNever(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
-      page: anyNamed('page'),
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      accessToken: anyNamed<String>('accessToken'),
+      page: anyNamed<int>('page'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     ));
 
     // Instead of accessing the private _refresh method, trigger refresh via a public API.
@@ -161,10 +161,10 @@ void main() {
     await tester.pump();
 
     verify(svc.fetchReviewQueue(
-      accessToken: anyNamed('accessToken'),
+      accessToken: anyNamed<String>('accessToken'),
       page: 1,
-      pageSize: anyNamed('pageSize'),
-      status: anyNamed('status'),
+      pageSize: anyNamed<int>('pageSize'),
+      status: anyNamed<String>('status'),
     )).called(1);
   });
 }


### PR DESCRIPTION
## Summary
- expose OAuth2Service callback and auth completer for tests
- guard debug logging in DeviceIntegrityService
- update tests for null-safety and async handling

## Testing
- `flutter test test/features/auth/application/oauth2_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c2ca3473688323bf2e3c0055d87e01