### PR TITLE
chore: scrub legacy flex app settings

### DIFF
--- a/.github/workflows/deploy-asora-function-dev.yml
+++ b/.github/workflows/deploy-asora-function-dev.yml
@@ -131,8 +131,6 @@ jobs:
               --name "$FUNC_APP" \
               --settings \
                 FUNCTIONS_EXTENSION_VERSION="~4" \
-                FUNCTIONS_WORKER_RUNTIME="node" \
-                WEBSITE_CONTENTSHARE="$CONTENT_SHARE" \
                 SCM_ZIPDEPLOY_CONTAINER="$DEPLOY_CONTAINER"
             
             # Remove incompatible settings for Flex Consumption
@@ -146,6 +144,8 @@ jobs:
                 SCM_RUN_FROM_PACKAGE_CONTAINER \
                 SCM_CONTAINER \
                 SCM_TARGET_PATH \
+                FUNCTIONS_WORKER_RUNTIME \
+                WEBSITE_CONTENTSHARE \
                 WEBSITE_CONTENTAZUREFILECONNECTIONSTRING \
               2>/dev/null || true
             


### PR DESCRIPTION
## Summary
- stop setting unsupported FUNCTIONS_WORKER_RUNTIME and WEBSITE_CONTENTSHARE values during flex deployment
- ensure legacy worker runtime and content share settings are deleted when configuring the app

## Testing
- not run (workflow rerun happens in GitHub)

------
https://chatgpt.com/codex/tasks/task_e_68ef35c1f1748323b897bb7746d71dd1