### PR TITLE
Adjust canary workflow guard for workflow_run events

### DIFF
--- a/.github/workflows/canary-k6.yml
+++ b/.github/workflows/canary-k6.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   canary-k6:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     name: Run k6 canary tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- relax the canary job guard so non-workflow_run events continue

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efa1df7ef48323802fa9824cf68d10