### PR TITLE
Fix indentation in dev deploy workflow

### DIFF
--- a/.github/workflows/deploy-asora-function-dev.yml
+++ b/.github/workflows/deploy-asora-function-dev.yml
@@ -185,23 +185,23 @@ jobs:
             fi
 
             PATCH_BODY=$(python3 - "$CURRENT_CFG" <<'PY'
-import json, pathlib, sys
+            import json, pathlib, sys
 
-path = pathlib.Path(sys.argv[1])
-config = json.loads(path.read_text())
-if not isinstance(config, dict):
-    raise SystemExit("functionAppConfig missing or invalid")
+            path = pathlib.Path(sys.argv[1])
+            config = json.loads(path.read_text())
+            if not isinstance(config, dict):
+                raise SystemExit("functionAppConfig missing or invalid")
 
-config["runtime"] = {"name": "node", "version": "20"}
+            config["runtime"] = {"name": "node", "version": "20"}
 
-scale = config.get("scaleAndConcurrency") or {}
-scale["instanceMemoryMB"] = 2048
-config["scaleAndConcurrency"] = scale
+            scale = config.get("scaleAndConcurrency") or {}
+            scale["instanceMemoryMB"] = 2048
+            config["scaleAndConcurrency"] = scale
 
-config["siteUpdateStrategy"] = {"type": "Recreate"}
+            config["siteUpdateStrategy"] = {"type": "Recreate"}
 
-payload = {"properties": {"functionAppConfig": config}}
-print(json.dumps(payload))
+            payload = {"properties": {"functionAppConfig": config}}
+            print(json.dumps(payload))
 PY
 )
 


### PR DESCRIPTION
## Summary
- indent the Python heredoc lines in the dev deployment workflow
- ensure the inline script remains valid YAML for actionlint

## Testing
- ./bin/actionlint -color *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68f0dff35bcc832386d54988240ab127