### PR TITLE
Fix oasdiff wrapper format detection

### DIFF
--- a/tools/openapi/oasdiff/bin/oasdiff.js
+++ b/tools/openapi/oasdiff/bin/oasdiff.js
@@ -82,7 +82,7 @@ function parseArgs(argv) {
 function resolveSpec(pathLike) {
   const absolutePath = path.resolve(process.cwd(), pathLike);
   const rawContent = fs.readFileSync(absolutePath, 'utf8');
-  const format = inferFormat(absolutePath);
+  const format = inferFormat(absolutePath, rawContent);
 
   if (format === 'json') {
     try {
@@ -106,11 +106,25 @@ function resolveSpec(pathLike) {
   };
 }
 
-function inferFormat(filePath) {
+function inferFormat(filePath, rawContent) {
+  const trimmed = typeof rawContent === 'string' ? rawContent.trimStart() : '';
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      JSON.parse(rawContent);
+      return 'json';
+    } catch (error) {
+      // Fall back to extension-based detection when JSON parsing fails.
+    }
+  }
+
   const ext = path.extname(filePath).toLowerCase();
   if (ext === '.json') {
     return 'json';
   }
+  if (ext === '.yaml' || ext === '.yml') {
+    return 'yaml';
+  }
+
   return 'yaml';
 }
 


### PR DESCRIPTION
## Summary
- detect JSON OpenAPI specs by inspecting their contents instead of relying on file extensions
- retain YAML fallbacks so the wrapper continues to support traditional files while handling process substitution streams

## Testing
- node tools/openapi/oasdiff/bin/oasdiff.js api/openapi/dist/openapi.json api/openapi/dist/openapi.json *(fails: missing openapi-diff module in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f756697bd08323a0a598c47c2a1841