### PR TITLE
Simplify k6 canary scripts and workflow

### DIFF
--- a/.github/workflows/deploy-asora-function-dev.yml
+++ b/.github/workflows/deploy-asora-function-dev.yml
@@ -27,25 +27,23 @@ jobs:
   canary-k6:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      BASE_URL: https://${{ env.FUNC_APP }}.azurewebsites.net
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install k6
-        run: |
-          set -euo pipefail
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/k6-archive-keyring.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
-            | sudo tee /etc/apt/sources.list.d/k6.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y k6
-          k6 version
+      - name: Setup k6
+        uses: grafana/setup-k6-action@v1
 
       - name: Smoke (health)
-        run: BASE_URL="https://${FUNC_APP}.azurewebsites.net" VUS=1 DURATION=30s k6 run load/k6/smoke.js
+        run: |
+          BASE_URL="$BASE_URL" VUS=1 DURATION=30s \
+          k6 run load/k6/smoke.js
 
       - name: Feed read
-        run: BASE_URL="https://${FUNC_APP}.azurewebsites.net" VUS=5 DURATION=60s k6 run load/k6/feed-read.js
+        run: |
+          BASE_URL="$BASE_URL" VUS=5 DURATION=60s \
+          k6 run load/k6/feed-read.js
 
       - name: Upload k6 summaries
         uses: actions/upload-artifact@v4

--- a/load/k6/feed-read.js
+++ b/load/k6/feed-read.js
@@ -1,96 +1,29 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import exec from 'k6/execution';
-import { clamp, deterministicJitter, durationToMs, resolveUrl } from './utils.js';
-
-const BASE = __ENV.BASE_URL;
-if (!BASE) throw new Error('BASE_URL is required');
-
-const FEED_PATH = __ENV.FEED_PATH || '/api/feed?guest=1&limit=10';
-const FEED_URL = resolveUrl(BASE, FEED_PATH);
-
-const WARMUP_DURATION = __ENV.FEED_WARMUP_DURATION || '15s';
-const STEADY_DURATION = __ENV.DURATION || '60s';
-const STEADY_VUS = Number(__ENV.VUS || 5);
-
-const BASE_SLEEP_SECONDS = Number(__ENV.FEED_BASE_SLEEP || 1);
-const JITTER_SECONDS = Number(__ENV.FEED_JITTER || 0.35);
-const WARMUP_BASE_SLEEP = Number(__ENV.FEED_WARMUP_SLEEP || BASE_SLEEP_SECONDS);
-const WARMUP_JITTER = Number(__ENV.FEED_WARMUP_JITTER || 0.2);
-
-const SLOW_THRESHOLD_MS = Number(__ENV.FEED_SLOW_THRESHOLD_MS || 180);
-const RECOVERY_RATIO = Number(__ENV.FEED_RECOVERY_RATIO || 0.003);
-const MAX_RECOVERY_SECONDS = Number(__ENV.FEED_MAX_RECOVERY || 0.6);
-const SAFETY_WINDOW = __ENV.FEED_SAFETY_WINDOW || '2500ms';
-
-const STEADY_DURATION_MS = durationToMs(STEADY_DURATION);
-const SAFETY_WINDOW_MS = durationToMs(SAFETY_WINDOW);
 
 export const options = {
   scenarios: {
-    warmup: {
-      executor: 'constant-vus',
-      exec: 'warmup',
-      vus: 1,
-      duration: WARMUP_DURATION,
-      gracefulStop: '0s',
-      tags: { test: 'feed-read', phase: 'warmup' },
-    },
     steady: {
       executor: 'constant-vus',
-      exec: 'steady',
-      vus: STEADY_VUS,
-      duration: STEADY_DURATION,
-      startTime: WARMUP_DURATION,
-      gracefulStop: '10s',
-      tags: { test: 'feed-read', phase: 'steady' },
+      vus: Number(__ENV.VUS || 5),
+      duration: __ENV.DURATION || '60s',
     },
   },
   thresholds: {
-    'http_req_duration{scenario:steady,endpoint:feed}': ['p(95)<200', 'p(99)<400'],
-    'http_req_failed{scenario:steady,endpoint:feed}': ['rate<0.01'],
+    'http_req_failed{endpoint:feed}': ['rate<0.01'],
+    'http_req_duration{endpoint:feed}': ['p(95)<200', 'p(99)<400'],
   },
   summaryTrendStats: ['min', 'avg', 'med', 'p(95)', 'p(99)'],
   tags: { test: 'feed-read' },
 };
 
-function fetchFeed() {
-  const res = http.get(FEED_URL, { tags: { endpoint: 'feed', phase: exec.scenario.name } });
+const BASE = __ENV.BASE_URL;
+if (!BASE) throw new Error('BASE_URL is required');
+
+export default function () {
+  const res = http.get(`${BASE}/feed?guest=1&limit=10`, { tags: { endpoint: 'feed' } });
   check(res, { 'status 200/204': (r) => r.status === 200 || r.status === 204 });
-  return res;
-}
-
-function adaptiveSleep(baseSeconds, jitterSeconds, responseDurationMs, includeRecovery = true) {
-  const jitter = deterministicJitter(exec.vu.idInTest, exec.vu.iterationInScenario, jitterSeconds);
-  const recovery = includeRecovery && responseDurationMs > SLOW_THRESHOLD_MS
-    ? clamp((responseDurationMs - SLOW_THRESHOLD_MS) * RECOVERY_RATIO, 0, MAX_RECOVERY_SECONDS)
-    : 0;
-  return clamp(baseSeconds + jitter + recovery, 0.2);
-}
-
-function steadyShouldSkipIteration() {
-  const elapsedMs = exec.scenario.timeInScenario * 1000;
-  const remainingMs = STEADY_DURATION_MS - elapsedMs;
-  return remainingMs <= SAFETY_WINDOW_MS;
-}
-
-export function warmup() {
-  const res = fetchFeed();
-  sleep(adaptiveSleep(WARMUP_BASE_SLEEP, WARMUP_JITTER, res.timings.duration));
-}
-
-export function steady() {
-  if (steadyShouldSkipIteration()) {
-    const elapsedMs = exec.scenario.timeInScenario * 1000;
-    const remainingMs = Math.max(0, STEADY_DURATION_MS - elapsedMs);
-    if (remainingMs > 0) {
-      sleep(remainingMs / 1000);
-    }
-    return;
-  }
-
-  const res = fetchFeed();
-  sleep(adaptiveSleep(BASE_SLEEP_SECONDS, JITTER_SECONDS, res.timings.duration));
+  sleep(1);
 }
 
 export function handleSummary(data) {

--- a/load/k6/smoke.js
+++ b/load/k6/smoke.js
@@ -1,55 +1,24 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { resolveUrl } from './utils.js';
+
+export const options = {
+  vus: Number(__ENV.VUS || 1),
+  duration: __ENV.DURATION || '30s',
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<200', 'p(99)<400'],
+  },
+  summaryTrendStats: ['min', 'avg', 'med', 'p(95)', 'p(99)'],
+  tags: { test: 'smoke' },
+};
 
 const BASE = __ENV.BASE_URL;
 if (!BASE) throw new Error('BASE_URL is required');
 
-const HEALTH_PATH = __ENV.HEALTH_PATH || '/api/health';
-const HEALTH_URL = resolveUrl(BASE, HEALTH_PATH);
-const WARMUP_DURATION = __ENV.WARMUP_DURATION || '10s';
-const TEST_VUS = Number(__ENV.VUS || 1);
-const TEST_DURATION = __ENV.DURATION || '30s';
-
-export const options = {
-  scenarios: {
-    warmup: {
-      executor: 'constant-vus',
-      exec: 'warmup',
-      vus: 1,
-      duration: WARMUP_DURATION,
-      gracefulStop: '0s',
-      tags: { test: 'smoke', phase: 'warmup' },
-    },
-    steady: {
-      executor: 'constant-vus',
-      exec: 'steady',
-      vus: TEST_VUS,
-      duration: TEST_DURATION,
-      startTime: WARMUP_DURATION,
-      gracefulStop: '0s',
-      tags: { test: 'smoke', phase: 'steady' },
-    },
-  },
-  thresholds: {
-    'http_req_failed{scenario:steady}': ['rate<0.01'],
-    'http_req_duration{scenario:steady}': ['p(95)<200', 'p(99)<400'],
-  },
-  summaryTrendStats: ['min', 'avg', 'med', 'p(95)', 'p(99)'],
-};
-
-function hitHealth() {
-  const res = http.get(HEALTH_URL, { tags: { endpoint: 'health' } });
+export default function () {
+  const res = http.get(`${BASE}/health`, { tags: { endpoint: 'health' } });
   check(res, { 'health 200': (r) => r.status === 200 });
   sleep(1);
-}
-
-export function warmup() {
-  hitHealth();
-}
-
-export function steady() {
-  hitHealth();
 }
 
 export function handleSummary(data) {


### PR DESCRIPTION
## Summary
- simplify the k6 smoke and feed-read scripts around a single BASE_URL with the required SLO thresholds
- switch the canary workflow to use the setup-k6 action and share the computed BASE_URL between steps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f77877a5fc83239007a040918c6287