### PR TITLE
Remove invalid env context from canary workflow

### DIFF
--- a/.github/workflows/deploy-asora-function-dev.yml
+++ b/.github/workflows/deploy-asora-function-dev.yml
@@ -27,8 +27,6 @@ jobs:
   canary-k6:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      BASE_URL: https://${{ env.FUNC_APP }}.azurewebsites.net
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- remove the job-level BASE_URL definition that referenced the unavailable env context in the canary workflow

## Testing
- ./bin/actionlint -color *(fails: binary not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68f795eb2b388323a3a334f355379d14