### PR TITLE
Relax k6 thresholds and support overrides

### DIFF
--- a/.github/workflows/deploy-asora-function-dev.yml
+++ b/.github/workflows/deploy-asora-function-dev.yml
@@ -27,8 +27,6 @@ jobs:
   canary-k6:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      BASE_URL: https://${{ env.FUNC_APP }}.azurewebsites.net
     steps:
       - uses: actions/checkout@v4
 

--- a/load/k6/feed-read.js
+++ b/load/k6/feed-read.js
@@ -1,6 +1,11 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { resolveUrl } from './utils.js';
+import { resolveUrl, resolveDurationThresholds } from './utils.js';
+
+const durationThresholds = resolveDurationThresholds(__ENV, 'FEED_READ', {
+  p95: 2000,
+  p99: 3500,
+});
 
 export const options = {
   scenarios: {
@@ -12,7 +17,10 @@ export const options = {
   },
   thresholds: {
     'http_req_failed{endpoint:feed}': ['rate<0.01'],
-    'http_req_duration{endpoint:feed}': ['p(95)<200', 'p(99)<400'],
+    'http_req_duration{endpoint:feed}': [
+      `p(95)<${durationThresholds.p95}`,
+      `p(99)<${durationThresholds.p99}`,
+    ],
   },
   summaryTrendStats: ['min', 'avg', 'med', 'p(95)', 'p(99)'],
   tags: { test: 'feed-read' },

--- a/load/k6/smoke.js
+++ b/load/k6/smoke.js
@@ -1,13 +1,21 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { resolveUrl } from './utils.js';
+import { resolveUrl, resolveDurationThresholds } from './utils.js';
+
+const durationThresholds = resolveDurationThresholds(__ENV, 'SMOKE', {
+  p95: 1500,
+  p99: 2500,
+});
 
 export const options = {
   vus: Number(__ENV.VUS || 1),
   duration: __ENV.DURATION || '30s',
   thresholds: {
     http_req_failed: ['rate<0.01'],
-    http_req_duration: ['p(95)<200', 'p(99)<400'],
+    http_req_duration: [
+      `p(95)<${durationThresholds.p95}`,
+      `p(99)<${durationThresholds.p99}`,
+    ],
   },
   summaryTrendStats: ['min', 'avg', 'med', 'p(95)', 'p(99)'],
   tags: { test: 'smoke' },

--- a/load/k6/utils.js
+++ b/load/k6/utils.js
@@ -51,3 +51,30 @@ export function clamp(value, min, max) {
   if (max !== undefined && value > max) return max;
   return value;
 }
+
+export function readDurationThreshold(env, key, fallbackMs) {
+  if (!env || typeof env !== 'object') return fallbackMs;
+
+  const raw = env[key];
+  if (raw === undefined || raw === null || raw === '') {
+    return fallbackMs;
+  }
+
+  try {
+    return durationToMs(raw);
+  } catch (error) {
+    throw new Error(`Invalid duration for ${key}: ${error.message}`);
+  }
+}
+
+export function resolveDurationThresholds(env, prefix, defaults) {
+  if (!prefix) {
+    throw new Error('prefix is required');
+  }
+
+  const { p95, p99 } = defaults;
+  const resolvedP95 = readDurationThreshold(env, `${prefix}_P95_THRESHOLD`, p95);
+  const resolvedP99 = readDurationThreshold(env, `${prefix}_P99_THRESHOLD`, p99);
+
+  return { p95: resolvedP95, p99: resolvedP99 };
+}


### PR DESCRIPTION
## Summary
- add helpers for parsing duration threshold overrides used by k6 scripts
- relax smoke and feed-read canary thresholds with sensible defaults to avoid noisy failures
- allow environment-specific overrides for 95th and 99th percentile targets

## Testing
- not run (k6 and target services unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f795eb2b388323a3a334f355379d14