### PR TITLE
Harden health endpoint and deployment guardrails

### DIFF
--- a/.github/workflows/deploy-asora-function-consumption-y1.yml
+++ b/.github/workflows/deploy-asora-function-consumption-y1.yml
@@ -64,14 +64,16 @@ jobs:
           set -euo pipefail
           npm ci
           npm run build
-          
+
           # Verify essential files
           test -f dist/host.json || { echo "::error::dist/host.json missing"; exit 1; }
           test -f dist/index.js || { echo "::error::dist/index.js missing"; exit 1; }
-          
+          test -f dist/src/shared/routes/health.js || { echo "::error::dist/src/shared/routes/health.js missing"; ls -al dist/src/shared/routes; exit 1; }
+          node -e "require.resolve('./dist/src/shared/routes/health.js')" || { echo "::error::health route missing from dist"; exit 1; }
+
           # Install production dependencies
           cd dist && npm install --omit=dev --no-audit --no-fund
-          
+
           # Verify package.json has correct CommonJS configuration
           echo "Package configuration:"
           jq '{name, version, type, main}' package.json

--- a/.github/workflows/deploy-asora-function-dev.yml
+++ b/.github/workflows/deploy-asora-function-dev.yml
@@ -73,6 +73,8 @@ jobs:
           npm run build
           test -f dist/host.json || { echo "::error::dist/host.json missing"; ls -al dist; exit 1; }
           test -f dist/index.js || { echo "::error::dist/index.js missing"; ls -al dist; exit 1; }
+          test -f dist/src/shared/routes/health.js || { echo "::error::dist/src/shared/routes/health.js missing"; ls -al dist/src/shared/routes; exit 1; }
+          node -e "require.resolve('./dist/src/shared/routes/health.js')" || { echo "::error::health route missing from dist"; exit 1; }
 
           # Prod deps in dist
           if [ -f dist/package.json ]; then
@@ -80,7 +82,7 @@ jobs:
           fi
 
           # Sanity: index.js must load without env (no top-level side effects)
-          (cd dist && node -e "require('./index.js'); console.log('OK')") || { echo "::error::dist/index.js throws at load"; exit 1; }
+          (cd dist && node -e "require('./index.js'); require('./src/shared/routes/health.js'); console.log('health OK')") || { echo "::error::dist/index.js throws at load"; exit 1; }
 
           pushd dist >/dev/null
           zip -r ../dist-func.zip . -x "**/*.map" "**/*.ts" "__tests__/*" "tests/*"

--- a/functions/package.json
+++ b/functions/package.json
@@ -80,6 +80,13 @@
     "hive-ai",
     "asora"
   ],
+  "sideEffects": [
+    "src/shared/routes/*",
+    "src/auth/routes/*",
+    "src/feed/routes/*",
+    "src/moderation/routes/*",
+    "src/privacy/routes/*"
+  ],
   "author": "Asora Team",
   "license": "MIT"
 }

--- a/functions/src/shared/routes/health.ts
+++ b/functions/src/shared/routes/health.ts
@@ -11,18 +11,31 @@ app.http('health', {
   route: 'health',
   handler: async (): Promise<HttpResponseInit> => {
     try {
-      const commit = process.env.GIT_SHA ?? 'unknown';
+      const commit = (process.env.GIT_SHA ?? 'unknown').trim() || 'unknown';
+      const payload = { status: 'ok', commit };
+      const body = JSON.stringify(payload);
+
       return {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        jsonBody: { status: 'ok', commit },
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+        body,
+        jsonBody: payload,
       };
     } catch {
       // Never crash liveness - return minimal response if anything fails
+      const payload = { status: 'ok' };
+
       return {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
-        jsonBody: { status: 'ok' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+        body: JSON.stringify(payload),
+        jsonBody: payload,
       };
     }
   },


### PR DESCRIPTION
## Summary
- ensure the health route always serializes a response body without relying on Azure host defaults
- declare route modules as side effects to prevent tree shaking in production builds
- verify the compiled health handler is present during CI packaging for both dev and reference Y1 workflows

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_690ad927efd88323b3c2acba2373a237