### PR TITLE
fix(ci): shellcheck SC2034 and dart format failures

### DIFF
--- a/.github/workflows/mobile-security-check.yml
+++ b/.github/workflows/mobile-security-check.yml
@@ -136,17 +136,7 @@ jobs:
             exit 1
           fi
 
-          # Detect empty spkiPinsBase64 arrays inside the staging/prod security blocks.
-          # The awk range covers the _stagingMobileSecurity and _prodMobileSecurity const blocks.
-          empty_staging=$(awk '/_stagingMobileSecurity/,/^\);/' "$ENV_FILE" \
-            | grep -c "spkiPinsBase64:\s*\[" | xargs -I{} sh -c \
-              'awk "/_stagingMobileSecurity/,/^\);/" '"$ENV_FILE"' | grep -c "spkiPinsBase64:\s*\[\]" || true')
-          empty_prod=$(awk '/_prodMobileSecurity/,/^\);/' "$ENV_FILE" \
-            | grep -c "spkiPinsBase64:\s*\[" | xargs -I{} sh -c \
-              'awk "/_prodMobileSecurity/,/^\);/" '"$ENV_FILE"' | grep -c "spkiPinsBase64:\s*\[\]" || true')
-
-          # Simpler direct check: search the entire file for the empty array patterns
-          # inside the staging and prod security const blocks
+          # Check for empty spkiPinsBase64 arrays inside the staging/prod security const blocks
           staging_empty=false
           prod_empty=false
 

--- a/lib/core/config/b2c_config.dart
+++ b/lib/core/config/b2c_config.dart
@@ -47,4 +47,3 @@ const Map<String, dynamic> kB2CConfig = {
   'knownAuthorities': [_kAuthorityHost],
   'googleIdpHint': 'Google',
 };
-

--- a/test/security/environment_spki_pin_test.dart
+++ b/test/security/environment_spki_pin_test.dart
@@ -100,8 +100,7 @@ See docs/runbooks/tls-pinning-rotation.md for the full procedure.
           expect(
             pinPattern.hasMatch(pin),
             isTrue,
-            reason:
-                'Invalid base64 SHA-256 format for staging pin: $pin '
+            reason: 'Invalid base64 SHA-256 format for staging pin: $pin '
                 '(expected 43-44 base64 chars)',
           );
         }
@@ -163,8 +162,7 @@ See docs/runbooks/tls-pinning-rotation.md for the full procedure.
           expect(
             pinPattern.hasMatch(pin),
             isTrue,
-            reason:
-                'Invalid base64 SHA-256 format for production pin: $pin '
+            reason: 'Invalid base64 SHA-256 format for production pin: $pin '
                 '(expected 43-44 base64 chars)',
           );
         }
@@ -180,8 +178,7 @@ See docs/runbooks/tls-pinning-rotation.md for the full procedure.
         expect(
           config.security.tlsPins.spkiPinsBase64.length >= 2,
           isTrue,
-          reason:
-              'Production must have at least 2 SPKI pins (leaf + backup) '
+          reason: 'Production must have at least 2 SPKI pins (leaf + backup) '
               'to survive certificate rotation without a forced app update. '
               'Extract the intermediate CA pin with: '
               'CERT_INDEX=1 ./scripts/extract-spki-pins.sh $_prodHost',


### PR DESCRIPTION
- Remove unused empty_staging/empty_prod variables from mobile-security-check.yml (SC2034)
- Inline reason: arguments in environment_spki_pin_test.dart (dart format)
- Remove trailing blank line in b2c_config.dart (dart format)