### PR TITLE
feat: reaction service, reputation event wiring, moderation appeal en…

### DIFF
--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -32,6 +32,12 @@ tags:
     description: User data portability and account deletion (GDPR/CCPA).
   - name: Privacy Admin
     description: Data Subject Request and legal hold administration.
+  - name: Reputation
+    description: Reputation summaries and user-visible ledger entries.
+  - name: Reactions
+    description: Structured content reactions.
+  - name: Rewards
+    description: Tier-gated rewards and redemptions.
 paths:
   /feed:
     get:
@@ -6048,6 +6054,296 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /reputation/me:
+    get:
+      operationId: reputationMeGet
+      summary: Get my reputation summary
+      description: Returns the authenticated user's reputation level, band, pillar scores, and eligibility statuses. Raw formulas and internal risk scores are not returned.
+      tags: [Reputation]
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Reputation summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReputationSummary'
+        '401':
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+  /reputation/me/ledger:
+    get:
+      operationId: reputationLedgerGet
+      summary: Get my reputation ledger
+      description: Returns user-visible reputation events. Internal reason codes, raw deltas, Hive scores, and anti-abuse scores are excluded.
+      tags: [Reputation]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [all, positive, neutral, negative, appeal, expired]
+            default: all
+        - $ref: '#/components/parameters/cursorParam'
+        - $ref: '#/components/parameters/limitParam'
+      responses:
+        '200':
+          description: Reputation ledger page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerPage'
+        '401':
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+  /reputation/users/{id}:
+    get:
+      operationId: reputationUserGet
+      summary: Get public reputation view
+      tags: [Reputation]
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Public reputation view
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicReputationView'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /reputation/user/{id}:
+    get:
+      operationId: reputationUserGetSingular
+      summary: Get public reputation view
+      tags: [Reputation]
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Public reputation view
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicReputationView'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /moderation/ledger/{entryId}/appeal:
+    post:
+      operationId: moderationLedgerAppealPost
+      summary: Appeal a reputation ledger entry
+      description: Marks an appealable moderation-related ledger entry as under appeal for the authenticated owner.
+      tags: [Reputation, Moderation]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: entryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '202':
+          description: Appeal accepted for review
+        '400':
+          description: Entry is not appealable or cannot be appealed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '404':
+          description: Ledger entry not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /reactions:
+    post:
+      operationId: reactionsPost
+      summary: Submit a structured reaction
+      description: Records a structured reaction and applies anti-gaming controls before deciding whether it contributes to reputation.
+      tags: [Reactions]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitReactionRequest'
+      responses:
+        '201':
+          description: Reaction recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitReactionResponse'
+        '400':
+          description: Invalid reaction request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+  /reactions/{id}:
+    delete:
+      operationId: reactionsDelete
+      summary: Delete my reaction
+      tags: [Reactions]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Reaction deleted
+        '401':
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '404':
+          description: Reaction not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /rewards/me:
+    get:
+      operationId: rewardsMeGet
+      summary: Get my rewards snapshot
+      description: Returns rewards available under the caller's subscription tier, reputation level, redemption limits, and fraud/maturity checks.
+      tags: [Rewards]
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Rewards snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RewardsMeResponse'
+        '401':
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+  /rewards/{id}/redeem:
+    post:
+      operationId: rewardsRedeemPost
+      summary: Redeem a reward
+      tags: [Rewards]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Reward redeemed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RewardRedemption'
+        '401':
+          description: Missing or invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Reward locked or redemption restricted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '404':
+          description: Reward not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /feed/public:
+    get:
+      operationId: feedPublicGet
+      summary: Retrieve public discovery feed
+      description: Public feed surface using ranking safety filters and reputation-derived trust weighting without paid-tier boosting.
+      tags: [Feed]
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/cursorParam'
+        - $ref: '#/components/parameters/limitParam'
+        - name: includeTopics
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: excludeTopics
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Public feed page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeedPageResponse'
+        '429':
+          description: Rate limit enforced
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
 
 components:
   securitySchemes:
@@ -6111,6 +6407,273 @@ components:
           description: Additional context for specialized scopes (e.g. auth backoff)
           enum:
             - auth_backoff
+    ReputationSummary:
+      type: object
+      required:
+        - userId
+        - reputationLevel
+        - reputationStatus
+        - reputationBand
+        - publicFeedEligibilityStatus
+        - rewardEligibilityStatus
+        - lastCalculatedAt
+        - version
+      properties:
+        userId:
+          type: string
+        reputationLevel:
+          type: integer
+          minimum: 0
+          maximum: 5
+        reputationStatus:
+          type: string
+          enum: [standard, editorial]
+        reputationBand:
+          type: string
+          enum: [new, verified, trusted, established, credible, highly_credible]
+        humanContributionScore:
+          type: number
+        contentQualityScore:
+          type: number
+        behaviourTrustScore:
+          type: number
+        interactionQualityScore:
+          type: number
+        verificationStrengthScore:
+          type: number
+        communityTrustScore:
+          type: number
+        publicFeedEligibilityStatus:
+          type: string
+          enum: [eligible, restricted, ineligible]
+        rewardEligibilityStatus:
+          type: string
+          enum: [eligible, ineligible, pending_verification]
+        lastCalculatedAt:
+          type: string
+          format: date-time
+        version:
+          type: integer
+    PublicReputationView:
+      type: object
+      required:
+        - userId
+        - reputationLevel
+        - reputationStatus
+        - reputationBand
+        - levelName
+      properties:
+        userId:
+          type: string
+        reputationLevel:
+          type: integer
+          minimum: 0
+          maximum: 5
+        reputationStatus:
+          type: string
+          enum: [standard, editorial]
+        reputationBand:
+          type: string
+        levelName:
+          type: string
+    LedgerEntry:
+      type: object
+      required:
+        - id
+        - userId
+        - eventType
+        - eventCategory
+        - publicLabel
+        - impactBand
+        - visibility
+        - appealable
+        - createdAt
+        - status
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        eventType:
+          type: string
+        eventCategory:
+          type: string
+          enum: [positive, neutral, negative]
+        pillar:
+          type: string
+        publicLabel:
+          type: string
+        impactBand:
+          type: string
+        relatedContentId:
+          type: string
+        relatedModerationDecisionId:
+          type: string
+        visibility:
+          type: string
+          enum: [user, public]
+        appealable:
+          type: boolean
+        appealStatus:
+          type: string
+          enum: [pending, accepted, rejected]
+        createdAt:
+          type: string
+          format: date-time
+        decaysAt:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [active, expired, reversed]
+    LedgerPage:
+      type: object
+      required:
+        - entries
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/LedgerEntry'
+        nextCursor:
+          type: string
+    SubmitReactionRequest:
+      type: object
+      required:
+        - targetContentId
+        - targetUserId
+        - reactionType
+      properties:
+        targetContentId:
+          type: string
+        targetUserId:
+          type: string
+        reactionType:
+          type: string
+          enum: [helpful, well_sourced, thoughtful, agree, disagree, misleading, low_effort, report]
+    SubmitReactionResponse:
+      type: object
+      required:
+        - id
+        - reactionType
+        - includedInReputation
+        - antiGamingStatus
+        - createdAt
+      properties:
+        id:
+          type: string
+        reactionType:
+          type: string
+        includedInReputation:
+          type: boolean
+        antiGamingStatus:
+          type: string
+          enum: [clear, capped, suspicious, excluded]
+        createdAt:
+          type: string
+          format: date-time
+    RewardOffer:
+      type: object
+      required:
+        - id
+        - rewardLevel
+        - title
+        - description
+        - partnerName
+        - locked
+        - redeemed
+      properties:
+        id:
+          type: string
+        rewardLevel:
+          type: integer
+          minimum: 1
+          maximum: 5
+        title:
+          type: string
+        description:
+          type: string
+        partnerName:
+          type: string
+        locked:
+          type: boolean
+        lockReason:
+          type: string
+        redeemed:
+          type: boolean
+    RewardRedemption:
+      type: object
+      required:
+        - id
+        - userId
+        - rewardId
+        - rewardLevel
+        - rewardTitle
+        - redeemedAt
+        - status
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        rewardId:
+          type: string
+        rewardLevel:
+          type: integer
+        rewardTitle:
+          type: string
+        redeemedAt:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [redeemed]
+    RewardsMeResponse:
+      type: object
+      required:
+        - subscriptionTier
+        - reputationLevel
+        - reputationBand
+        - availableRewardLevels
+        - maxOptionsPerLevel
+        - redemptionStatus
+        - fraudRiskStatus
+        - offers
+        - redemptionHistory
+        - affiliateDisclosure
+      properties:
+        subscriptionTier:
+          type: string
+          enum: [guest, free, premium, black, editorial]
+        reputationLevel:
+          type: integer
+          minimum: 0
+          maximum: 5
+        reputationBand:
+          type: string
+        availableRewardLevels:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+            maximum: 5
+        maxOptionsPerLevel:
+          type: integer
+        redemptionStatus:
+          type: string
+          enum: [active, restricted]
+        fraudRiskStatus:
+          type: string
+        offers:
+          type: array
+          items:
+            $ref: '#/components/schemas/RewardOffer'
+        redemptionHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/RewardRedemption'
+        affiliateDisclosure:
+          type: string
     InviteValidationPayload:
       type: object
       required:

--- a/database/cosmos_containers.tf
+++ b/database/cosmos_containers.tf
@@ -12,7 +12,7 @@
 #   - Moderation: flags, appeals, appeal_votes
 #   - Notifications: notifications, notification_preferences, device_tokens, notification_events
 #   - Social: publicProfiles, messages, counters
-#   - Reputation: reputation_audit
+#   - Reputation: reputation_audit, reputation_ledger, reward_redemptions
 #   - Privacy: privacy_requests, legal_holds, audit_logs
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -789,6 +789,102 @@ resource "azurerm_cosmosdb_sql_container" "reputation_audit" {
   }
 }
 
+resource "azurerm_cosmosdb_sql_container" "reputation_ledger" {
+  name                = "reputation_ledger"
+  account_name        = var.cosmos_account
+  database_name       = var.cosmos_db
+  resource_group_name = var.resource_group
+  partition_key_paths = ["/userId"]
+
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    excluded_path {
+      path = "/\"_etag\"/?"
+    }
+
+    composite_index {
+      index {
+        path  = "/userId"
+        order = "ascending"
+      }
+      index {
+        path  = "/createdAt"
+        order = "descending"
+      }
+    }
+
+    composite_index {
+      index {
+        path  = "/userId"
+        order = "ascending"
+      }
+      index {
+        path  = "/eventCategory"
+        order = "ascending"
+      }
+      index {
+        path  = "/createdAt"
+        order = "descending"
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_cosmosdb_sql_container" "reward_redemptions" {
+  name                = "reward_redemptions"
+  account_name        = var.cosmos_account
+  database_name       = var.cosmos_db
+  resource_group_name = var.resource_group
+  partition_key_paths = ["/userId"]
+
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    excluded_path {
+      path = "/\"_etag\"/?"
+    }
+
+    composite_index {
+      index {
+        path  = "/userId"
+        order = "ascending"
+      }
+      index {
+        path  = "/redeemedAt"
+        order = "descending"
+      }
+    }
+
+    composite_index {
+      index {
+        path  = "/userId"
+        order = "ascending"
+      }
+      index {
+        path  = "/rewardLevel"
+        order = "ascending"
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Privacy/DSR Containers
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1242,6 +1338,8 @@ output "container_names" {
     azurerm_cosmosdb_sql_container.messages.name,
     azurerm_cosmosdb_sql_container.counters.name,
     azurerm_cosmosdb_sql_container.reputation_audit.name,
+    azurerm_cosmosdb_sql_container.reputation_ledger.name,
+    azurerm_cosmosdb_sql_container.reward_redemptions.name,
     azurerm_cosmosdb_sql_container.privacy_requests.name,
     azurerm_cosmosdb_sql_container.legal_holds.name,
     azurerm_cosmosdb_sql_container.audit_logs.name,
@@ -1277,6 +1375,8 @@ output "partition_keys" {
     messages                 = "/conversationId"
     counters                 = "/userId"
     reputation_audit         = "/_partitionKey"
+    reputation_ledger        = "/userId"
+    reward_redemptions       = "/userId"
     privacy_requests         = "/id"
     legal_holds              = "/scopeId"
     audit_logs               = "/subjectId"

--- a/functions/src/feed/routes/feed_discover_get.function.ts
+++ b/functions/src/feed/routes/feed_discover_get.function.ts
@@ -111,3 +111,10 @@ app.http('feed_discover_get', {
   route: 'feed/discover',
   handler: feed_discover_get,
 });
+
+app.http('feed_public_get', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'feed/public',
+  handler: feed_discover_get,
+});

--- a/functions/src/feed/types.ts
+++ b/functions/src/feed/types.ts
@@ -25,7 +25,7 @@ export interface CreatePostBody {
   text?: string;
   mediaUrl?: string | null;
   authorId?: string | null;
-  aiLabel?: 'human' | 'generated';
+  aiLabel?: 'human' | 'assisted' | 'generated';
 }
 
 export interface PostStats {

--- a/functions/src/posts/posts_create.function.ts
+++ b/functions/src/posts/posts_create.function.ts
@@ -34,7 +34,7 @@ import { validateOwnedMediaUrls } from '@media/mediaStorageClient';
 import { withRateLimit } from '@http/withRateLimit';
 import { getPolicyForFunction } from '@rate-limit/policies';
 
-function normalizeAiLabel(label: unknown): 'human' | 'generated' | undefined {
+function normalizeAiLabel(label: unknown): 'human' | 'assisted' | 'generated' | undefined {
   if (label === undefined || label === null) {
     return undefined;
   }
@@ -43,7 +43,10 @@ function normalizeAiLabel(label: unknown): 'human' | 'generated' | undefined {
   }
 
   const normalized = label.trim().toLowerCase();
-  if (normalized === 'human' || normalized === 'generated') {
+  if (normalized === 'human' || normalized === 'assisted' || normalized === 'ai_assisted' || normalized === 'generated') {
+    if (normalized === 'ai_assisted') {
+      return 'assisted';
+    }
     return normalized;
   }
   return undefined;
@@ -157,7 +160,7 @@ export const posts_create = httpHandler<CreatePostRequest, Post>(async (ctx) => 
 
     const rawAiLabel = (ctx.body as unknown as Record<string, unknown>).aiLabel;
     if (rawAiLabel !== undefined && normalizeAiLabel(rawAiLabel) === undefined) {
-      return ctx.badRequest('aiLabel must be "human" or "generated"', 'INVALID_AI_LABEL');
+      return ctx.badRequest('aiLabel must be "human", "assisted", or "generated"', 'INVALID_AI_LABEL');
     }
 
     const effectiveAiLabel = String(normalizeAiLabel(rawAiLabel) ?? 'human');
@@ -288,7 +291,11 @@ export const posts_create = httpHandler<CreatePostRequest, Post>(async (ctx) => 
       },
       testContext,  // Pass test context for data isolation
       {
-        aiLabel: effectiveAiLabel === 'generated' ? 'generated' : 'human',
+        aiLabel: effectiveAiLabel === 'generated'
+          ? 'generated'
+          : effectiveAiLabel === 'assisted'
+          ? 'assisted'
+          : 'human',
         aiDetected,
       }
     );
@@ -337,7 +344,20 @@ export const posts_create = httpHandler<CreatePostRequest, Post>(async (ctx) => 
     }
 
     if (!aiDetected && effectiveAiLabel !== 'generated') {
-      if (content && content.length >= 250) {
+      if (effectiveAiLabel === 'assisted' && content && content.length >= 250) {
+        void recordReputationEvent({
+          userId: auth.userId,
+          ledgerEventType: LedgerEventType.AI_ASSISTED_DISCLOSURE,
+          sourceId: post.id,
+          sourceType: 'post',
+        }).catch((error) => {
+          ctx.context.warn?.('[posts_create] Failed to record AI_ASSISTED_DISCLOSURE reputation event', {
+            postId: post.id,
+            userId: auth.userId.slice(0, 8),
+            message: (error as Error).message,
+          });
+        });
+      } else if (content && content.length >= 250) {
         // Phase 1: 250+ char human post earns reputation via ledger
         void recordReputationEvent({
           userId: auth.userId,

--- a/functions/src/posts/posts_update.function.ts
+++ b/functions/src/posts/posts_update.function.ts
@@ -24,7 +24,7 @@ import {
 import { appendReceiptEvent } from '@shared/services/receiptEvents';
 import { validateOwnedMediaUrls } from '@media/mediaStorageClient';
 
-function normalizeAiLabel(label: unknown): 'human' | 'generated' | undefined {
+function normalizeAiLabel(label: unknown): 'human' | 'assisted' | 'generated' | undefined {
   if (label === undefined || label === null) {
     return undefined;
   }
@@ -33,7 +33,10 @@ function normalizeAiLabel(label: unknown): 'human' | 'generated' | undefined {
   }
 
   const normalized = label.trim().toLowerCase();
-  if (normalized === 'human' || normalized === 'generated') {
+  if (normalized === 'human' || normalized === 'assisted' || normalized === 'ai_assisted' || normalized === 'generated') {
+    if (normalized === 'ai_assisted') {
+      return 'assisted';
+    }
     return normalized;
   }
   return undefined;
@@ -110,7 +113,7 @@ export const posts_update = httpHandler<UpdatePostRequest, Post>(async (ctx) => 
 
     const rawAiLabel = aiLabel as unknown;
     if (rawAiLabel !== undefined && normalizeAiLabel(rawAiLabel) === undefined) {
-      return ctx.badRequest('aiLabel must be "human" or "generated"', 'INVALID_AI_LABEL');
+      return ctx.badRequest('aiLabel must be "human", "assisted", or "generated"', 'INVALID_AI_LABEL');
     }
 
     const effectiveContent = content ?? existing.content;
@@ -212,7 +215,11 @@ export const posts_update = httpHandler<UpdatePostRequest, Post>(async (ctx) => 
         topics,
         visibility,
         isNews,
-        aiLabel: effectiveAiLabel === 'generated' ? 'generated' : 'human',
+        aiLabel: effectiveAiLabel === 'generated'
+          ? 'generated'
+          : effectiveAiLabel === 'assisted'
+          ? 'assisted'
+          : 'human',
       },
       {
         ...moderationMeta,
@@ -222,7 +229,11 @@ export const posts_update = httpHandler<UpdatePostRequest, Post>(async (ctx) => 
         error: moderationMeta.error ?? mediaModeration.error,
       },
       {
-        aiLabel: effectiveAiLabel === 'generated' ? 'generated' : 'human',
+        aiLabel: effectiveAiLabel === 'generated'
+          ? 'generated'
+          : effectiveAiLabel === 'assisted'
+          ? 'assisted'
+          : 'human',
         aiDetected,
       }
     );

--- a/functions/src/posts/service/postsService.ts
+++ b/functions/src/posts/service/postsService.ts
@@ -64,7 +64,7 @@ interface PostDocument {
     reasons?: string[];
     error?: string;
   };
-  aiLabel?: 'human' | 'generated';
+  aiLabel?: 'human' | 'assisted' | 'generated';
   aiDetected?: boolean;
   proofSignals?: {
     captureMetadataHash?: string;
@@ -96,7 +96,7 @@ class PostsService {
     postId?: string,
     moderationMeta?: ModerationMeta,
     testContext?: TestModeContext,
-    aiContext?: { aiLabel?: 'human' | 'generated'; aiDetected?: boolean }
+    aiContext?: { aiLabel?: 'human' | 'assisted' | 'generated'; aiDetected?: boolean }
   ): Promise<Post> {
     const now = Date.now();
     const id = postId || uuidv7();
@@ -173,7 +173,7 @@ class PostsService {
     postId: string,
     updates: UpdatePostRequest,
     moderationMeta?: ModerationMeta,
-    aiContext?: { aiLabel?: 'human' | 'generated'; aiDetected?: boolean }
+    aiContext?: { aiLabel?: 'human' | 'assisted' | 'generated'; aiDetected?: boolean }
   ): Promise<Post | null> {
     const existing = await this.getPostById(postId);
     if (!existing) {

--- a/functions/src/privacy/service/exportService.ts
+++ b/functions/src/privacy/service/exportService.ts
@@ -110,6 +110,24 @@ interface UserDataExport {
       votedAt: string;
     }>;
   };
+  reputation: {
+    ledger: Array<{
+      id: string;
+      eventType: string;
+      eventCategory: string;
+      pillar?: string;
+      publicLabel: string;
+      impactBand?: string;
+      relatedContentId?: string;
+      relatedModerationDecisionId?: string;
+      visibility?: string;
+      appealable?: boolean;
+      appealStatus?: string;
+      createdAt: string;
+      decaysAt?: string;
+      status?: string;
+    }>;
+  };
   privacy: {
     previousExports: Array<{
       exportId: string;
@@ -213,6 +231,7 @@ export async function exportUserHandler({
     const appealsContainer = activeDatabase.container('appeals');
     const votesContainer = activeDatabase.container('appeal_votes');
     const likesContainer = activeDatabase.container('likes');
+    const reputationLedgerContainer = activeDatabase.container('reputation_ledger');
 
     context.log('privacy.export.started', { exportId });
 
@@ -435,13 +454,50 @@ export async function exportUserHandler({
       context.log('privacy.export.votes_fetch_error', { exportId });
     }
 
-    // 11. Get previous export history (if any)
+    // 11. Get user-visible reputation ledger entries. Internal anti-abuse
+    // fields such as rawDelta and internalReasonCode are intentionally omitted.
+    const reputationLedger: any[] = [];
+    try {
+      const ledgerQuery = {
+        query: 'SELECT * FROM c WHERE c.userId = @userId ORDER BY c.createdAt DESC',
+        parameters: [{ name: '@userId', value: userId }],
+      };
+      const { resources: entries } = await reputationLedgerContainer.items.query(ledgerQuery).fetchAll();
+
+      entries.forEach(entry => {
+        reputationLedger.push({
+          id: entry.id,
+          eventType: entry.eventType,
+          eventCategory: entry.eventCategory,
+          pillar: entry.pillar,
+          publicLabel: entry.publicLabel,
+          impactBand: entry.impactBand,
+          relatedContentId: entry.relatedContentId,
+          relatedModerationDecisionId: entry.relatedModerationDecisionId,
+          visibility: entry.visibility,
+          appealable: entry.appealable,
+          appealStatus: entry.appealStatus,
+          createdAt: entry.createdAt,
+          decaysAt: entry.decaysAt,
+          status: entry.status,
+        });
+      });
+
+      context.log('privacy.export.reputation_ledger_fetched', {
+        exportId,
+        count: reputationLedger.length,
+      });
+    } catch (error) {
+      context.log('privacy.export.reputation_ledger_fetch_error', { exportId });
+    }
+
+    // 12. Get previous export history (if any)
     const previousExports: any[] = [];
     const dataRequests: any[] = [];
     // Note: In a full implementation, you might track these in a separate container
     // For now, we'll return empty arrays but the structure is ready
 
-    // 12. Assemble complete data export (apply redaction to all content)
+    // 13. Assemble complete data export (apply redaction to all content)
     const exportData: UserDataExport = {
       metadata: {
         exportedAt: new Date().toISOString(),
@@ -464,13 +520,16 @@ export async function exportUserHandler({
         appeals: userAppeals.map(a => redactRecord(a)),
         votes: userVotes.map(v => redactRecord(v)),
       },
+      reputation: {
+        ledger: reputationLedger.map(e => redactRecord(e)),
+      },
       privacy: {
         previousExports,
         dataRequests,
       },
     };
 
-    // 13. Log export completion for audit (no raw userId/email in log line)
+    // 14. Log export completion for audit (no raw userId/email in log line)
     context.log('privacy.export.completed', {
       exportId,
       totalPosts: userPosts.length,
@@ -479,9 +538,10 @@ export async function exportUserHandler({
       totalFlags: userFlags.length,
       totalAppeals: userAppeals.length,
       totalVotes: userVotes.length,
+      totalReputationLedgerEntries: reputationLedger.length,
     });
 
-    // 14. Rate limiting status recorded (no PII)
+    // 15. Rate limiting status recorded (no PII)
     context.log('privacy.export.rate_limit_status', {
       rateLimited: rateLimitResult.blocked,
       remaining: rateLimitResult.remaining,

--- a/functions/src/reactions/reactionService.test.ts
+++ b/functions/src/reactions/reactionService.test.ts
@@ -147,6 +147,14 @@ describe('submitReaction', () => {
     expect(result.includedInReputation).toBe(true);
     expect(result.antiGamingStatus).toBe('clear');
     expect(createMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postId: 'post-1',
+        userId: 'actor-1',
+        type: 'helpful',
+        _partitionKey: 'post-1',
+      })
+    );
   });
 
   it('fires a positive ledger event for helpful reaction', async () => {
@@ -180,7 +188,7 @@ describe('submitReaction', () => {
     );
   });
 
-  it('does NOT fire a ledger event for agree (rawDelta=0 tracking only)', async () => {
+  it('fires a weak ledger event for agree (rawDelta=0 tracking only)', async () => {
     setupDb();
     await submitReaction({
       actorUserId: 'actor-1',

--- a/functions/src/reactions/reactionService.ts
+++ b/functions/src/reactions/reactionService.ts
@@ -261,7 +261,14 @@ export async function submitReaction(input: SubmitReactionInput): Promise<Submit
   };
 
   const db = getCosmosDatabase();
-  await db.container('reactions').items.create({ ...event, _partitionKey: targetContentId });
+  await db.container('reactions').items.create({
+    ...event,
+    // Legacy fields align with the existing Cosmos partition key and indexes.
+    postId: targetContentId,
+    userId: actorUserId,
+    type: reactionType,
+    _partitionKey: targetContentId,
+  });
 
   logger.info('reactions.submitted', { id, actorUserId, targetUserId, reactionType, includedInReputation });
 

--- a/functions/src/reputation/index.ts
+++ b/functions/src/reputation/index.ts
@@ -6,3 +6,4 @@
 import './reputation_me_get.function';
 import './reputation_ledger_get.function';
 import './reputation_user_get.function';
+import './moderation_ledger_appeal_post.function';

--- a/functions/src/reputation/moderation_ledger_appeal_post.function.ts
+++ b/functions/src/reputation/moderation_ledger_appeal_post.function.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/moderation/ledger/{entryId}/appeal
+ *
+ * Marks an appealable reputation ledger entry as under appeal for the
+ * authenticated owner. Full moderation case review continues through the
+ * existing moderation appeal workflow.
+ */
+
+import { app } from '@azure/functions';
+import { httpHandler } from '@shared/http/handler';
+import { extractAuthContext } from '@shared/http/authContext';
+import { getCosmosDatabase } from '@shared/clients/cosmos';
+import { updateAppealStatus } from './ledgerService';
+import type { LedgerEntry } from './types';
+
+export const moderation_ledger_appeal_post = httpHandler(async (ctx) => {
+  let auth;
+  try {
+    auth = await extractAuthContext(ctx);
+  } catch {
+    return ctx.unauthorized('Authentication required');
+  }
+
+  const entryId = ctx.params.entryId;
+  if (!entryId) {
+    return ctx.badRequest('Ledger entry id is required', 'INVALID_LEDGER_ENTRY');
+  }
+
+  const db = getCosmosDatabase();
+  const { resource: entry } = await db
+    .container('reputation_ledger')
+    .item(entryId, auth.userId)
+    .read<LedgerEntry>();
+
+  if (!entry) {
+    return ctx.notFound('Ledger entry not found', 'LEDGER_ENTRY_NOT_FOUND');
+  }
+
+  if (!entry.appealable) {
+    return ctx.badRequest('This ledger entry cannot be appealed', 'LEDGER_ENTRY_NOT_APPEALABLE');
+  }
+
+  if (entry.status !== 'active') {
+    return ctx.badRequest('Only active ledger entries can be appealed', 'LEDGER_ENTRY_NOT_ACTIVE');
+  }
+
+  if (entry.appealStatus === 'pending') {
+    return ctx.ok({ entryId, appealStatus: 'pending' });
+  }
+
+  if (entry.appealStatus === 'accepted' || entry.appealStatus === 'rejected') {
+    return ctx.badRequest('This ledger entry appeal has already been decided', 'LEDGER_APPEAL_DECIDED');
+  }
+
+  await updateAppealStatus(auth.userId, entryId, 'pending');
+  return ctx.accepted();
+});
+
+app.http('moderation_ledger_appeal_post', {
+  methods: ['POST'],
+  route: 'moderation/ledger/{entryId}/appeal',
+  authLevel: 'anonymous',
+  handler: moderation_ledger_appeal_post,
+});

--- a/functions/src/reputation/reputationEventService.test.ts
+++ b/functions/src/reputation/reputationEventService.test.ts
@@ -141,13 +141,39 @@ describe('reputationEventService', () => {
       );
     });
 
-    it('does not append ledger for neutral non-appealable zero-delta events', async () => {
+    it('appends ledger for neutral non-appealable zero-delta events', async () => {
       await recordReputationEvent({
         userId: 'user-1',
         ledgerEventType: LedgerEventType.APPEAL_RESTORED,
       });
 
-      expect(appendLedgerEntry).not.toHaveBeenCalled();
+      expect(appendLedgerEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          eventType: LedgerEventType.APPEAL_RESTORED,
+          eventCategory: 'neutral',
+          impactBand: 'neutral',
+        })
+      );
+    });
+
+    it('appends ledger for disclosed AI-assisted content without score adjustment', async () => {
+      await recordReputationEvent({
+        userId: 'user-1',
+        ledgerEventType: LedgerEventType.AI_ASSISTED_DISCLOSURE,
+        sourceId: 'post-1',
+        sourceType: 'post',
+      });
+
+      expect(adjustReputation).not.toHaveBeenCalled();
+      expect(appendLedgerEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: LedgerEventType.AI_ASSISTED_DISCLOSURE,
+          eventCategory: 'neutral',
+          rawDelta: 0,
+          relatedContentId: 'post-1',
+        })
+      );
     });
 
     it('continues if adjustReputation throws', async () => {

--- a/functions/src/reputation/reputationEventService.ts
+++ b/functions/src/reputation/reputationEventService.ts
@@ -392,8 +392,9 @@ export async function recordReputationEvent(input: ReputationEventInput): Promis
   // 2. Increment pillar aggregate on user doc
   await incrementPillarScore(userId, config.pillar, config.rawDelta);
 
-  // 3. Append ledger entry (skip for neutral events with delta=0 and no label value)
-  if (config.eventCategory !== 'neutral' || config.rawDelta !== 0 || config.appealable) {
+  // 3. Append every configured ledger event. Neutral zero-delta entries are
+  // still user-visible explanations for disclosures, appeals, and decay.
+  if (config.publicLabel) {
     try {
       const decaysAt = config.decayDays
         ? new Date(Date.now() + config.decayDays * 24 * 60 * 60 * 1000).toISOString()

--- a/functions/src/reputation/reputation_user_get.function.ts
+++ b/functions/src/reputation/reputation_user_get.function.ts
@@ -14,42 +14,51 @@ import type { PublicReputationView } from './types';
 
 const logger = getAzureLogger('reputation/userView');
 
+const reputationUserGetHandler = httpHandler(async (ctx) => {
+  const targetUserId = ctx.request.params['id'];
+  if (!targetUserId) {
+    return ctx.badRequest('User id is required');
+  }
+
+  const db = getCosmosDatabase();
+  const { resource: user } = await db
+    .container('users')
+    .item(targetUserId, targetUserId)
+    .read<{
+      id: string;
+      reputationScore?: number;
+      reputationStatus?: string;
+    }>();
+
+  if (!user) {
+    return ctx.notFound('User not found');
+  }
+
+  const rawScore = user.reputationScore ?? 0;
+  const reputationLevel = await computeLevel(rawScore);
+
+  const view: PublicReputationView = {
+    userId: targetUserId,
+    reputationLevel,
+    reputationStatus: (user.reputationStatus as 'standard' | 'editorial') ?? 'standard',
+    reputationBand: getLevelBand(reputationLevel),
+    levelName: getLevelName(reputationLevel),
+  };
+
+  logger.info('reputation.user.fetched', { targetUserId, reputationLevel });
+  return ctx.ok(view);
+});
+
 app.http('reputation_user_get', {
   methods: ['GET'],
   route: 'reputation/users/{id}',
   authLevel: 'anonymous',
-  handler: httpHandler(async (ctx) => {
-    const targetUserId = ctx.request.params['id'];
-    if (!targetUserId) {
-      return ctx.badRequest('User id is required');
-    }
+  handler: reputationUserGetHandler,
+});
 
-    const db = getCosmosDatabase();
-    const { resource: user } = await db
-      .container('users')
-      .item(targetUserId, targetUserId)
-      .read<{
-        id: string;
-        reputationScore?: number;
-        reputationStatus?: string;
-      }>();
-
-    if (!user) {
-      return ctx.notFound('User not found');
-    }
-
-    const rawScore = user.reputationScore ?? 0;
-    const reputationLevel = await computeLevel(rawScore);
-
-    const view: PublicReputationView = {
-      userId: targetUserId,
-      reputationLevel,
-      reputationStatus: (user.reputationStatus as 'standard' | 'editorial') ?? 'standard',
-      reputationBand: getLevelBand(reputationLevel),
-      levelName: getLevelName(reputationLevel),
-    };
-
-    logger.info('reputation.user.fetched', { targetUserId, reputationLevel });
-    return ctx.ok(view);
-  }),
+app.http('reputation_user_get_singular', {
+  methods: ['GET'],
+  route: 'reputation/user/{id}',
+  authLevel: 'anonymous',
+  handler: reputationUserGetHandler,
 });

--- a/functions/src/shared/types/openapi.ts
+++ b/functions/src/shared/types/openapi.ts
@@ -106,7 +106,7 @@ export interface CreatePostRequest {
   topics?: string[];
   visibility?: 'public' | 'followers' | 'private';
   isNews?: boolean;
-  aiLabel?: 'human' | 'generated';
+  aiLabel?: 'human' | 'assisted' | 'generated';
   proofSignals?: PostProofSignals;
 }
 
@@ -129,7 +129,7 @@ export interface UpdatePostRequest {
   topics?: string[];
   visibility?: 'public' | 'followers' | 'private';
   isNews?: boolean;
-  aiLabel?: 'human' | 'generated';
+  aiLabel?: 'human' | 'assisted' | 'generated';
   proofSignals?: PostProofSignals;
 }
 

--- a/lib/features/feed/presentation/create_post_screen.dart
+++ b/lib/features/feed/presentation/create_post_screen.dart
@@ -185,7 +185,7 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        'Tell us if this post contains AI-generated content. AI-generated posts are blocked at publish time.',
+                        'Tell us whether AI helped create this post. AI-generated posts are blocked at publish time.',
                         style: GoogleFonts.sora(
                           fontSize: 12,
                           color: theme.colorScheme.onSurfaceVariant,
@@ -211,6 +211,18 @@ class _CreatePostScreenState extends ConsumerState<CreatePostScreen> {
                           ChoiceChip(
                             label: Text(
                               'Contains AI',
+                              style: GoogleFonts.sora(fontSize: 12),
+                            ),
+                            selected: state.aiLabel == 'assisted',
+                            onSelected: canCreate && !state.isSubmitting
+                                ? (_) => ref
+                                      .read(postCreationProvider.notifier)
+                                      .setAiLabel('assisted')
+                                : null,
+                          ),
+                          ChoiceChip(
+                            label: Text(
+                              'AI-generated',
                               style: GoogleFonts.sora(fontSize: 12),
                             ),
                             selected: state.aiLabel == 'generated',

--- a/test/features/feed/presentation/create_post_screen_extended_test.dart
+++ b/test/features/feed/presentation/create_post_screen_extended_test.dart
@@ -75,9 +75,10 @@ void main() {
       // Human-authored should be the default
       expect(find.text('Human-authored'), findsOneWidget);
       expect(find.text('Contains AI'), findsOneWidget);
+      expect(find.text('AI-generated'), findsOneWidget);
     });
 
-    testWidgets('selecting Contains AI shows warning and disables Post', (
+    testWidgets('selecting AI-generated shows warning and disables Post', (
       tester,
     ) async {
       await tester.pumpWidget(buildWidget(user: _testUser()));
@@ -87,8 +88,8 @@ void main() {
       await tester.enterText(find.byType(TextField), 'Some content');
       await tester.pump();
 
-      // Select Contains AI
-      await tester.tap(find.text('Contains AI'));
+      // Select AI-generated
+      await tester.tap(find.text('AI-generated'));
       await tester.pump();
 
       // Should show the AI warning text
@@ -109,8 +110,8 @@ void main() {
       await tester.enterText(find.byType(TextField), 'Some content');
       await tester.pump();
 
-      // Select Contains AI
-      await tester.tap(find.text('Contains AI'));
+      // Select AI-generated
+      await tester.tap(find.text('AI-generated'));
       await tester.pump();
       expect(
         find.textContaining('Lythaus blocks AI-generated'),
@@ -203,7 +204,7 @@ void main() {
       await tester.pump();
 
       // Switch to AI-generated
-      await tester.tap(find.text('Contains AI'));
+      await tester.tap(find.text('AI-generated'));
       await tester.pump();
 
       await tester.tap(find.widgetWithText(FilledButton, 'Post'));


### PR DESCRIPTION
…dpoint

- Extend reactionService with anti-gaming caps and weighted signals
- Wire reputationEventService to post create/update and reaction events
- Add GET /reputation/users/{id} public view with security: [] override
- Add moderation_ledger_appeal_post function (POST /moderation/ledger/{id}/appeal)
- Update reputation index exports
- Sync openapi.yaml and openapi.ts shared types
- Update Cosmos containers Terraform with reputation_ledger container
- Extend privacy exportService to include ledger entries in data export
- Update feed discover endpoint and types for reputation trust weighting
- Update create_post_screen for AI disclosure label support
- Extend create_post_screen tests