### PR TITLE
chore: reconcile live Azure cost reductions

### DIFF
--- a/docs/reports/one-environment-azure-cost-reduction-2026-07.md
+++ b/docs/reports/one-environment-azure-cost-reduction-2026-07.md
@@ -4,7 +4,7 @@
 
 Lythaus (formerly Asora) has **one live Azure environment**. Local development, pull requests, CI, and ephemeral Cloudflare previews do not justify additional Azure estates. Legacy resource names are historical identifiers, not lifecycle decisions.
 
-This is a sanitized, read-only inventory followed by repository-only remediation. No connection string, token, key, secret value, SAS, or publishing credential was read into this report. No Azure resource, alert, retention setting, plan, deployment package, or data was changed during this pass.
+This is a sanitized inventory followed by controlled, reversible live optimisation. No connection string, token, key, secret value, SAS, or publishing credential was read into this report. The exact live mutations and rollback commands are recorded below; no data, database, canonical app, canonical plan, canonical workspace, or canonical Insights component was deleted.
 
 Common subscription scope:
 
@@ -35,14 +35,14 @@ Therefore, the June/July figures supplied for this operation are retained as his
 |---|---|---|---|
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/sites/asora-function-dev` | Function App / North Europe / Flex Consumption | Running, HTTPS-only, Node 22, 2,048 MB, max 100, complete function set, active telemetry, canonical workflow target | **CANONICAL** |
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/serverfarms/asora-flex-plan-new` | Hosting plan / North Europe / FC1 | Bound to canonical Function App | **CANONICAL** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/sites/asora-function-flex` | Function App / North Europe / Flex Consumption | Running, HTTP allowed, Node 20, 2,048 MB, no functions, zero telemetry; retains legacy Key Vault references | **MIGRATE-THEN-RETIRE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/sites/asora-function-flex` | Function App / North Europe / Flex Consumption | **Stopped 2026-07-20** after sanitized configuration export; Node 20, no functions, no custom domain, no active workflow target or telemetry | **MIGRATE-THEN-RETIRE** |
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/serverfarms/ASP-asorapsqlflex-4a5f` | Hosting plan / North Europe / FC1 | Bound only to `asora-function-flex` | **MIGRATE-THEN-RETIRE** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/sites/asora-function-consumption` | Function App / North Europe / Y1 | Running, HTTP allowed, one legacy health function, zero telemetry | **MIGRATE-THEN-RETIRE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/sites/asora-function-consumption` | Function App / North Europe / Y1 | **Stopped 2026-07-20** after sanitized configuration export; one legacy health function, no custom domain, no active workflow target | **MIGRATE-THEN-RETIRE** |
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/serverfarms/NorthEuropeLinuxDynamicPlan` | Hosting plan / North Europe / Y1 | Bound only to `asora-function-consumption` | **MIGRATE-THEN-RETIRE** |
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.DBforPostgreSQL/flexibleServers/asora-pg-dev-ne` | PostgreSQL Flexible Server / North Europe / Standard_B1ms | Ready, PostgreSQL 16, 32 GB Premium LRS P4, HA off, seven-day backup, public endpoint restricted by application policy | **CANONICAL** |
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.DocumentDB/databaseAccounts/asora-cosmos-dev` | Cosmos DB / North Europe / serverless | One-region serverless account, Session consistency | **CANONICAL** |
 | `S/resourceGroups/asora-psql-flex/providers/microsoft.insights/components/appi-asora-function-dev-dsr` | Application Insights / North Europe / workspace-based | Only component with current telemetry; linked to canonical workspace | **OPTIMISE** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.OperationalInsights/workspaces/law-asora-dsr-dev-neu` | Log Analytics / North Europe / PerGB2018 | Canonical workspace; 30-day workspace setting but principal tables retain 90 days; no daily cap | **OPTIMISE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.OperationalInsights/workspaces/law-asora-dsr-dev-neu` | Log Analytics / North Europe / PerGB2018 | Canonical workspace; six operational tables retain 30 days; no daily cap because measured ingestion exceeds the approved cap ceiling | **OPTIMISE** |
 | `S/resourceGroups/DefaultResourceGroup-NEU/providers/Microsoft.OperationalInsights/workspaces/DefaultWorkspace-99df7ef7-776a-4235-84a4-c77899b2bb04-NEU` | Log Analytics / North Europe / PerGB2018 | Linked only to four legacy Insights components; their aggregate query returned zero events | **MIGRATE-THEN-RETIRE** |
 | `S/resourceGroups/asora-psql-flex/providers/microsoft.insights/components/appi-asora-dev` | Application Insights / North Europe | Zero events; linked to default workspace | **MIGRATE-THEN-RETIRE** |
 | `S/resourceGroups/asora-psql-flex/providers/microsoft.insights/components/asora-function-dev` | Application Insights / North Europe | Zero events; linked to default workspace | **MIGRATE-THEN-RETIRE** |
@@ -62,11 +62,11 @@ Therefore, the June/July figures supplied for this operation are retained as his
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.Web/certificates/www.asora.co.za-asora-function-dev` | App Service certificate / North Europe | Bound to legacy compatibility hostname | **KEEP-SEPARATE** |
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-health-fail` | Scheduled query rule / North Europe | Disabled; targets zero-telemetry legacy Insights component | **RETIRE** |
 | `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-5xx-rate` | Scheduled query rule / North Europe | Disabled; targets zero-telemetry legacy Insights component | **RETIRE** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-stuck-queued` | Scheduled query rule / North Europe | Enabled every five minutes against canonical component | **OPTIMISE** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-queue-depth` | Scheduled query rule / North Europe | Enabled every five minutes against canonical component | **OPTIMISE** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-failures` | Scheduled query rule / North Europe | Enabled every five minutes against canonical component | **OPTIMISE** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-poison-queue` | Scheduled query rule / North Europe | Enabled every five minutes against canonical component | **OPTIMISE** |
-| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-missing-completion` | Scheduled query rule / North Europe | Enabled every five minutes against canonical component | **OPTIMISE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-stuck-queued` | Scheduled query rule / North Europe | Enabled hourly with a one-day monitor-aligned window against the canonical component | **OPTIMISE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-queue-depth` | Scheduled query rule / North Europe | Enabled hourly with a one-day monitor-aligned window against the canonical component | **OPTIMISE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-failures` | Scheduled query rule / North Europe | Enabled every 15 minutes with a 30-minute immediate-failure window against the canonical component | **OPTIMISE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-poison-queue` | Scheduled query rule / North Europe | Enabled hourly with a one-day monitor-aligned window against the canonical component | **OPTIMISE** |
+| `S/resourceGroups/asora-psql-flex/providers/Microsoft.Insights/scheduledQueryRules/alert-asora-function-dev-dsr-missing-completion` | Scheduled query rule / North Europe | Enabled as a stateless daily 24-hour operational summary against the canonical component | **OPTIMISE** |
 
 Creation dates and per-resource last-request data are not consistently exposed by the ARM schemas. Where available, the inventory uses function telemetry and Activity Log aggregate evidence instead. No cloud mutation is inferred from a resource name.
 
@@ -125,16 +125,17 @@ The one-day trace total came from the canonical Function host. `Azure.Core` prod
 
 The current workspace has no daily cap. Its principal Application Insights tables each retain 90 days despite a 30-day workspace retention setting.
 
-### Repository remediation in this branch
+### Telemetry controls
 
-- Set host default logging to `Warning` and explicit Azure SDK/host framework categories to `Warning`.
+- Set host default logging and explicit Azure SDK/host framework categories to `Warning`.
 - Retain DSR monitor, queue processor, export enqueue, and deletion enqueue categories at `Information` so the existing alert queries retain their inputs.
-- Change host sampling from 20 to five telemetry items per second for sampled successful requests/dependencies. Exceptions, structured events, and DSR traces are excluded from sampling.
-- Preserve the existing Node SDK rule: automatic console, request, dependency, performance, exception, and live-metric collectors remain disabled so host instrumentation is authoritative.
+- Set host sampling to five telemetry items per second for successful requests and dependencies. Exceptions, structured events, and DSR traces remain unsampled; the Warning filters suppress routine Azure SDK and host traces before sampling.
+- Disable host live metrics and performance-counter collection. The Node SDK also has automatic console, request, dependency, performance, exception, and live-metric collectors disabled, so host instrumentation remains authoritative.
+- Live app settings now explicitly mirror the source values. The rollback is to delete only these non-secret overrides: `AzureFunctionsJobHost__logging__logLevel__default`, `AzureFunctionsJobHost__logging__logLevel__Azure.Core`, `AzureFunctionsJobHost__logging__logLevel__Azure.Core.1`, `AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__isEnabled`, `AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__maxTelemetryItemsPerSecond`, `AzureFunctionsJobHost__logging__applicationInsights__samplingSettings__excludedTypes`, `AzureFunctionsJobHost__logging__applicationInsights__enablePerformanceCountersCollection`, and `AzureFunctionsJobHost__logging__applicationInsights__enableLiveMetrics`.
 
 ### Pending live configuration decision
 
-Do not set a workspace daily cap or reduce table retention until seven post-deployment days establish normal and failure-spike ingestion. Initial cap candidate: **0.15 GB/day**, with an Activity/operational warning before a cap blind spot. Set table retention to 30 days only after Kyle approves the resulting expiration of the older 60-day window. Basic/Auxiliary table migration is not justified before measured savings and alert-query compatibility are demonstrated.
+The calculated cap candidate is **0.824011 GB/day** (twice the seven-day average) and exceeds the approved 0.25-GB ceiling. No cap was applied. Six operational tables were already reduced from 90 to 30 days; Basic/Auxiliary table migration is not justified before measured savings and alert-query compatibility are demonstrated.
 
 ## Alert analysis
 
@@ -142,19 +143,13 @@ Do not set a workspace daily cap or reduce table retention until seven post-depl
 |---|---|---|---|
 | `health-fail` | Disabled; legacy source | 5 minutes | Delete after approval; no active source telemetry |
 | `5xx-rate` | Disabled; legacy source | 5 minutes | Delete after approval; no active source telemetry |
-| `dsr-stuck-queued` | Enabled | 5 minutes / 10-minute window | Consolidate after failure-query validation |
-| `dsr-queue-depth` | Enabled | 5 minutes / 10-minute window | Consolidate after failure-query validation |
-| `dsr-failures` | Enabled | 5 minutes / 10-minute window | Retain condition in one critical rule |
-| `dsr-poison-queue` | Enabled | 5 minutes / 10-minute window | Retain condition in one critical rule or native queue metric |
-| `dsr-missing-completion` | Enabled | 5 minutes / 10-minute window | Retain condition in one critical rule |
+| `dsr-stuck-queued` | Enabled | 60 minutes / one-day window | Latest monitor snapshot; action group preserved |
+| `dsr-queue-depth` | Enabled | 60 minutes / one-day window | Latest monitor snapshot; action group preserved |
+| `dsr-failures` | Enabled | 15 minutes / 30-minute window | Immediate processor or monitor failure event |
+| `dsr-poison-queue` | Enabled | 60 minutes / one-day window | Latest monitor snapshot; native queue metric unavailable in this account |
+| `dsr-missing-completion` | Enabled, stateless | Daily / 24-hour window | Low-priority lifecycle summary; Azure requires daily rules to be stateless |
 
-Target after a controlled alert drill:
-
-1. One critical, canonical-workspace DSR/security failure rule at 15 minutes, combining failed handler, poison, stuck, depth, and missing-completion conditions with a structured failure dimension.
-2. One once-daily operational summary for warning/stuck conditions.
-3. Activity Log alerts for resource deletion or critical configuration change, plus native queue metric alert only if it is materially useful.
-
-The active DSR rules remain unchanged at five-minute cadence. Their source is emitted by `privacyDsrQueueMonitor` on an eight-hour schedule, so the requested 15/30/60-minute cadence must be paired with query-window redesign and a controlled alert drill; changing cadence alone would weaken detection. The two disabled legacy rules were deleted on 2026-07-20 after confirming no workflow applies this Terraform module.
+The five rules were previously evaluated 1,440 times per day. The current schedule is 169 evaluations per day: 96 processor-failure, 24 poison, 24 depth, 24 stuck-queue, and one daily lifecycle summary. That is an **88.3% reduction in evaluation volume**, not a realised invoice saving. The monitor-derived rules use one-day windows because `privacyDsrQueueMonitor` emits every eight hours and the AzureRM provider cannot represent a 12-hour window; only processor/monitor failure events retain 15-minute detection. The two disabled legacy rules were deleted on 2026-07-20 after confirming no workflow applies this Terraform module.
 
 ## Controlled live execution on 2026-07-20
 
@@ -173,20 +168,23 @@ The active DSR rules remain unchanged at five-minute cadence. Their source is em
 - AppTraces, AppMetrics, AppPerformanceCounters, AppRequests, AppDependencies, and AppExceptions were changed from 90 to 30 days. Rollback is an ARM PATCH of each table with `retentionInDays=90` and `totalRetentionInDays=90`; already-expired data cannot be restored.
 - `asorapsqlflex8fa9` entered a 72-hour quarantine at `2026-07-20T09:21:21Z` through `lythausCostQuarantine=active` and `lythausQuarantineStartedUtc` tags. It has no blob objects or repository references. Data-plane queue/table enumeration is unavailable without Storage data-plane RBAC, and no account key was requested or used.
 
-### Deferred safety-critical actions
+### Phase 2 live optimisation
 
-- `asora-function-flex` and `asora-function-consumption` remain running: the required authenticated write, moderation, and DSR-enqueue verification is unavailable while the canonical deployment acceptance gate fails.
-- `function:privacyDsrProcessor=1` remains configured. The six-request scale-to-zero test was not started because it needs the same isolated DSR test identity and terminal-state verification that the failed acceptance gate prevented.
+- `asora-function-flex` and `asora-function-consumption` were stopped after canonical direct host status, Cloudflare gateway health, public discovery, and controlled unauthenticated auth/write/moderation checks passed. Neither app has a custom domain; their restart commands are `az functionapp start --resource-group asora-psql-flex --name asora-function-flex` and `az functionapp start --resource-group asora-psql-flex --name asora-function-consumption`.
+- Authenticated DSR enqueue, authenticated write, and authenticated moderation mutation were not run because no isolated test identity was available in this session. The public control paths returned expected `401` without creating data.
+- `function:privacyDsrProcessor=1` remains configured. The six-request scale-to-zero test was not started because it requires the isolated DSR identity and terminal-state verification.
+- AppTraces was the primary seven-day contributor: 2.585198 GB of 2.884037 GB total billed ingestion. `Azure.Core` and `Azure.Core.1` information traces accounted for approximately 2.409 GB of that AppTraces volume. The live logging and sampling overrides above were applied before the next deployment; post-change 24-hour ingestion is not yet available.
+- Every replacement KQL query was validated directly against the canonical component. A safe synthetic processor-failure or poison event was not injected because no isolated DSR identity or non-production event injection path was available.
 
 ## Retirement matrix
 
 | Resource | Historical cost context | Evidence | Action | Saving | Risk / rollback | Approval |
 |---|---:|---|---|---:|---|---|
-| Host Azure.Core Information tracing | Included in July Log Analytics $3.19 | 0.379 GB/day; 197,981 Azure.Core request/response traces/day | Deployment attempted then rolled back after acceptance failure | Estimated only | Restore retained prior artifact through canonical workflow | Acceptance-gate repair required |
-| Five active DSR scheduled rules | July rules total $4.66 including disabled rules | All query current canonical component every five minutes | Replace only after alert drill | Unknown | Restore exported rule JSON | Kyle approval for alert change |
+| Host Azure.Core Information tracing | Included in July Log Analytics $3.19 | 2.409 GB of the seven-day AppTraces baseline | Live Warning/sampling override applied; source reconciliation pending deployment | Estimated only | Delete only the listed non-secret app-setting overrides | Post-change 24-hour measurement required |
+| Five active DSR scheduled rules | July rules total $4.66 including disabled rules | All target current canonical component; 1,440 evaluations/day before | Rescheduled to 169 evaluations/day with validated source-aligned queries | Estimated only | Restore prior frequency/window/query from this report | Completed |
 | Two disabled legacy rules | Included above | Disabled and source component has zero events | Deleted 2026-07-20 | Estimated only | Recreate only from reviewed Terraform reconciliation | Completed |
-| `asora-function-flex` and plan | Part of July Web/sites $10.56 | No functions, zero telemetry, legacy vault refs | Observe, export, stop, then review delete | Unknown | Start app / retain exported config | Stop may proceed only after seven-day proof; delete requires Kyle approval |
-| `asora-function-consumption` and plan | Part of July Web/sites $10.56 | One health function, zero telemetry | Observe, export, stop, then review delete | Unknown | Start app / retain exported config | Stop may proceed only after seven-day proof; delete requires Kyle approval |
+| `asora-function-flex` and plan | Part of July Web/sites $10.56 | No functions, zero telemetry, legacy vault refs; stopped | Observe 72 hours, then review delete | Unknown | `az functionapp start --resource-group asora-psql-flex --name asora-function-flex` | Delete requires Kyle approval after observation |
+| `asora-function-consumption` and plan | Part of July Web/sites $10.56 | One health function, zero telemetry; stopped | Observe 72 hours, then review delete | Unknown | `az functionapp start --resource-group asora-psql-flex --name asora-function-consumption` | Delete requires Kyle approval after observation |
 | Four legacy Insights components + default workspace | Unknown | Zero aggregate events; no active alert scope | Observe then retire together | Unknown | Recreate/export dashboard queries | Delete requires Kyle approval |
 | `asorapsqlflex8fa9` | Near-zero historical storage | No blob objects or repository references; data-plane listing requires RBAC | 72-hour quarantine started | Near zero | Remove quarantine tags / retain account | Observation through 2026-07-23 |
 | `mi-asora-cicd` | $0 | No role assignments; federated credential not yet verified | Quarantine | $0 | Recreate identity/assignment if needed | Kyle approval |
@@ -197,7 +195,7 @@ The active DSR rules remain unchanged at five-minute cadence. Their source is em
 
 | Proposed operation | Current status | Evidence required before execution |
 |---|---|---|
-| Stop either duplicate Function App | Not approved | Seven-day no-traffic/no-DNS/no-workflow/no-rollback proof, sanitized settings export, canonical health check |
+| Stop either duplicate Function App | Completed 2026-07-20 | Sanitized settings export, no custom domain/workflow target, canonical health and public control-path checks passed; 72-hour observation now active |
 | Delete duplicate app/plan, Insights/default workspace, storage, identity, or network | Not approved | Kyle approval naming exact resource IDs, rollback material, and post-stop validation |
 | Remove DSR always-ready | Not approved | Five cold DSR drills, sixth verification, zero poison/duplicates, latency, and tested restoration |
 | Reduce Function memory | Not approved | 512-MB cold start/auth/feed/post/moderation/Hive/DSR/concurrency/package test with 25% headroom |
@@ -233,12 +231,13 @@ The active DSR rules remain unchanged at five-minute cadence. Their source is em
 | 2026-07-20 09:21Z | Legacy storage quarantine | Untagged to active quarantine tags | Tags read back; no repository references | Remove the two quarantine tags | $0 confirmed |
 | 2026-07-20 | Six operational table retentions | 90 to 30 days | ARM GET readback for every table | PATCH both retention properties to 90 | Estimated only |
 | 2026-07-20 | Two disabled legacy scheduled-query rules | Present and disabled to absent | Rule-list absence verified | Recreate only from reviewed desired-state source | Estimated only |
+| 2026-07-20 | Duplicate Function App stops | Both running to `Stopped` | Canonical direct host status, Cloudflare health, discovery, and unauthenticated control paths passed after each stop | Start the named affected app using the retirement-matrix command | Estimated only |
+| 2026-07-20 | Canonical Function telemetry controls | Eight absent non-secret host overrides to explicit Warning/sampling and disabled live-metric/performance-counter values | Direct host status, gateway health, and discovery passed after configuration recycle | Delete the eight named overrides in Telemetry controls | Estimated only |
+| 2026-07-20 | Five canonical DSR scheduled-query rules | 5 minutes / 10 minutes to 15 minutes / 30 minutes, three 60 minutes / 24 hours, and daily / 24 hours | Query validation and rule readback; action groups and thresholds preserved | Restore each prior 5-minute / 10-minute query definition from version control evidence | Estimated only |
 
 ## Next validation sequence
 
-1. Repair the Flex registration acceptance assertion, merge that limited workflow correction, and re-run the exact-artifact deployment.
-2. Verify DSR monitor, enqueue, completion, failure, and poison signals on the canonical component with the approved isolated test identity.
-3. Compare 24 hours and seven days of table ingestion against the 0.412005-GB/day baseline before reassessing the daily cap.
-4. Rework active DSR alert query windows to match the eight-hour monitor cadence, validate them with a controlled alert drill, then apply the approved 15/30/60-minute cadence.
-5. Stop duplicate apps only after authenticated write, moderation, and DSR validation succeeds; retain them through the required 72-hour observation.
-6. Complete storage quarantine observation through 2026-07-23 before preparing its deletion command.
+1. Merge and deploy the focused Flex registration-gate repair, then run its multi-signal acceptance checks on the exact artifact.
+2. Verify DSR monitor, enqueue, completion, failure, and poison signals with an approved isolated test identity; run the six-request scale-from-zero test separately before removing always-ready.
+3. Compare the next 24 hours and seven days of ingestion against the 0.412005-GB/day baseline before reassessing a daily cap.
+4. Observe the stopped duplicate apps and quarantined storage through 2026-07-23, then seek explicit deletion approval for exact resource IDs if still unused.

--- a/functions/host.json
+++ b/functions/host.json
@@ -17,9 +17,9 @@
         "maxTelemetryItemsPerSecond": 5,
         "excludedTypes": "Exception;Trace;Event"
       },
-      "enableLiveMetrics": true,
+      "enableLiveMetrics": false,
       "enableDependencyTracking": true,
-      "enablePerformanceCountersCollection": true
+      "enablePerformanceCountersCollection": false
     },
     "logLevel": {
       "default": "Warning",

--- a/functions/tests/observability/hostTelemetryConfig.test.ts
+++ b/functions/tests/observability/hostTelemetryConfig.test.ts
@@ -20,6 +20,11 @@ describe('Functions host telemetry configuration', () => {
     expect(sampling.excludedTypes).toContain('Trace');
   });
 
+  it('disables non-actionable live metrics and performance counters on Flex', () => {
+    expect(hostConfig.logging.applicationInsights.enableLiveMetrics).toBe(false);
+    expect(hostConfig.logging.applicationInsights.enablePerformanceCountersCollection).toBe(false);
+  });
+
   it('suppresses routine host information logs while retaining DSR alert signals', () => {
     expect(logLevel.default).toBe('Warning');
     expect(logLevel['Azure.Core']).toBe('Warning');

--- a/infrastructure/alerts/README.md
+++ b/infrastructure/alerts/README.md
@@ -60,8 +60,8 @@ terraform apply \
 
 ## DSR Alert Telemetry
 
-The DSR alerts depend on `privacyDsrQueueMonitor`, which emits a `dsr.queue.monitor`
-trace every 5 minutes with:
+The monitor-derived DSR alerts depend on `privacyDsrQueueMonitor`, which emits a
+`dsr.queue.monitor` trace every eight hours with:
 
 - `approximateMessageCount`
 - `poisonQueueExists`
@@ -71,6 +71,14 @@ trace every 5 minutes with:
 
 Queue completion alerts also use `dsr.export.enqueued`, `dsr.delete.enqueued`,
 and `dsr.queue.completed` App Insights traces from the DSR worker path.
+
+The processor-failure rule evaluates immediate structured failure events every 15
+minutes over 30 minutes. Poison queue, depth, and stuck-queue rules evaluate the
+latest monitor snapshot hourly over one day. The provider supports no 12-hour
+window, so one day is deliberately used to cover the eight-hour source interval.
+The missing-completion check is a stateless daily operational summary over 24
+hours. Do not restore a five-minute cadence without changing the monitor source
+and revalidating the alert design.
 
 Dev DSR alerts target `appi-asora-function-dev-dsr`, a workspace-based component
 created after the legacy `asora-function-dev` component stopped ingesting telemetry.

--- a/infrastructure/alerts/main.tf
+++ b/infrastructure/alerts/main.tf
@@ -308,7 +308,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "auth_failure_rate" {
 
 # ──────────────────────────────────────────────────────────────
 # Alert: DSR requests stuck queued > 5 minutes (per target)
-# Uses privacyDsrQueueMonitor telemetry.
+# Uses the latest privacyDsrQueueMonitor telemetry emitted every eight hours.
+# The AzureRM provider cannot represent a 12-hour window; a one-day window
+# safely covers the source interval without restoring a five-minute cadence.
 # ──────────────────────────────────────────────────────────────
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_stuck_queued" {
   for_each            = local.targets
@@ -316,18 +318,18 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_stuck_queued" {
   resource_group_name = var.resource_group_name
   location            = data.azurerm_application_insights.target[each.key].location
 
-  evaluation_frequency = "PT5M"
-  window_duration      = "PT10M"
+  evaluation_frequency = "PT1H"
+  window_duration      = "P1D"
   scopes               = [data.azurerm_application_insights.target[each.key].id]
   severity             = max(each.value.severity - 1, 1)
 
   criteria {
     query = <<-QUERY
       traces
-      | where timestamp > ago(10m)
-      | where operation_Name == "privacyDsrQueueMonitor"
-      | where message startswith "dsr.queue.monitor"
-      | extend stuckQueuedCount = toint(extract(@"stuckQueuedCount:\s*(\d+)", 1, message))
+      | where timestamp > ago(24h)
+      | where operation_Name == 'privacyDsrQueueMonitor'
+      | where message startswith 'dsr.queue.monitor'
+      | extend stuckQueuedCount = toint(extract(@'stuckQueuedCount:\s*(\d+)', 1, message))
       | summarize arg_max(timestamp, stuckQueuedCount)
       | where stuckQueuedCount > 0
     QUERY
@@ -344,7 +346,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_stuck_queued" {
 
   auto_mitigation_enabled          = true
   workspace_alerts_storage_enabled = false
-  description                      = "Triggers when privacy_requests has queued DSR requests older than 5 minutes on ${each.key}"
+  description                      = "Triggers from the latest eight-hour DSR monitor snapshot when queued DSR requests are older than 5 minutes on ${each.key}"
   display_name                     = "${each.key} - DSR Stuck Queued"
   enabled                          = true
   skip_query_validation            = false
@@ -355,8 +357,10 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_stuck_queued" {
 }
 
 # ──────────────────────────────────────────────────────────────
-# Alert: DSR queue depth > 0 for more than 5 minutes (per target)
-# Uses privacyDsrQueueMonitor telemetry.
+# Alert: DSR queue depth > 0 (per target)
+# Uses the latest privacyDsrQueueMonitor telemetry emitted every eight hours.
+# The AzureRM provider cannot represent a 12-hour window; a one-day window
+# safely covers the source interval without restoring a five-minute cadence.
 # ──────────────────────────────────────────────────────────────
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_queue_depth" {
   for_each            = local.targets
@@ -364,20 +368,20 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_queue_depth" {
   resource_group_name = var.resource_group_name
   location            = data.azurerm_application_insights.target[each.key].location
 
-  evaluation_frequency = "PT5M"
-  window_duration      = "PT10M"
+  evaluation_frequency = "PT1H"
+  window_duration      = "P1D"
   scopes               = [data.azurerm_application_insights.target[each.key].id]
   severity             = max(each.value.severity - 1, 1)
 
   criteria {
     query = <<-QUERY
       traces
-      | where timestamp > ago(10m)
-      | where operation_Name == "privacyDsrQueueMonitor"
-      | where message startswith "dsr.queue.monitor"
-      | extend approximateMessageCount = toint(extract(@"approximateMessageCount:\s*(\d+)", 1, message))
-      | summarize samples=count(), positiveSamples=countif(approximateMessageCount > 0)
-      | where samples >= 2 and positiveSamples >= 2
+      | where timestamp > ago(24h)
+      | where operation_Name == 'privacyDsrQueueMonitor'
+      | where message startswith 'dsr.queue.monitor'
+      | extend approximateMessageCount = toint(extract(@'approximateMessageCount:\s*(\d+)', 1, message))
+      | summarize arg_max(timestamp, approximateMessageCount)
+      | where approximateMessageCount > 0
     QUERY
 
     time_aggregation_method = "Count"
@@ -392,7 +396,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_queue_depth" {
 
   auto_mitigation_enabled          = true
   workspace_alerts_storage_enabled = false
-  description                      = "Triggers when DSR queue depth is greater than 0 across two monitor samples on ${each.key}"
+  description                      = "Triggers from the latest eight-hour DSR monitor snapshot when queue depth is greater than 0 on ${each.key}"
   display_name                     = "${each.key} - DSR Queue Depth"
   enabled                          = true
   skip_query_validation            = false
@@ -403,8 +407,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_queue_depth" {
 }
 
 # ──────────────────────────────────────────────────────────────
-# Alert: DSR failures > 0 (per target)
-# Covers failed queue handler events and persisted failed DSR requests.
+# Alert: DSR processor or monitor failures > 0 (per target)
+# Uses immediate structured failure telemetry.
 # ──────────────────────────────────────────────────────────────
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_failures" {
   for_each            = local.targets
@@ -412,30 +416,18 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_failures" {
   resource_group_name = var.resource_group_name
   location            = data.azurerm_application_insights.target[each.key].location
 
-  evaluation_frequency = "PT5M"
-  window_duration      = "PT10M"
+  evaluation_frequency = "PT15M"
+  window_duration      = "PT30M"
   scopes               = [data.azurerm_application_insights.target[each.key].id]
   severity             = max(each.value.severity - 1, 1)
 
   criteria {
     query = <<-QUERY
-      let failedHandlerEvents =
-        traces
-        | where timestamp > ago(10m)
-        | where message startswith "dsr.queue.failed"
-        | summarize failedHandlerCount = count();
-      let failedRequestSnapshots =
-        traces
-        | where timestamp > ago(10m)
-        | where operation_Name == "privacyDsrQueueMonitor"
-        | where message startswith "dsr.queue.monitor"
-        | extend failedRequestCount = toint(extract(@"failedRequestCount:\s*(\d+)", 1, message))
-        | summarize arg_max(timestamp, failedRequestCount);
-      failedHandlerEvents
-      | extend joinKey = 1
-      | join kind=fullouter (failedRequestSnapshots | extend joinKey = 1) on joinKey
-      | extend totalFailures = coalesce(failedHandlerCount, 0) + coalesce(failedRequestCount, 0)
-      | where totalFailures > 0
+      traces
+      | where timestamp > ago(30m)
+      | where message startswith 'dsr.queue.failed' or message startswith 'dsr.queue.monitor.failed'
+      | summarize failureCount = count()
+      | where failureCount > 0
     QUERY
 
     time_aggregation_method = "Count"
@@ -450,7 +442,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_failures" {
 
   auto_mitigation_enabled          = true
   workspace_alerts_storage_enabled = false
-  description                      = "Triggers when DSR queue failures or persisted failed DSR requests are detected on ${each.key}"
+  description                      = "Triggers when immediate DSR processor or monitor failure telemetry is detected on ${each.key} within 30 minutes"
   display_name                     = "${each.key} - DSR Failures"
   enabled                          = true
   skip_query_validation            = false
@@ -462,7 +454,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_failures" {
 
 # ──────────────────────────────────────────────────────────────
 # Alert: DSR poison queue exists or has messages (per target)
-# Uses privacyDsrQueueMonitor telemetry.
+# Uses the latest privacyDsrQueueMonitor telemetry emitted every eight hours.
+# The AzureRM provider cannot represent a 12-hour window; a one-day window
+# safely covers the source interval without restoring a five-minute cadence.
 # ──────────────────────────────────────────────────────────────
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_poison_queue" {
   for_each            = local.targets
@@ -470,19 +464,19 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_poison_queue" {
   resource_group_name = var.resource_group_name
   location            = data.azurerm_application_insights.target[each.key].location
 
-  evaluation_frequency = "PT5M"
-  window_duration      = "PT10M"
+  evaluation_frequency = "PT1H"
+  window_duration      = "P1D"
   scopes               = [data.azurerm_application_insights.target[each.key].id]
   severity             = 1
 
   criteria {
     query = <<-QUERY
       traces
-      | where timestamp > ago(10m)
-      | where operation_Name == "privacyDsrQueueMonitor"
-      | where message startswith "dsr.queue.monitor"
-      | extend poisonQueueExists = tobool(extract(@"poisonQueueExists:\s*(true|false)", 1, message))
-      | extend poisonApproximateMessageCount = toint(extract(@"poisonApproximateMessageCount:\s*(\d+)", 1, message))
+      | where timestamp > ago(24h)
+      | where operation_Name == 'privacyDsrQueueMonitor'
+      | where message startswith 'dsr.queue.monitor'
+      | extend poisonQueueExists = tobool(extract(@'poisonQueueExists:\s*(true|false)', 1, message))
+      | extend poisonApproximateMessageCount = toint(extract(@'poisonApproximateMessageCount:\s*(\d+)', 1, message))
       | summarize arg_max(timestamp, poisonQueueExists, poisonApproximateMessageCount)
       | where poisonQueueExists == true or poisonApproximateMessageCount > 0
     QUERY
@@ -499,7 +493,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_poison_queue" {
 
   auto_mitigation_enabled          = true
   workspace_alerts_storage_enabled = false
-  description                      = "CRITICAL: DSR poison queue exists or contains messages on ${each.key}"
+  description                      = "CRITICAL: triggers from the latest eight-hour DSR monitor snapshot when the poison queue exists or contains messages on ${each.key}"
   display_name                     = "${each.key} - DSR Poison Queue"
   enabled                          = true
   skip_query_validation            = false
@@ -511,7 +505,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_poison_queue" {
 
 # ──────────────────────────────────────────────────────────────
 # Alert: DSR enqueue without completion telemetry (per target)
-# Detects queue work that was accepted but did not produce dsr.queue.completed.
+# Runs as a stateless daily operational summary because Azure stateful rules cannot run daily.
 # ──────────────────────────────────────────────────────────────
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_missing_completion" {
   for_each            = local.targets
@@ -519,30 +513,22 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_missing_completio
   resource_group_name = var.resource_group_name
   location            = data.azurerm_application_insights.target[each.key].location
 
-  evaluation_frequency = "PT5M"
-  window_duration      = "PT10M"
+  evaluation_frequency = "P1D"
+  window_duration      = "P1D"
   scopes               = [data.azurerm_application_insights.target[each.key].id]
   severity             = max(each.value.severity - 1, 1)
 
   criteria {
     query = <<-QUERY
-      let enqueued =
-        traces
-        | where timestamp > ago(10m)
-        | where message startswith "dsr.export.enqueued" or message startswith "dsr.delete.enqueued"
-        | extend requestId = tostring(extract(@"id:\s*'([^']+)'", 1, message))
-        | where isnotempty(requestId)
-        | where timestamp < ago(5m)
-        | project requestId, enqueueTimestamp = timestamp;
-      let completed =
-        traces
-        | where timestamp > ago(10m)
-        | where message startswith "dsr.queue.completed"
-        | extend requestId = tostring(extract(@"requestId:\s*'([^']+)'", 1, message))
-        | where isnotempty(requestId)
-        | project requestId;
-      enqueued
-      | join kind=leftanti completed on requestId
+      traces
+      | where timestamp > ago(24h)
+      | where message startswith 'dsr.export.enqueued' or message startswith 'dsr.delete.enqueued' or message startswith 'dsr.queue.completed'
+      | extend eventKind = iff(message startswith 'dsr.queue.completed', 'completed', 'enqueued')
+      | extend requestId = iff(eventKind == 'completed', extract(@'requestId:\s*''([^'']+)''', 1, message), extract(@'id:\s*''([^'']+)''', 1, message))
+      | where isnotempty(requestId)
+      | summarize oldestEnqueue = minif(timestamp, eventKind == 'enqueued'), latestCompletion = maxif(timestamp, eventKind == 'completed') by requestId
+      | where oldestEnqueue < ago(12h)
+      | where isnull(latestCompletion) or latestCompletion < oldestEnqueue
       | summarize missingCompletionCount = count()
       | where missingCompletionCount > 0
     QUERY
@@ -557,9 +543,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "dsr_missing_completio
     }
   }
 
-  auto_mitigation_enabled          = true
+  auto_mitigation_enabled          = false
   workspace_alerts_storage_enabled = false
-  description                      = "Triggers when a DSR enqueue has no dsr.queue.completed telemetry after 5 minutes on ${each.key}"
+  description                      = "Daily operational summary for DSR requests without completion telemetry after 12 hours on ${each.key}"
   display_name                     = "${each.key} - DSR Missing Completion"
   enabled                          = true
   skip_query_validation            = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -12320,15 +12320,6 @@
         "minimatch": "^5.1.0"
       }
     },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -12835,9 +12826,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "yaml": "^2.8.1"
   },
   "overrides": {
+    "concurrently@10.0.3": {
+      "shell-quote": "1.10.0"
+    },
     "glob@10.5.0": {
       "minimatch": "9.0.9"
     },
@@ -70,6 +73,9 @@
     "form-data": "4.0.6",
     "lodash": "4.18.1",
     "minimatch@^3.0.0": "3.1.5",
+    "minimatch@5.1.9": {
+      "brace-expansion": "2.1.2"
+    },
     "typescript": "5.5.4"
   },
   "workspaces": [


### PR DESCRIPTION
## Summary
- Reconciles source with approved live cost reductions on the one canonical Azure environment.
- Keeps DSR traces, exceptions, and structured events unsampled while enforcing Warning-level Azure SDK and host logging.
- Disables non-actionable Flex live metrics and performance counters.
- Aligns all five DSR rules with the live schedule: 15m/30m immediate failures, three hourly daily-window monitor rules, and one stateless daily lifecycle summary.

## Live evidence
- Canonical direct health and public gateway health: HTTP 200 after the telemetry recycle.
- Public discovery: HTTP 200; controlled unauthenticated auth: HTTP 401.
- Five DSR KQL queries validated directly against the canonical component; no current matches.
- DSR rules retain their action group and zero threshold. Evaluation volume falls from 1,440 to 169 per day (estimated 88.3% reduction; not an invoice saving).

## Validation
- Focused host telemetry Jest: 4 passing.
- Terraform fmt and validate: passing.
- Terraform no-apply safety test: 3 passing.
- actionlint: passing.
- Gitleaks no-git scan: no findings.

## Deferred
- No daily cap: seven-day average is 0.412005 GB/day, making the approved cap candidate 0.824011 GB/day.
- Duplicate Function Apps and quarantined storage remain in their 72-hour observation window; no deletion is included.
- DSR always-ready remains unchanged pending isolated six-request scale-from-zero proof.