### PR TITLE
chore: add guarded Azure read-role workflow

### DIFF
--- a/.github/workflows/azure-temporary-read-roles.yml
+++ b/.github/workflows/azure-temporary-read-roles.yml
@@ -1,0 +1,414 @@
+name: Temporary Azure Read Role Assignments v2
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+concurrency:
+  group: azure-temporary-read-roles-v2
+  cancel-in-progress: false
+
+jobs:
+  assign-and-verify:
+    runs-on: ubuntu-latest
+    environment: dev
+    timeout-minutes: 30
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      EXPECTED_SP_OBJECT_ID: 6d9e43cf-c68a-4e1e-bd29-441e9e32e256
+      RESOURCE_GROUP: asora-psql-flex
+      COSMOS_ACCOUNT: asora-cosmos-dev
+      COSMOS_DATABASE: asora
+      COSMOS_DATA_SCOPE: /dbs/asora
+      DSR_STORAGE_ACCOUNT: stasoradsrdev
+      DSR_CONTAINER: dsr-exports
+      MEDIA_STORAGE_ACCOUNT: asoramediadev
+      MEDIA_CONTAINER: user-media
+      KEY_VAULT: kv-asora-flex-dev
+      POSTGRES_SECRET_NAME: postgres-connection-string
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify identity and target resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p evidence
+
+          account_json="$(az account show -o json)"
+          test "$(jq -r '.tenantId' <<<"$account_json")" = "$AZURE_TENANT_ID"
+          test "$(jq -r '.id' <<<"$account_json")" = "$AZURE_SUBSCRIPTION_ID"
+
+          sp_object_id="$(az ad sp show --id "$AZURE_CLIENT_ID" --query id -o tsv)"
+          test "$sp_object_id" = "$EXPECTED_SP_OBJECT_ID"
+
+          rg_scope="$(az group show --name "$RESOURCE_GROUP" --query id -o tsv)"
+          test -n "$rg_scope"
+
+          cosmos_scope="$(az cosmosdb show --resource-group "$RESOURCE_GROUP" --name "$COSMOS_ACCOUNT" --query id -o tsv)"
+          test -n "$cosmos_scope"
+
+          storage_scopes='[]'
+          while IFS='|' read -r storage_account container; do
+            account_id="$(az storage account show --name "$storage_account" --query id -o tsv)"
+            account_rg="$(az storage account show --name "$storage_account" --query resourceGroup -o tsv)"
+            test -n "$account_id"
+            test -n "$account_rg"
+            container_scope="$account_id/blobServices/default/containers/$container"
+            az resource show --ids "$container_scope" -o none
+            storage_scopes="$(jq -c --arg account "$storage_account" --arg container "$container" --arg resourceGroup "$account_rg" --arg scope "$container_scope" '. + [{account:$account,container:$container,resourceGroup:$resourceGroup,scope:$scope}]' <<<"$storage_scopes")"
+          done <<EOF
+          $DSR_STORAGE_ACCOUNT|$DSR_CONTAINER
+          $MEDIA_STORAGE_ACCOUNT|$MEDIA_CONTAINER
+          EOF
+
+          jq -n \
+            --arg principalId "$sp_object_id" \
+            --arg resourceGroup "$RESOURCE_GROUP" \
+            --arg resourceGroupScope "$rg_scope" \
+            --arg cosmosAccount "$COSMOS_ACCOUNT" \
+            --arg cosmosDatabase "$COSMOS_DATABASE" \
+            --arg cosmosScope "$COSMOS_DATA_SCOPE" \
+            --argjson storage "$storage_scopes" \
+            '{principalObjectId:$principalId,resourceGroup:$resourceGroup,resourceGroupScope:$resourceGroupScope,cosmosAccount:$cosmosAccount,cosmosDatabase:$cosmosDatabase,cosmosScope:$cosmosScope,storage:$storage,tenantSubscriptionMatch:true,targetResourcesVerified:true}' > evidence/target-context.json
+
+          {
+            echo "SP_OBJECT_ID=$sp_object_id"
+            echo "RG_SCOPE=$rg_scope"
+            echo "COSMOS_SCOPE=$cosmos_scope"
+          } >> "$GITHUB_ENV"
+
+      - name: Inspect existing assignments and coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          assignment_error="$(mktemp)"
+          assignments_raw="$(az role assignment list --assignee-object-id "$SP_OBJECT_ID" --all -o json 2>"$assignment_error" || true)"
+          if [[ -z "$assignments_raw" ]]; then
+            assignments_raw='[]'
+          fi
+          assignment_error_code="$(grep -Eo 'AuthorizationFailed|Forbidden|ResourceNotFound|BadParameter|AuthenticationFailed' "$assignment_error" | head -n 1 || true)"
+          if [[ -n "$assignment_error_code" && "$assignments_raw" == '[]' ]]; then
+            jq -n --arg errorCode "$assignment_error_code" '{status:"error",operation:"role assignment list",errorCode:$errorCode}' > evidence/existing-assignment-error.json
+            rm -f "$assignment_error"
+            exit 22
+          fi
+          if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$assignments_raw"; then
+            assignments_raw='[]'
+          fi
+          jq '[.[] | {assignmentId:(.id // ""),role:(.roleDefinitionName // ""),roleDefinitionId:(.roleDefinitionId // ""),scope:(.scope // ""),createdOn:(.createdOn // null)}]' <<<"$assignments_raw" > evidence/existing-assignments.json
+
+          role_definitions='[]'
+          role_definition_errors='[]'
+          while IFS= read -r role_id; do
+            [[ -n "$role_id" ]] || continue
+            definition="$(az role definition show --id "$role_id" -o json 2>"$assignment_error" || true)"
+            if jq -e 'type == "object"' >/dev/null 2>&1 <<<"$definition"; then
+              role_definitions="$(jq --argjson definition "$definition" '. + [$definition]' <<<"$role_definitions")"
+            else
+              error_code="$(grep -Eo 'AuthorizationFailed|Forbidden|ResourceNotFound|BadParameter|AuthenticationFailed' "$assignment_error" | head -n 1 || true)"
+              role_definition_errors="$(jq --arg roleId "$role_id" --arg errorCode "${error_code:-unknown}" '. + [{roleDefinitionId:$roleId,errorCode:$errorCode}]' <<<"$role_definition_errors")"
+            fi
+          done < <(jq -r '.[].roleDefinitionId // empty' evidence/existing-assignments.json | sort -u)
+          jq -n --argjson assignments "$(cat evidence/existing-assignments.json)" --argjson roleDefinitions "$role_definitions" --argjson errors "$role_definition_errors" '{assignments:$assignments,roleDefinitions:$roleDefinitions,roleDefinitionErrors:$errors}' > evidence/existing-assignment-details.json
+          if jq -e '.roleDefinitionErrors | length > 0' evidence/existing-assignment-details.json >/dev/null; then
+            exit 23
+          fi
+
+          cosmos_role_definitions="$(az cosmosdb sql role definition list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" -o json 2>"$assignment_error" || true)"
+          assignment_error_code="$(grep -Eo 'AuthorizationFailed|Forbidden|ResourceNotFound|BadParameter|AuthenticationFailed' "$assignment_error" | head -n 1 || true)"
+          if [[ -n "$assignment_error_code" && -z "$cosmos_role_definitions" ]]; then
+            jq -n --arg errorCode "$assignment_error_code" '{status:"error",operation:"Cosmos role definition list",errorCode:$errorCode}' > evidence/cosmos-role-definition-error.json
+            rm -f "$assignment_error"
+            exit 24
+          fi
+          if [[ -z "$cosmos_role_definitions" ]]; then
+            cosmos_role_definitions='[]'
+          fi
+          printf '%s\n' "$cosmos_role_definitions" > evidence/cosmos-role-definitions.json
+
+          cosmos_assignments="$(az cosmosdb sql role assignment list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" -o json 2>"$assignment_error" || true)"
+          assignment_error_code="$(grep -Eo 'AuthorizationFailed|Forbidden|ResourceNotFound|BadParameter|AuthenticationFailed' "$assignment_error" | head -n 1 || true)"
+          if [[ -n "$assignment_error_code" && -z "$cosmos_assignments" ]]; then
+            jq -n --arg errorCode "$assignment_error_code" '{status:"error",operation:"Cosmos role assignment list",errorCode:$errorCode}' > evidence/existing-cosmos-assignment-error.json
+            rm -f "$assignment_error"
+            exit 25
+          fi
+          if [[ -z "$cosmos_assignments" ]]; then
+            cosmos_assignments='[]'
+          fi
+          if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$cosmos_assignments"; then
+            cosmos_assignments='[]'
+          fi
+          jq '[.[] | {assignmentId:(.id // ""),principalId:(.principalId // ""),roleDefinitionId:(.roleDefinitionId // ""),scope:(.scope // "")}]' <<<"$cosmos_assignments" > evidence/existing-cosmos-assignments.json
+          rm -f "$assignment_error"
+
+          python3 - <<'PY'
+          import fnmatch
+          import json
+          from pathlib import Path
+
+          evidence = Path("evidence")
+          assignments = json.loads((evidence / "existing-assignments.json").read_text())
+          details = json.loads((evidence / "existing-assignment-details.json").read_text())
+          definitions = {item.get("name", "").lower(): item for item in details["roleDefinitions"]}
+          definitions.update({item.get("id", "").rstrip("/").split("/")[-1].lower(): item for item in details["roleDefinitions"]})
+
+          def is_ancestor(scope, target):
+              scope = (scope or "").rstrip("/").lower()
+              target = (target or "").rstrip("/").lower()
+              return bool(scope) and (target == scope or target.startswith(scope + "/"))
+
+          def permits(role_definition, action, data=False):
+              action = action.lower()
+              for permission in role_definition.get("permissions", []):
+                  allows = permission.get("dataActions" if data else "actions", [])
+                  denies = permission.get("notDataActions" if data else "notActions", [])
+                  if any(fnmatch.fnmatchcase(action, pattern.lower()) for pattern in allows) and not any(fnmatch.fnmatchcase(action, pattern.lower()) for pattern in denies):
+                      return True
+              return False
+
+          def definition_for(assignment):
+              role_id = (assignment.get("roleDefinitionId") or "").rstrip("/").split("/")[-1].lower()
+              return definitions.get(role_id) or definitions.get((assignment.get("role") or "").lower(), {})
+
+          def covering(target, action, data=False):
+              found = []
+              for assignment in assignments:
+                  if is_ancestor(assignment.get("scope"), target) and permits(definition_for(assignment), action, data):
+                      found.append({"assignmentId": assignment.get("assignmentId"), "role": assignment.get("role"), "scope": assignment.get("scope")})
+              return found
+
+          context = json.loads((evidence / "target-context.json").read_text())
+          resource_group_scope = context["resourceGroupScope"]
+          storage = {item["container"]: item["scope"] for item in context["storage"]}
+          inventory = covering(resource_group_scope, "Microsoft.Resources/subscriptions/resourceGroups/resources/read")
+          blob_reads = {container: covering(scope, "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read", True) for container, scope in storage.items()}
+          coverage = {
+              "resourceGroupInventory": {"provided": bool(inventory), "coveringAssignments": inventory},
+              "blobDataRead": {container: {"provided": bool(items), "coveringAssignments": items} for container, items in blob_reads.items()},
+          }
+          (evidence / "existing-coverage.json").write_text(json.dumps(coverage, indent=2) + "\n")
+          PY
+
+      - name: Probe Key Vault metadata only
+        shell: bash
+        run: |
+          set -euo pipefail
+          error_file="$(mktemp)"
+          query="[?name == '$POSTGRES_SECRET_NAME'] | [0].{id:id,name:name}"
+          secret_metadata="$(az keyvault secret list --vault-name "$KEY_VAULT" --query "$query" -o json 2>"$error_file" || true)"
+          if jq -e '.id' >/dev/null 2>&1 <<<"$secret_metadata"; then
+            jq -n --argjson metadata "$secret_metadata" '{status:"metadata-accessible",secretId:$metadata.id,secretName:$metadata.name,valueRead:false}' > evidence/postgres-secret-access.json
+          else
+            error_code="$(grep -Eo 'AuthorizationFailed|Forbidden|ResourceNotFound|BadParameter|AuthenticationFailed' "$error_file" | head -n 1 || true)"
+            jq -n --arg errorCode "${error_code:-unknown}" '{status:"not-accessible",errorCode:$errorCode,valueRead:false}' > evidence/postgres-secret-access.json
+          fi
+          rm -f "$error_file"
+
+      - name: Preflight role-assignment write permission
+        shell: bash
+        run: |
+          set -euo pipefail
+          error_file="$(mktemp)"
+          permissions_url="https://management.azure.com${RG_SCOPE}/providers/Microsoft.Authorization/permissions?api-version=2015-07-01"
+          permission_json="$(az rest --method get --url "$permissions_url" -o json 2>"$error_file" || true)"
+          error_code="$(grep -Eo 'AuthorizationFailed|Forbidden|ResourceNotFound|BadParameter|AuthenticationFailed' "$error_file" | head -n 1 || true)"
+          if ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$permission_json"; then
+            jq -n --arg requiredAction 'Microsoft.Authorization/roleAssignments/write' --arg cosmosAction 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/write' --arg errorCode "${error_code:-unknown}" '{status:"error",requiredActions:[$requiredAction,$cosmosAction],errorCode:$errorCode}' > evidence/role-assignment-write-preflight.json
+            rm -f "$error_file"
+            exit 20
+          fi
+          jq '.' <<<"$permission_json" > evidence/role-assignment-permissions.json
+          permission_status="$(python3 - <<'PY'
+          import fnmatch
+          import json
+
+          document = json.load(open("evidence/role-assignment-permissions.json"))
+          actions = []
+          not_actions = []
+          for permission in document.get("value", []):
+              actions.extend(permission.get("actions", []))
+              not_actions.extend(permission.get("notActions", []))
+
+          def allowed(action):
+              return any(fnmatch.fnmatchcase(action.lower(), pattern.lower()) for pattern in actions) and not any(fnmatch.fnmatchcase(action.lower(), pattern.lower()) for pattern in not_actions)
+
+          print(json.dumps({
+              "authorizationRoleAssignmentsWrite": allowed("Microsoft.Authorization/roleAssignments/write"),
+              "cosmosRoleAssignmentsWrite": allowed("Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/write"),
+          }))
+          PY
+          )"
+          has_auth_write="$(jq -r '.authorizationRoleAssignmentsWrite' <<<"$permission_status")"
+          has_cosmos_write="$(jq -r '.cosmosRoleAssignmentsWrite' <<<"$permission_status")"
+          jq -n --arg authWrite "$has_auth_write" --arg cosmosWrite "$has_cosmos_write" --arg requiredAction 'Microsoft.Authorization/roleAssignments/write' --arg cosmosAction 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments/write' '{status:(if ($authWrite == "true" and $cosmosWrite == "true") then "allowed" else "denied" end),requiredActions:[$requiredAction,$cosmosAction],authorizationRoleAssignmentsWrite:($authWrite == "true"),cosmosRoleAssignmentsWrite:($cosmosWrite == "true")}' > evidence/role-assignment-write-preflight.json
+          rm -f "$error_file"
+          if [[ "$has_auth_write" != "true" || "$has_cosmos_write" != "true" ]]; then
+            exit 20
+          fi
+
+      - name: Create or reuse only missing approved assignments
+        shell: bash
+        run: |
+          set -euo pipefail
+          observed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          assignments='[]'
+
+          record_assignment() {
+            local approved_role="$1" approved_scope="$2" decision="$3" assignment_id="$4" covering_role="$5" covering_scope="$6" revoke="$7"
+            assignments="$(jq -c --arg approvedRole "$approved_role" --arg approvedScope "$approved_scope" --arg decision "$decision" --arg assignmentId "$assignment_id" --arg coveringRole "$covering_role" --arg coveringScope "$covering_scope" --arg revoke "$revoke" --arg observedAt "$observed_at" '. + [{approvedRole:$approvedRole,approvedScope:$approvedScope,decision:$decision,assignmentId:(if $assignmentId == "" then null else $assignmentId end),coveringRole:(if $coveringRole == "" then null else $coveringRole end),coveringScope:(if $coveringScope == "" then null else $coveringScope end),revocationCommand:(if $revoke == "" then null else $revoke end),observedAt:$observedAt}]' <<<"$assignments")"
+          }
+
+          reader_assignment="$(jq -r --arg scope "$RG_SCOPE" '[.[] | select(.role == "Reader" and .scope == $scope)] | first | .assignmentId // empty' evidence/existing-assignments.json || true)"
+          inventory_covering="$(jq -r '.resourceGroupInventory.coveringAssignments[0] // empty' evidence/existing-coverage.json || true)"
+          if [[ -n "$reader_assignment" ]]; then
+            reader_scope="$RG_SCOPE"
+            record_assignment 'Reader' "$RG_SCOPE" 'pre-existing' "$reader_assignment" 'Reader' "$reader_scope" ''
+          elif [[ -n "$inventory_covering" ]]; then
+            covering_role="$(jq -r '.role // ""' <<<"$inventory_covering")"
+            covering_scope="$(jq -r '.scope // ""' <<<"$inventory_covering")"
+            covering_id="$(jq -r '.assignmentId // ""' <<<"$inventory_covering")"
+            record_assignment 'Reader' "$RG_SCOPE" 'redundant' "$covering_id" "$covering_role" "$covering_scope" ''
+          else
+            result="$(az role assignment create --assignee-object-id "$SP_OBJECT_ID" --assignee-principal-type ServicePrincipal --role 'Reader' --scope "$RG_SCOPE" -o json)"
+            assignment_id="$(jq -r '.id' <<<"$result")"
+            record_assignment 'Reader' "$RG_SCOPE" 'created' "$assignment_id" '' '' "az role assignment delete --ids $assignment_id"
+          fi
+
+          cosmos_role_id="$(jq -r '[.[] | select(.roleName == "Cosmos DB Built-in Data Reader")][0].id // empty' evidence/cosmos-role-definitions.json || true)"
+          if [[ -z "$cosmos_role_id" ]]; then
+            jq -n '{status:"blocked",reason:"Cosmos DB Built-in Data Reader role definition was not found"}' > evidence/assignment-creation-result.json
+            exit 21
+          fi
+          cosmos_assignment="$(jq -r --arg principalId "$SP_OBJECT_ID" --arg roleId "$cosmos_role_id" --arg scope "$COSMOS_DATA_SCOPE" '[.[] | select(.principalId == $principalId and .roleDefinitionId == $roleId and .scope == $scope)] | first | .assignmentId // empty' evidence/existing-cosmos-assignments.json || true)"
+          if [[ -n "$cosmos_assignment" ]]; then
+            record_assignment 'Cosmos DB Built-in Data Reader' "$COSMOS_DATA_SCOPE" 'pre-existing' "$cosmos_assignment" 'Cosmos DB Built-in Data Reader' "$COSMOS_DATA_SCOPE" ''
+          else
+            result="$(az cosmosdb sql role assignment create --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" --principal-id "$SP_OBJECT_ID" --role-definition-id "$cosmos_role_id" --scope "$COSMOS_DATA_SCOPE" -o json)"
+            assignment_id="$(jq -r '.id' <<<"$result")"
+            record_assignment 'Cosmos DB Built-in Data Reader' "$COSMOS_DATA_SCOPE" 'created' "$assignment_id" '' '' "az cosmosdb sql role assignment delete --resource-group $RESOURCE_GROUP --account-name $COSMOS_ACCOUNT --role-assignment-id $assignment_id"
+          fi
+
+          while IFS='|' read -r storage_account container; do
+            account_id="$(az storage account show --name "$storage_account" --query id -o tsv)"
+            scope="$account_id/blobServices/default/containers/$container"
+            exact_assignment="$(jq -r --arg role 'Storage Blob Data Reader' --arg scope "$scope" '[.[] | select(.role == $role and .scope == $scope)] | first | .assignmentId // empty' evidence/existing-assignments.json || true)"
+            covering="$(jq -r --arg container "$container" '.blobDataRead[$container].coveringAssignments[0] // empty' evidence/existing-coverage.json || true)"
+            if [[ -n "$exact_assignment" ]]; then
+              record_assignment 'Storage Blob Data Reader' "$scope" 'pre-existing' "$exact_assignment" 'Storage Blob Data Reader' "$scope" ''
+            elif [[ -n "$covering" ]]; then
+              covering_role="$(jq -r '.role // ""' <<<"$covering")"
+              covering_scope="$(jq -r '.scope // ""' <<<"$covering")"
+              covering_id="$(jq -r '.assignmentId // ""' <<<"$covering")"
+              record_assignment 'Storage Blob Data Reader' "$scope" 'redundant' "$covering_id" "$covering_role" "$covering_scope" ''
+            else
+              result="$(az role assignment create --assignee-object-id "$SP_OBJECT_ID" --assignee-principal-type ServicePrincipal --role 'Storage Blob Data Reader' --scope "$scope" -o json)"
+              assignment_id="$(jq -r '.id' <<<"$result")"
+              record_assignment 'Storage Blob Data Reader' "$scope" 'created' "$assignment_id" '' '' "az role assignment delete --ids $assignment_id"
+            fi
+          done <<EOF
+          $DSR_STORAGE_ACCOUNT|$DSR_CONTAINER
+          $MEDIA_STORAGE_ACCOUNT|$MEDIA_CONTAINER
+          EOF
+
+          jq -n --arg observedAt "$observed_at" --argjson assignments "$assignments" '{status:"complete",observedAt:$observedAt,assignments:$assignments}' > evidence/assignment-creation-result.json
+
+      - name: Wait for read-role propagation
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..10}; do
+            if az cosmosdb sql database list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" -o none && \
+               az storage blob list --account-name "$DSR_STORAGE_ACCOUNT" --container-name "$DSR_CONTAINER" --auth-mode login -o none && \
+               az storage blob list --account-name "$MEDIA_STORAGE_ACCOUNT" --container-name "$MEDIA_CONTAINER" --auth-mode login -o none; then
+              exit 0
+            fi
+            sleep 30
+          done
+          exit 1
+
+      - name: Run bounded read-only tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          az resource list --resource-group "$RESOURCE_GROUP" --query '[].{name:name,type:type,resourceGroup:resourceGroup,state:provisioningState}' -o json > evidence/resource-inventory.json
+          az cosmosdb show --resource-group "$RESOURCE_GROUP" --name "$COSMOS_ACCOUNT" --query '{name:name,resourceGroup:resourceGroup,provisioningState:provisioningState}' -o json > evidence/cosmos-account-metadata.json
+          az cosmosdb sql database list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" -o json > evidence/cosmos-databases.json
+          az cosmosdb sql container list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" --database-name "$COSMOS_DATABASE" -o json > evidence/cosmos-containers.json
+
+          npm ci --prefix functions --ignore-scripts --no-audit --no-fund
+          COSMOS_ENDPOINT="$(az cosmosdb show --resource-group "$RESOURCE_GROUP" --name "$COSMOS_ACCOUNT" --query documentEndpoint -o tsv)" \
+          COSMOS_DATABASE="$COSMOS_DATABASE" \
+          NODE_PATH=functions/node_modules \
+          node <<'NODE'
+          const { DefaultAzureCredential } = require('@azure/identity');
+          const { CosmosClient } = require('@azure/cosmos');
+          const fs = require('node:fs');
+
+          (async () => {
+            const credential = new DefaultAzureCredential();
+            const client = new CosmosClient({ endpoint: process.env.COSMOS_ENDPOINT, aadCredentials: credential });
+            const database = client.database(process.env.COSMOS_DATABASE);
+            const containers = (await database.containers.readAll().fetchAll()).resources;
+            const probes = [];
+            for (const container of containers.slice(0, 2)) {
+              const result = await database.container(container.id).items.query({ query: 'SELECT TOP 1 c.id FROM c' }, { maxItemCount: 1 }).fetchAll();
+              probes.push({ container: container.id, returnedItems: result.resources.length });
+            }
+            fs.writeFileSync('evidence/cosmos-bounded-query.json', JSON.stringify({ listedContainers: containers.length, probes, boundedQuerySucceeded: true }, null, 2));
+          })().catch((error) => {
+            fs.writeFileSync('evidence/cosmos-bounded-query.json', JSON.stringify({ boundedQuerySucceeded: false, errorName: error.name, errorCode: error.code ?? null }, null, 2));
+            process.exitCode = 1;
+          });
+          NODE
+
+          NODE_PATH=functions/node_modules node <<'NODE'
+          const { DefaultAzureCredential } = require('@azure/identity');
+          const { BlobServiceClient } = require('@azure/storage-blob');
+          const fs = require('node:fs');
+
+          async function probe(account, containerName) {
+            const service = new BlobServiceClient(`https://${account}.blob.core.windows.net`, new DefaultAzureCredential());
+            const container = service.getContainerClient(containerName);
+            let first = null;
+            for await (const blob of container.listBlobsFlat()) {
+              first = blob.name;
+              break;
+            }
+            if (!first) return { account, container: containerName, listedObjects: 0, boundedMetadataRead: 'empty' };
+            const properties = await container.getBlobClient(first).getProperties();
+            return { account, container: containerName, listedObjects: 1, boundedMetadataRead: 'passed', contentLength: properties.contentLength ?? null, contentType: properties.contentType ?? null };
+          }
+
+          Promise.all([
+            probe(process.env.DSR_STORAGE_ACCOUNT, process.env.DSR_CONTAINER),
+            probe(process.env.MEDIA_STORAGE_ACCOUNT, process.env.MEDIA_CONTAINER),
+          ]).then((results) => fs.writeFileSync('evidence/blob-bounded-read.json', JSON.stringify(results, null, 2)))
+            .catch((error) => {
+              fs.writeFileSync('evidence/blob-bounded-read.json', JSON.stringify({ boundedMetadataRead: 'failed', errorName: error.name, errorCode: error.code ?? null }, null, 2));
+              process.exitCode = 1;
+            });
+          NODE
+
+      - name: Upload private evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: azure-temporary-read-role-evidence-v2
+          path: evidence/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/azure-temporary-read-roles.yml
+++ b/.github/workflows/azure-temporary-read-roles.yml
@@ -332,6 +332,7 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in {1..10}; do
+            echo "Checking read-role propagation (attempt $attempt/10)."
             if az cosmosdb sql database list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" -o none && \
                az storage blob list --account-name "$DSR_STORAGE_ACCOUNT" --container-name "$DSR_CONTAINER" --auth-mode login -o none && \
                az storage blob list --account-name "$MEDIA_STORAGE_ACCOUNT" --container-name "$MEDIA_CONTAINER" --auth-mode login -o none; then


### PR DESCRIPTION
Adds only the temporary Azure read-role workflow. It handles empty assignment results safely, inventories existing role scopes, evaluates broader read coverage, preflights role-assignment write permission, and records bounded read evidence. No provider action is dispatched by this PR.