### PR TITLE
ops: report Azure extraction usage preflight

### DIFF
--- a/.github/workflows/azure-temporary-encrypted-extraction.yml
+++ b/.github/workflows/azure-temporary-encrypted-extraction.yml
@@ -198,6 +198,7 @@ jobs:
             newBillingProductCreated: false,
           };
           await writeFile(join(root, "usage-preflight.json"), `${JSON.stringify(guard, null, 2)}\n`);
+          console.log(`AZURE_EXTRACTION_USAGE_PREFLIGHT ${JSON.stringify(guard)}`);
           if (totalRecords > Number(process.env.MAX_COSMOS_RECORDS)) {
             throw new Error("Cosmos record guard exceeded");
           }


### PR DESCRIPTION
Temporary workflow-only correction after run 30439894466 safely stopped at the DSR object-count cap. Adds one sanitized preflight totals line before the existing guards. No cap increase, secret output, Azure write, provider resource, or unrelated change.