### PR TITLE
Fix native API CORS preflight responses

### DIFF
--- a/apps/lythaus-public-api/src/index.ts
+++ b/apps/lythaus-public-api/src/index.ts
@@ -453,7 +453,7 @@ function corsOrigin(request: Request, env: Env): string | undefined {
 }
 
 function response(request: Request, env: Env, body: unknown, init: ResponseInit = {}): Response {
-  const result = json(body, init);
+  const result = init.status === 204 ? new Response(null, init) : json(body, init);
   const origin = corsOrigin(request, env);
   if (origin) {
     result.headers.set('access-control-allow-origin', origin);

--- a/scripts/tests/native-architecture-invariants.test.js
+++ b/scripts/tests/native-architecture-invariants.test.js
@@ -218,6 +218,13 @@ test('jobs Worker exposes durable privacy and appeal workflows', () => {
   assert.match(source, /backup\.schema_validation\.completed/);
 });
 
+test('public API CORS preflight uses a bodyless 204 response', () => {
+  const source = fs.readFileSync(path.join(root, 'apps/lythaus-public-api/src/index.ts'), 'utf8');
+  assert.match(source, /init\.status === 204 \? new Response\(null, init\) : json\(body, init\)/);
+  assert.match(source, /request\.method === 'OPTIONS'/);
+  assert.match(source, /'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS'/);
+});
+
 test('PlanetScale CI uses a disposable local PostgreSQL 17 service', () => {
   const workflow = fs.readFileSync(path.join(root, '.github/workflows/native-planetscale-ci.yml'), 'utf8');
   assert.match(workflow, /image: postgres:17/);


### PR DESCRIPTION
## Summary
- return a bodyless HTTP 204 for native public API preflight requests
- add a native architecture regression assertion

## Validation
- native TypeScript typecheck
- native architecture tests (30/30)
- PostgreSQL 17 migration/role validation
- API Contract and OpenAPI checks
- Functions regression (2287 active tests)
- control-panel tests/build
- marketing build/contract
- dependency audit and migration tests
- git diff --check

## Production evidence
Live preflight on the merged PR #474 deployment returned HTTP 400 because JSON serialization attempted to attach a body to status 204. This PR fixes that root cause without weakening CORS or any check.