### PR TITLE
Fix PlanetScale verifier system roots

### DIFF
--- a/scripts/ci/verify-planetscale-production-schema.mjs
+++ b/scripts/ci/verify-planetscale-production-schema.mjs
@@ -93,8 +93,11 @@ const connection = new URL(databaseUrl);
 if (connection.searchParams.get('sslmode') !== 'verify-full') {
   throw new Error('production schema verification requires sslmode=verify-full');
 }
+if (connection.searchParams.get('sslrootcert') === 'system') {
+  connection.searchParams.delete('sslrootcert');
+}
 
-const client = new Client({ connectionString: databaseUrl, ssl: { rejectUnauthorized: true } });
+const client = new Client({ connectionString: connection.toString(), ssl: { rejectUnauthorized: true } });
 await client.connect();
 try {
   await client.query('BEGIN READ ONLY');

--- a/scripts/tests/native-architecture-invariants.test.js
+++ b/scripts/tests/native-architecture-invariants.test.js
@@ -250,6 +250,9 @@ test('production migrations remain explicit while Worker deployment verifies rea
   assert.match(verifier, /5cae370456c8b6083dc7342130f6214444d0452c494660e52c175b18f5da4110/);
   assert.match(verifier, /committed migration SHA-256 mismatch/);
   assert.match(verifier, /approved applied migration payload mismatch/);
+  assert.match(verifier, /searchParams\.get\('sslrootcert'\) === 'system'/);
+  assert.match(verifier, /searchParams\.delete\('sslrootcert'\)/);
+  assert.match(verifier, /ssl: \{ rejectUnauthorized: true \}/);
   assert.doesNotMatch(verifier, /to_regclass|identity\.users|content\.posts/);
 });
 


### PR DESCRIPTION
## Summary
- keep the production verifier fail-closed on `sslmode=verify-full`
- translate PlanetScale's `sslrootcert=system` URI sentinel to Node's trusted system roots
- retain `rejectUnauthorized: true` and add a regression invariant

## Root cause
Run 30489513596 reached the read-only verifier and failed before every Worker deployment because `node-postgres` interpreted `sslrootcert=system` as a local file named `system`.

## Validation
- live read-only verifier against `lythaus/lythaus-core/main`: passed, nine migrations
- canonical migration payload: 45,647 bytes
- canonical SHA-256: `5cae370456c8b6083dc7342130f6214444d0452c494660e52c175b18f5da4110`
- `npm run test:native-architecture`
- `npm run typecheck:native`
- `git diff --check`

The failed deployment did not upload any Worker. This PR changes no provider resource, route, DNS record, database schema, or Azure state.