### PR TITLE
Enable exact-main marketing deployment

### DIFF
--- a/.github/workflows/deploy-marketing-preview.yml
+++ b/.github/workflows/deploy-marketing-preview.yml
@@ -1,7 +1,18 @@
-name: Deploy Lythaus marketing preview
+name: Deploy Lythaus marketing
 
 on:
   workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact 40-character commit SHA to build and deploy
+        required: true
+        type: string
+      deployment_class:
+        description: Pages deployment class
+        required: true
+        default: preview
+        type: choice
+        options: [preview, production]
 
 permissions:
   contents: read
@@ -13,12 +24,33 @@ concurrency:
 jobs:
   deploy-and-validate:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 20
     env:
       PAGES_PROJECT: lythaus-marketing
-      PAGES_BRANCH: codex/lythaus-domain-migration
+      PAGES_BRANCH: ${{ inputs.deployment_class == 'production' && 'main' || 'codex/lythaus-domain-migration' }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Require exact approved SHA
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          DEPLOYMENT_CLASS: ${{ inputs.deployment_class }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "release_sha must be a full 40-character commit SHA" >&2; exit 1; }
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          if [[ "$DEPLOYMENT_CLASS" = "production" ]]; then
+            git fetch --no-tags origin main
+            test "$(git rev-parse origin/main)" = "$RELEASE_SHA" || {
+              echo "Refusing production deployment: release_sha is not current origin/main." >&2
+              exit 1
+            }
+          fi
 
       - uses: actions/setup-node@v5
         with:
@@ -39,7 +71,7 @@ jobs:
           npm run build
           node ../../scripts/cloudflare/validate-marketing-output.mjs dist
 
-      - name: Deploy immutable preview only
+      - name: Deploy exact marketing artifact
         id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- extend the existing `lythaus-marketing` deployment workflow to support preview or production
- require an exact 40-character release SHA and require production to equal current `origin/main`
- deploy production through the protected `production` environment to the existing Pages project
- retain the ten-route, forbidden-origin, sitemap, robots, and security-header checks

## Validation
- workflow YAML parse
- `npm run test:native-architecture`
- `git diff --check`

This creates no Pages project, account, DNS record, paid plan, Cloudflare resource, PlanetScale resource, or Azure mutation.