### PR TITLE
Add temporary read-only Azure deletion inventory

### DIFF
--- a/.github/workflows/azure-temporary-deletion-inventory.yml
+++ b/.github/workflows/azure-temporary-deletion-inventory.yml
@@ -1,0 +1,199 @@
+name: Temporary Azure Deletion Inventory
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: Exact 40-character main SHA authorised for inventory
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  EXPECTED_PRINCIPAL_ID: 6d9e43cf-c68a-4e1e-bd29-441e9e32e256
+  RESOURCE_GROUP: asora-psql-flex
+  COSMOS_ACCOUNT: asora-cosmos-dev
+
+jobs:
+  inventory:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact main
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Enforce exact main SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected='${{ inputs.expected_main_sha }}'
+          [[ "$expected" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$GITHUB_REF" == 'refs/heads/main' ]]
+          actual="$(git rev-parse HEAD)"
+          remote="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+          [[ "$actual" == "$expected" ]]
+          [[ "$remote" == "$expected" ]]
+
+      - name: Authenticate with existing Azure OIDC identity
+        uses: azure/login@v3
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify approved identity and scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          tenant_id="$(az account show --query tenantId --output tsv)"
+          subscription_id="$(az account show --query id --output tsv)"
+          principal_id="$(az ad sp show --id "$AZURE_CLIENT_ID" --query id --output tsv)"
+          [[ "$tenant_id" == "$AZURE_TENANT_ID" ]]
+          [[ "$subscription_id" == "$AZURE_SUBSCRIPTION_ID" ]]
+          [[ "$principal_id" == "$EXPECTED_PRINCIPAL_ID" ]]
+          az group show --name "$RESOURCE_GROUP" --query id --output tsv >/dev/null
+          az cosmosdb show --resource-group "$RESOURCE_GROUP" --name "$COSMOS_ACCOUNT" \
+            --query id --output tsv >/dev/null
+
+      - name: Collect sanitized read-only inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/azure-deletion-inventory"
+          mkdir -p "$output/services"
+
+          az account show \
+            --query '{subscriptionId:id,subscriptionName:name,tenantId:tenantId,state:state}' \
+            --output json >"$output/account.json"
+          az group show --name "$RESOURCE_GROUP" \
+            --query '{id:id,name:name,location:location,managedBy:managedBy,tags:tags}' \
+            --output json >"$output/resource-group.json"
+          az group list \
+            --query '[].{id:id,name:name,location:location,managedBy:managedBy}' \
+            --output json >"$output/visible-resource-groups.json"
+          az resource list \
+            --query '[].{id:id,name:name,type:type,resourceGroup:resourceGroup,location:location,kind:kind,sku:sku.name,plan:plan.name,tags:tags}' \
+            --output json >"$output/visible-resources.json"
+          az resource list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,type:type,resourceGroup:resourceGroup,location:location,kind:kind,sku:sku.name,plan:plan.name,tags:tags}' \
+            --output json >"$output/resource-group-resources.json"
+
+          az extension add --name resource-graph --only-show-errors >/dev/null
+          az graph query --first 1000 --query \
+            "Resources | project id, name, type, resourceGroup, subscriptionId, location, kind, sku=tostring(sku.name), tags | order by type asc, name asc" \
+            --output json >"$output/resource-graph.json"
+
+          az lock list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,level:level,notes:notes,owners:owners}' \
+            --output json >"$output/services/resource-locks.json"
+          az role assignment list --scope "$(az group show --name "$RESOURCE_GROUP" --query id --output tsv)" --include-inherited \
+            --query '[].{id:id,principalId:principalId,principalType:principalType,roleDefinitionName:roleDefinitionName,scope:scope}' \
+            --output json >"$output/services/resource-group-role-assignments.json"
+
+          az functionapp list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,state:state,kind:kind,location:location,hostNames:hostNames,serverFarmId:serverFarmId,httpsOnly:httpsOnly,identity:identity}' \
+            --output json >"$output/services/function-apps.json"
+          jq -r '.[].name' "$output/services/function-apps.json" | while read -r app; do
+            [[ -n "$app" ]] || continue
+            az functionapp deployment slot list --resource-group "$RESOURCE_GROUP" --name "$app" \
+              --query '[].{id:id,name:name,state:state,hostNames:hostNames}' --output json \
+              >"$output/services/function-slots-${app}.json"
+          done
+
+          az postgres flexible-server list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,location:location,state:state,version:version,sku:sku,storage:storage,backup:backup,highAvailability:highAvailability,network:network}' \
+            --output json >"$output/services/postgresql-servers.json"
+          jq -r '.[].name' "$output/services/postgresql-servers.json" | while read -r server; do
+            [[ -n "$server" ]] || continue
+            az postgres flexible-server db list --resource-group "$RESOURCE_GROUP" --server-name "$server" \
+              --query '[].{id:id,name:name,charset:charset,collation:collation}' --output json \
+              >"$output/services/postgresql-databases-${server}.json"
+            az postgres flexible-server firewall-rule list --resource-group "$RESOURCE_GROUP" --name "$server" \
+              --query '[].{id:id,name:name,startIpAddress:startIpAddress,endIpAddress:endIpAddress}' --output json \
+              >"$output/services/postgresql-firewall-${server}.json"
+          done
+
+          az cosmosdb show --resource-group "$RESOURCE_GROUP" --name "$COSMOS_ACCOUNT" \
+            --query '{id:id,name:name,location:location,kind:kind,consistencyPolicy:consistencyPolicy,locations:locations,capabilities:capabilities,backupPolicy:backupPolicy,identity:identity}' \
+            --output json >"$output/services/cosmos-account.json"
+          az cosmosdb sql database list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" \
+            --query '[].{id:id,name:name,resource:resource}' --output json \
+            >"$output/services/cosmos-databases.json"
+          az cosmosdb sql container list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" --database-name asora \
+            --query '[].{id:id,name:name,partitionKey:resource.partitionKey,indexingPolicy:resource.indexingPolicy,uniqueKeyPolicy:resource.uniqueKeyPolicy}' \
+            --output json >"$output/services/cosmos-containers.json"
+          az cosmosdb sql role assignment list --resource-group "$RESOURCE_GROUP" --account-name "$COSMOS_ACCOUNT" \
+            --query '[].{id:id,principalId:principalId,roleDefinitionId:roleDefinitionId,scope:scope}' \
+            --output json >"$output/services/cosmos-role-assignments.json"
+
+          az storage account list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,location:location,kind:kind,sku:sku.name,accessTier:accessTier,allowBlobPublicAccess:allowBlobPublicAccess,minimumTlsVersion:minimumTlsVersion,identity:identity}' \
+            --output json >"$output/services/storage-accounts.json"
+          jq -r '.[].name' "$output/services/storage-accounts.json" | while read -r account; do
+            [[ -n "$account" ]] || continue
+            az storage container-rm list --resource-group "$RESOURCE_GROUP" --storage-account "$account" \
+              --query '[].{id:id,name:name,publicAccess:publicAccess,hasImmutabilityPolicy:hasImmutabilityPolicy,hasLegalHold:hasLegalHold}' \
+              --output json >"$output/services/storage-containers-${account}.json"
+          done
+
+          az keyvault list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,location:location,enableRbacAuthorization:properties.enableRbacAuthorization,enableSoftDelete:properties.enableSoftDelete,softDeleteRetentionInDays:properties.softDeleteRetentionInDays,enablePurgeProtection:properties.enablePurgeProtection}' \
+            --output json >"$output/services/key-vaults.json"
+          az network vnet list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,location:location,addressSpace:addressSpace,subnets:subnets[].{id:id,name:name,addressPrefix:addressPrefix,privateEndpointNetworkPolicies:privateEndpointNetworkPolicies}}' \
+            --output json >"$output/services/virtual-networks.json"
+          az network private-endpoint list --resource-group "$RESOURCE_GROUP" \
+            --query '[].{id:id,name:name,location:location,subnet:subnet.id,privateLinkServiceConnections:privateLinkServiceConnections[].{name:name,privateLinkServiceId:privateLinkServiceId,groupIds:groupIds,status:privateLinkServiceConnectionState.status}}' \
+            --output json >"$output/services/private-endpoints.json"
+
+          az ad app show --id "$AZURE_CLIENT_ID" \
+            --query '{id:id,appId:appId,displayName:displayName,signInAudience:signInAudience}' \
+            --output json >"$output/services/oidc-application.json"
+          az ad app federated-credential list --id "$AZURE_CLIENT_ID" \
+            --query '[].{id:id,name:name,issuer:issuer,subject:subject,audiences:audiences}' \
+            --output json >"$output/services/oidc-federated-credentials.json"
+          az ad sp show --id "$AZURE_CLIENT_ID" \
+            --query '{id:id,appId:appId,displayName:displayName,accountEnabled:accountEnabled,servicePrincipalType:servicePrincipalType}' \
+            --output json >"$output/services/oidc-service-principal.json"
+
+          principal_id="$(jq -r '.id' "$output/services/oidc-service-principal.json")"
+          rg_id="$(jq -r '.id' "$output/resource-group.json")"
+          az role assignment list --scope "$rg_id" --include-inherited \
+            --query "[?principalId=='$principal_id'].{id:id,roleDefinitionName:roleDefinitionName,scope:scope,principalId:principalId}" \
+            --output json >"$output/services/oidc-management-role-assignments.json"
+
+          jq -n \
+            --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg sourceSha "$GITHUB_SHA" \
+            --arg resourceGroup "$RESOURCE_GROUP" \
+            --slurpfile resources "$output/resource-group-resources.json" \
+            --slurpfile graph "$output/resource-graph.json" \
+            --slurpfile locks "$output/services/resource-locks.json" \
+            '{schemaVersion:1,generatedAt:$generatedAt,sourceSha:$sourceSha,readOnly:true,resourceGroup:$resourceGroup,resourceCount:($resources[0]|length),resourceGraphCount:($graph[0].data|length),lockCount:($locks[0]|length),files:["account.json","resource-group.json","visible-resource-groups.json","visible-resources.json","resource-group-resources.json","resource-graph.json","services/"]}' \
+            >"$output/manifest.json"
+          (cd "$output" && find . -type f -print0 | sort -z | xargs -0 sha256sum) >"$output/evidence-manifest.sha256"
+
+          resource_count="$(jq 'length' "$output/resource-group-resources.json")"
+          graph_count="$(jq '.data | length' "$output/resource-graph.json")"
+          printf 'AZURE_DELETION_INVENTORY_COUNTS resource_group=%s resource_graph=%s\n' "$resource_count" "$graph_count"
+
+      - name: Upload sanitized deletion inventory
+        uses: actions/upload-artifact@v4
+        with:
+          name: azure-deletion-inventory-${{ github.sha }}
+          path: ${{ runner.temp }}/azure-deletion-inventory
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Azure logout
+        if: always()
+        shell: bash
+        run: az logout || true

--- a/.github/workflows/azure-temporary-deletion-inventory.yml
+++ b/.github/workflows/azure-temporary-deletion-inventory.yml
@@ -87,7 +87,7 @@ jobs:
             --output json >"$output/resource-group-resources.json"
 
           az extension add --name resource-graph --only-show-errors >/dev/null
-          az graph query --first 1000 --query \
+          az graph query --first 1000 --graph-query \
             "Resources | project id, name, type, resourceGroup, subscriptionId, location, kind, sku=tostring(sku.name), tags | order by type asc, name asc" \
             --output json >"$output/resource-graph.json"
 


### PR DESCRIPTION
## Summary
- add one manually dispatched OIDC workflow
- inventory Azure metadata and hidden Resource Graph dependencies read-only
- upload a sanitized, checksummed evidence artifact

## Safety
- no Azure data reads beyond metadata
- no secret retrieval
- no role, firewall, resource, or data mutations
- no new paid resource or billing line

## Validation
- actionlint
- Prettier
- git diff --check