### PR TITLE
Add temporary Google OAuth secret sync

### DIFF
--- a/.github/workflows/cloudflare-temporary-google-secret-sync.yml
+++ b/.github/workflows/cloudflare-temporary-google-secret-sync.yml
@@ -1,0 +1,105 @@
+name: Temporary Google OAuth Secret Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: Exact 40-character main SHA authorised for secret sync
+        required: true
+        type: string
+      expected_worker_version:
+        description: Current public Worker version ID used as rollback
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      GOOGLE_OAUTH_CLIENT_SECRET_WEB: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET_WEB }}
+      WORKER_NAME: lythaus-public-api-development
+    steps:
+      - name: Check out exact main
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Enforce exact main and approved Worker
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected='${{ inputs.expected_main_sha }}'
+          expected_version='${{ inputs.expected_worker_version }}'
+          [[ "$expected" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$expected_version" =~ ^[0-9a-f-]{36}$ ]]
+          [[ "$GITHUB_REF" == 'refs/heads/main' ]]
+          actual="$(git rev-parse HEAD)"
+          remote="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+          [[ "$actual" == "$expected" ]]
+          [[ "$remote" == "$expected" ]]
+          [[ -n "$CLOUDFLARE_API_TOKEN" ]]
+          [[ -n "$CLOUDFLARE_ACCOUNT_ID" ]]
+          [[ -n "$GOOGLE_OAUTH_CLIENT_SECRET_WEB" ]]
+          printf '::add-mask::%s\n' "$GOOGLE_OAUTH_CLIENT_SECRET_WEB"
+
+          before="$RUNNER_TEMP/cloudflare-before.json"
+          curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME/deployments" \
+            >"$before"
+          jq -e '.success == true' "$before" >/dev/null
+          current_version="$(jq -r '.result.deployments[0].versions[0].version_id' "$before")"
+          [[ "$current_version" == "$expected_version" ]]
+
+          mkdir -p "$RUNNER_TEMP/google-secret-sync-evidence"
+          jq '{success,result:{deployments:[.result.deployments[0] | {id,created_on,versions:[.versions[] | {version_id,percentage}]}]}}' \
+            "$before" >"$RUNNER_TEMP/google-secret-sync-evidence/before-deployment.json"
+          printf 'npx wrangler versions deploy %s@100 --name %s\n' "$current_version" "$WORKER_NAME" \
+            >"$RUNNER_TEMP/google-secret-sync-evidence/rollback-command.txt"
+
+      - name: Reuse protected Google client secret on existing Worker
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s' "$GOOGLE_OAUTH_CLIENT_SECRET_WEB" | \
+            npx --yes wrangler@4.50.0 secret put GOOGLE_CLIENT_SECRET --name "$WORKER_NAME"
+
+      - name: Verify secret binding and Worker readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/google-secret-sync-evidence"
+          secrets="$RUNNER_TEMP/cloudflare-secrets.json"
+          after="$RUNNER_TEMP/cloudflare-after.json"
+          curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME/secrets" \
+            >"$secrets"
+          jq -e '.success == true and any(.result[]; .name == "GOOGLE_CLIENT_SECRET")' "$secrets" >/dev/null
+          curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$WORKER_NAME/deployments" \
+            >"$after"
+          jq -e '.success == true' "$after" >/dev/null
+          jq '{success,result:{deployments:[.result.deployments[0] | {id,created_on,versions:[.versions[] | {version_id,percentage}]}]}}' \
+            "$after" >"$evidence/after-deployment.json"
+          jq '{secretNames:[.result[].name] | sort}' "$secrets" >"$evidence/secret-names.json"
+
+          curl --fail --silent --show-error --max-time 15 https://api.lythaus.co/health >/dev/null
+          curl --fail --silent --show-error --max-time 15 https://api.lythaus.co/ready >/dev/null
+          (cd "$evidence" && find . -type f -print0 | sort -z | xargs -0 sha256sum) >"$evidence/evidence-manifest.sha256"
+
+      - name: Upload sanitized sync evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: google-oauth-secret-sync-${{ github.sha }}
+          path: ${{ runner.temp }}/google-secret-sync-evidence
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Summary
- add one manually dispatched production workflow
- reuse the existing protected Google OAuth client secret
- update only GOOGLE_CLIENT_SECRET on the existing public Worker
- capture sanitized before/after deployment and rollback evidence

## Safety
- no new Google credential
- no new Worker or paid resource
- no secret values in logs or artifacts
- exact-main and exact-current-version guards

## Validation
- actionlint
- Prettier
- git diff --check