### PR TITLE
Fix PostgreSQL firewall inventory argument

### DIFF
--- a/.github/workflows/azure-temporary-deletion-inventory.yml
+++ b/.github/workflows/azure-temporary-deletion-inventory.yml
@@ -131,7 +131,7 @@ jobs:
             az postgres flexible-server db list --resource-group "$RESOURCE_GROUP" --server-name "$server" \
               --query '[].{id:id,name:name,charset:charset,collation:collation}' --output json \
               >"$output/services/postgresql-databases-${server}.json"
-            az postgres flexible-server firewall-rule list --resource-group "$RESOURCE_GROUP" --name "$server" \
+            az postgres flexible-server firewall-rule list --resource-group "$RESOURCE_GROUP" --server-name "$server" \
               --query '[].{id:id,name:name,startIpAddress:startIpAddress,endIpAddress:endIpAddress}' --output json \
               >"$output/services/postgresql-firewall-${server}.json"
           done


### PR DESCRIPTION
## Summary
- use the supported PostgreSQL flexible-server firewall list argument
- preserve read-only Azure inventory behavior

## Validation
- Prettier check
- actionlint
- ShellCheck via actionlint
- git diff --check

This PR changes only the temporary Azure deletion inventory workflow and performs no provider mutation.