### PR TITLE
Add scoped ADR 003 OAuth gate deferral

### DIFF
--- a/infrastructure/cloudflare/production-gates.json
+++ b/infrastructure/cloudflare/production-gates.json
@@ -1,12 +1,13 @@
 {
   "schemaVersion": "lythaus-production-gates-v2",
-  "releaseSha": null,
+  "releaseSha": "f815d646aac8e0690df381d3dc333b0dba5f36ae",
   "releaseShaPolicy": "workflow input must equal the checked-out merged main SHA",
   "cutoverAuthorized": true,
   "migrationUsageAuthorized": false,
   "migrationUsageMaxUsd": 0,
   "estimatedIncrementalCostUsd": 0,
   "azureDeletionAuthorized": false,
+  "azureDeletionExecution": "NOT STARTED",
   "requiredOwnerActions": [
     "Approve migration usage only if a future measured estimate exceeds US$0",
     "AUTHORISE FINAL AZURE DELETION only after every final gate is completed"
@@ -43,9 +44,18 @@
         "status": "IN PROGRESS",
         "evidence": ["infrastructure/lythaus-resource-registry.json", "docs/runbooks/native-deployment-and-rollback.md"]
       },
-      "domainAndOAuthCutover": {
+      "domainCutover": {
         "status": "IN PROGRESS",
         "evidence": ["docs/architecture/lythaus-domain-architecture.md", "apps/lythaus-public-api/src/index.ts"]
+      },
+      "googleOAuthAcceptance": {
+        "status": "DEFERRED TO ADR 003",
+        "ownerApproved": true,
+        "launchBlocking": true,
+        "scope": "Google OAuth end-to-end session acceptance only",
+        "decisionDate": "2026-08-02",
+        "expiresWhen": "ADR 003 authentication acceptance completes",
+        "evidence": ["docs/evidence/azure-exit/2026-08-02/azure-independence-closure.md"]
       },
       "runtimeCutover": {
         "status": "IN PROGRESS",
@@ -55,7 +65,7 @@
         "status": "IN PROGRESS",
         "evidence": ["scripts/validate-github-azure-disconnection.mjs", "docs/evidence/azure-exit/2026-07-30/github-to-azure-disconnection.md"]
       },
-      "azureDeletionEvidence": {
+      "azureDeletionInventory": {
         "status": "IN PROGRESS",
         "evidence": ["docs/runbooks/lythaus-azure-exit.md", "docs/runbooks/native-deployment-and-rollback.md"]
       }

--- a/scripts/tests/native-architecture-invariants.test.js
+++ b/scripts/tests/native-architecture-invariants.test.js
@@ -1,5 +1,7 @@
+import { spawnSync, execFileSync } from 'node:child_process';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
@@ -294,7 +296,17 @@ test('production deployment is fail-closed on predeploy and final gate phases', 
   const validator = fs.readFileSync(path.join(root, 'scripts/validate-production-gates.mjs'), 'utf8');
   assert.match(workflow, /Validate production predeployment gates/);
   assert.ok(Object.keys(manifest.gates.predeploy).length >= 6);
-  assert.ok(Object.keys(manifest.gates.final).length >= 5);
+  assert.ok(Object.keys(manifest.gates.final).length >= 6);
+  assert.ok(manifest.gates.final.domainCutover);
+  assert.equal(manifest.gates.final.domainAndOAuthCutover, undefined);
+  assert.equal(manifest.gates.final.googleOAuthAcceptance.status, 'DEFERRED TO ADR 003');
+  assert.equal(manifest.gates.final.googleOAuthAcceptance.ownerApproved, true);
+  assert.equal(manifest.gates.final.googleOAuthAcceptance.launchBlocking, true);
+  assert.equal(manifest.gates.final.googleOAuthAcceptance.scope, 'Google OAuth end-to-end session acceptance only');
+  assert.equal(manifest.gates.final.googleOAuthAcceptance.decisionDate, '2026-08-02');
+  assert.equal(manifest.gates.final.googleOAuthAcceptance.expiresWhen, 'ADR 003 authentication acceptance completes');
+  assert.ok(manifest.gates.final.azureDeletionInventory);
+  assert.equal(manifest.azureDeletionExecution, 'NOT STARTED');
   assert.equal(manifest.cutoverAuthorized, true);
   assert.equal(manifest.migrationUsageAuthorized, false);
   assert.equal(manifest.migrationUsageMaxUsd, 0);
@@ -302,7 +314,59 @@ test('production deployment is fail-closed on predeploy and final gate phases', 
   assert.equal(manifest.azureDeletionAuthorized, false);
   assert.match(validator, /phase === 'predeploy'/);
   assert.match(validator, /phase === 'final'/);
+  assert.match(validator, /DEFERRED TO ADR 003/);
+  assert.match(validator, /googleOAuthAcceptance/);
   assert.match(validator, /zero-cost deployment requires migration usage authorization false and maximum US\$0/);
+});
+
+test('ADR 003 deferral is accepted only for final Google OAuth acceptance', () => {
+  const manifestPath = path.join(root, 'infrastructure/cloudflare/production-gates.json');
+  const validatorSource = fs.readFileSync(path.join(root, 'scripts/validate-production-gates.mjs'), 'utf8');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lythaus-production-gates-'));
+  const temporaryManifestPath = path.join(temporaryRoot, 'infrastructure/cloudflare/production-gates.json');
+  const temporaryValidatorPath = path.join(temporaryRoot, 'scripts/validate-production-gates.mjs');
+
+  try {
+    fs.mkdirSync(path.dirname(temporaryManifestPath), { recursive: true });
+    fs.mkdirSync(path.dirname(temporaryValidatorPath), { recursive: true });
+    fs.writeFileSync(temporaryValidatorPath, validatorSource);
+
+    const validManifest = structuredClone(manifest);
+    for (const record of Object.values(validManifest.gates.predeploy)) record.status = 'COMPLETED';
+    for (const [gateName, record] of Object.entries(validManifest.gates.final)) {
+      if (gateName !== 'googleOAuthAcceptance') record.status = 'COMPLETED';
+    }
+    fs.writeFileSync(temporaryManifestPath, JSON.stringify(validManifest));
+
+    assert.doesNotThrow(() => execFileSync(
+      process.execPath,
+      [temporaryValidatorPath, '--phase', 'final'],
+      {
+        cwd: temporaryRoot,
+        env: { ...process.env, RELEASE_SHA: validManifest.releaseSha },
+        encoding: 'utf8',
+      },
+    ));
+
+    const invalidManifest = structuredClone(validManifest);
+    invalidManifest.gates.final.domainCutover = structuredClone(validManifest.gates.final.googleOAuthAcceptance);
+    fs.writeFileSync(temporaryManifestPath, JSON.stringify(invalidManifest));
+    const result = spawnSync(
+      process.execPath,
+      [temporaryValidatorPath, '--phase', 'final'],
+      {
+        cwd: temporaryRoot,
+        env: { ...process.env, RELEASE_SHA: invalidManifest.releaseSha },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stdout}${result.stderr}`, /final\.domainCutover may not use DEFERRED TO ADR 003/);
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
 });
 
 test('production deployment accepts only the exact merged main SHA', () => {

--- a/scripts/validate-production-gates.mjs
+++ b/scripts/validate-production-gates.mjs
@@ -7,13 +7,25 @@ const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 const phaseIndex = process.argv.indexOf('--phase');
 const phase = phaseIndex === -1 ? null : process.argv[phaseIndex + 1];
 const expectedSha = process.env.RELEASE_SHA ?? '';
-const allowedStatuses = new Set(['COMPLETED', 'IN PROGRESS', 'BLOCKED', 'DEFERRED BY ARCHITECTURE', 'FAILED ACCEPTANCE']);
+const allowedStatuses = new Set(['COMPLETED', 'IN PROGRESS', 'BLOCKED', 'DEFERRED TO ADR 003', 'FAILED ACCEPTANCE']);
 const failures = [];
+
+function isApprovedGoogleOAuthDeferral(groupName, gateName, record) {
+  return groupName === 'final'
+    && gateName === 'googleOAuthAcceptance'
+    && record?.status === 'DEFERRED TO ADR 003'
+    && record?.ownerApproved === true
+    && record?.launchBlocking === true
+    && record?.scope === 'Google OAuth end-to-end session acceptance only'
+    && record?.decisionDate === '2026-08-02'
+    && record?.expiresWhen === 'ADR 003 authentication acceptance completes';
+}
 
 if (manifest.schemaVersion !== 'lythaus-production-gates-v2') failures.push('unsupported production gate manifest schema');
 if (manifest.releaseSha !== null && (typeof manifest.releaseSha !== 'string' || !/^[0-9a-f]{40}$/.test(manifest.releaseSha))) failures.push('releaseSha must be null before merge or a full 40-character commit SHA');
 if (manifest.releaseShaPolicy !== 'workflow input must equal the checked-out merged main SHA') failures.push('releaseShaPolicy must require the merged main checkout');
 if (manifest.azureDeletionAuthorized !== false) failures.push('Azure deletion authorization must remain false in the production gate manifest');
+if (manifest.azureDeletionExecution !== 'NOT STARTED') failures.push('Azure deletion execution must remain NOT STARTED');
 if (typeof manifest.estimatedIncrementalCostUsd !== 'number' || manifest.estimatedIncrementalCostUsd < 0) failures.push('estimatedIncrementalCostUsd must be a non-negative number');
 if (manifest.estimatedIncrementalCostUsd === 0) {
   if (manifest.migrationUsageAuthorized !== false || manifest.migrationUsageMaxUsd !== 0) {
@@ -36,6 +48,9 @@ for (const groupName of ['predeploy', 'final']) {
   for (const [gateName, record] of Object.entries(group)) {
     if (!allowedStatuses.has(record?.status)) failures.push(`${groupName}.${gateName} has unsupported status ${record?.status}`);
     if (!Array.isArray(record?.evidence) || record.evidence.length === 0) failures.push(`${groupName}.${gateName} must cite evidence`);
+    if (record?.status === 'DEFERRED TO ADR 003' && !isApprovedGoogleOAuthDeferral(groupName, gateName, record)) {
+      failures.push(`${groupName}.${gateName} may not use DEFERRED TO ADR 003`);
+    }
   }
 }
 
@@ -50,7 +65,9 @@ if (phase === 'predeploy' || phase === 'final') {
 
 if (phase === 'final') {
   for (const [gateName, record] of Object.entries(manifest.gates?.final ?? {})) {
-    if (record.status !== 'COMPLETED') failures.push(`final.${gateName} is not COMPLETED`);
+    if (record.status !== 'COMPLETED' && !isApprovedGoogleOAuthDeferral('final', gateName, record)) {
+      failures.push(`final.${gateName} is not COMPLETED`);
+    }
   }
 }
 


### PR DESCRIPTION
## Scope\n\nGate-control only for Azure Independence Closure.\n\n- records release SHA f815d646aac8e0690df381d3dc333b0dba5f36ae\n- renames the domain and Azure deletion inventory gates\n- permits DEFERRED TO ADR 003 only on final.googleOAuthAcceptance with exact owner-approved metadata\n- adds executable validator coverage proving other final gates cannot use the exception\n\nNo runtime source, Worker configuration, dependencies, infrastructure resources, deployment inputs, provider mutations, secrets, or cost-generating actions are included. No Worker redeployment is required.\n\nValidation: 32 native architecture tests, predeploy gate validation, and git diff --check pass.