### PR TITLE
chore(ci): refresh actions/cache on current workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}


### PR DESCRIPTION
Replaces closed PR #439 from current main.

Updates the retained CI workflow from actions/cache@v5 to actions/cache@v6. No other workflow or provider changes are included.

Validation and approval are intentionally left for a separate review.