### PR TITLE
chore(ci): refresh actions/checkout on retained workflows

### DIFF
--- a/.github/workflows/alpha-feed-performance.yml
+++ b/.github/workflows/alpha-feed-performance.yml
@@ -26,7 +26,7 @@ jobs:
     environment: dev
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 1

--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -17,7 +17,7 @@ jobs:
   api_contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/beta-smoke.yml
+++ b/.github/workflows/beta-smoke.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set smoke report path
         run: echo "BETA_SMOKE_REPORT_PATH=$RUNNER_TEMP/beta-smoke-report.json" >> "$GITHUB_ENV"

--- a/.github/workflows/cache-check.yml
+++ b/.github/workflows/cache-check.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Wait for deployment to settle
         if: ${{ github.event_name == 'workflow_run' }}

--- a/.github/workflows/canary-k6.yml
+++ b/.github/workflows/canary-k6.yml
@@ -18,7 +18,7 @@ jobs:
     name: Run k6 canary tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install k6
         uses: grafana/setup-k6-action@v1
@@ -110,7 +110,7 @@ jobs:
       K6_BASE_URL: ${{ vars.MVP_PUBLIC_API_BASE_URL }}
       K6_SMOKE_TOKEN: ${{ secrets.K6_SMOKE_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install k6
         uses: grafana/setup-k6-action@v1

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -62,7 +62,7 @@ jobs:
     name: Validate legal operation registers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Validate legal register files
         run: bash scripts/check_legal_registers.sh
@@ -71,7 +71,7 @@ jobs:
     name: Lint workflows (actionlint + shellcheck)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install dependencies (jq, shellcheck)
         run: |
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Validate pinned Flutter version source-of-truth
         run: bash scripts/validate-flutter-toolchain-pinning.sh
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Validate staging/prod alert recipients
         run: bash scripts/validate-alert-routing-config.sh
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install ripgrep
         run: sudo apt-get update -qq && sudo apt-get install -y ripgrep
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install ripgrep
         run: sudo apt-get update -qq && sudo apt-get install -y ripgrep
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Validate extension bundle version
         run: |
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:
@@ -323,7 +323,7 @@ jobs:
       run:
         working-directory: apps/control-panel
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:
@@ -348,7 +348,7 @@ jobs:
       run:
         working-directory: apps/marketing-site
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:
@@ -384,7 +384,7 @@ jobs:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Run gitleaks
@@ -394,7 +394,7 @@ jobs:
     name: GitHub-to-Azure disconnection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Test disconnection scanner
         run: node --test scripts/tests/github-azure-disconnection.test.mjs
       - name: Reject executable Azure paths
@@ -404,7 +404,7 @@ jobs:
     name: Dependency audit (high/critical)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
@@ -422,7 +422,7 @@ jobs:
     name: Validate MVP TLS pinning guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Reject strict pinning without validated pins
         run: bash scripts/validate-mvp-tls-pinning.sh
@@ -432,7 +432,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -517,7 +517,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [flutter_tests, secret-scan]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
         with:
           flutter-version-file: .fvmrc
@@ -553,7 +553,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-java@v5
         with:
@@ -631,7 +631,7 @@ jobs:
     runs-on: macos-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: subosito/flutter-action@v2
         with:
@@ -687,7 +687,7 @@ jobs:
       run:
         working-directory: functions
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install jq for guards
         run: |
@@ -831,7 +831,7 @@ jobs:
     name: Azure Retirement Hardening Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Run Azure retirement validation
         run: bash scripts/validate-azure-retirement.sh
@@ -845,7 +845,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Dependency Review (block high/critical CVEs)
         uses: actions/dependency-review-action@v5
@@ -860,7 +860,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [workflow_lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check DSR required keys match deploy workflow
         run: bash scripts/check-dsr-runbook-consistency.sh

--- a/.github/workflows/cloudflare-domain-audit.yml
+++ b/.github/workflows/cloudflare-domain-audit.yml
@@ -30,7 +30,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Require the audit token
         shell: bash

--- a/.github/workflows/deploy-alpha-web.yml
+++ b/.github/workflows/deploy-alpha-web.yml
@@ -49,7 +49,7 @@ jobs:
     environment: ${{ inputs.target_environment }}
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 1

--- a/.github/workflows/deploy-marketing-preview.yml
+++ b/.github/workflows/deploy-marketing-preview.yml
@@ -30,7 +30,7 @@ jobs:
       PAGES_PROJECT: lythaus-marketing
       PAGES_BRANCH: ${{ inputs.deployment_class == 'production' && 'main' || 'codex/lythaus-domain-migration' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_sha }}
           fetch-depth: 0

--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       API_BASE_URL: ${{ vars.MVP_PUBLIC_API_BASE_URL }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -44,7 +44,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -65,7 +65,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -107,7 +107,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -145,7 +145,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Setup Node.js
       uses: actions/setup-node@v5

--- a/.github/workflows/launch-readiness-gate.yml
+++ b/.github/workflows/launch-readiness-gate.yml
@@ -11,7 +11,7 @@ jobs:
     name: Validate launch blocker evidence
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Validate observability alert routing config
         run: bash scripts/validate-alert-routing-config.sh

--- a/.github/workflows/mobile-release-build.yml
+++ b/.github/workflows/mobile-release-build.yml
@@ -15,7 +15,7 @@ jobs:
       KEYSTORE_PATH: android/app/upload-keystore.jks
       KEY_PROPERTIES_PATH: android/key.properties
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
         with:
           flutter-version-file: .fvmrc

--- a/.github/workflows/mobile-security-check.yml
+++ b/.github/workflows/mobile-security-check.yml
@@ -16,7 +16,7 @@ jobs:
     name: Validate mobile security contracts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check for SPKI pin placeholders
         shell: bash

--- a/.github/workflows/mvp-preview-validate.yml
+++ b/.github/workflows/mvp-preview-validate.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Run validation against explicit preview
         env:
           DOMAIN: ${{ inputs.domain }}

--- a/.github/workflows/native-migrations-validation.yml
+++ b/.github/workflows/native-migrations-validation.yml
@@ -33,7 +33,7 @@ jobs:
   migration-baseline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/native-planetscale-ci.yml
+++ b/.github/workflows/native-planetscale-ci.yml
@@ -30,7 +30,7 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/native-secret-scan.yml
+++ b/.github/workflows/native-secret-scan.yml
@@ -13,7 +13,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/native-workers-deploy.yml
+++ b/.github/workflows/native-workers-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     environment: production
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/native-workers-validation.yml
+++ b/.github/workflows/native-workers-validation.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref || github.ref }}
       - uses: actions/setup-node@v5

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -11,6 +11,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Validate SQL files exist
         run: test -f database/migrate_to_target_schema.sql

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Test protected-resource plan guard
         working-directory: .


### PR DESCRIPTION
Replaces closed PR #435 from current main.

Updates only the 24 retained workflows that currently use actions/checkout@v4 or @v5 to actions/checkout@v7. No removed Azure-era workflow is reintroduced.

Validation and approval are intentionally left for a separate review.