### PR TITLE
fix(ci): baseline design system gate on manual runs

### DIFF
--- a/scripts/design_system_gate.sh
+++ b/scripts/design_system_gate.sh
@@ -30,17 +30,24 @@ search() {
 resolve_target_files() {
   local base="${DESIGN_SYSTEM_GATE_BASE:-}"
 
+  # workflow_dispatch has no github.event.before. Use the checked-out
+  # commit's parent so manual main runs enforce only newly introduced
+  # production Dart violations, just like push runs.
+  if [ -z "$base" ] && [ -n "${GITHUB_SHA:-}" ]; then
+    base="$(git rev-parse "${GITHUB_SHA}^" 2>/dev/null || true)"
+  fi
+
   if [ -n "$base" ] && git cat-file -e "${base}^{commit}" 2>/dev/null; then
     mapfile -t target_files < <(
       git diff --name-only --diff-filter=ACMR "$base"...HEAD -- 'lib/**/*.dart' \
-        | awk '!/^lib\/(design_system|generated)\//'
+        | awk '!/^lib\\/(design_system|generated)\\//'
     )
     return
   fi
 
   mapfile -t target_files < <(
     git ls-files 'lib/**/*.dart' \
-      | awk '!/^lib\/(design_system|generated)\//'
+      | awk '!/^lib\\/(design_system|generated)\\//'
   )
 }
 


### PR DESCRIPTION
## What changed

Use the checked-out commit parent as the design-system gate baseline when CI runs through `workflow_dispatch` and `DESIGN_SYSTEM_GATE_BASE` is empty.

## Why

The manual main CI run scanned the entire historical Flutter tree and failed on pre-existing `TextStyle(...)` usages. Push and pull-request runs already use an incremental baseline. This keeps manual runs consistent without weakening detection of new production Dart violations.

## Scope

- Changes only `scripts/design_system_gate.sh`.
- No provider, secret, deployment, or Azure-resource changes.
- Based directly on current `main` at `a2fd3bcb85f6988d57c2f000276142e42bfcd4f8`.

Actions validation should confirm the manual CI gate and downstream deployment path.