### PR TITLE
ci: align post-deploy gates with native Cloudflare runtime

### DIFF
--- a/.github/workflows/cache-check.yml
+++ b/.github/workflows/cache-check.yml
@@ -26,12 +26,6 @@ on:
       staging_domain:
         description: 'Optional edge host override for manual runs'
         required: false
-  workflow_run:
-    workflows:
-      - "native-workers-deploy"
-    types: [completed]
-    branches: [main]
-
 env:
   DEFAULT_EDGE_DOMAIN: api.lythaus.co
   TEST_ENDPOINT: '/api/feed/discover'
@@ -67,7 +61,7 @@ jobs:
           NODE_ENV: test
 
   live-cache-validation:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     name: Validate Edge Cache Behavior
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -75,10 +69,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-
-      - name: Wait for deployment to settle
-        if: ${{ github.event_name == 'workflow_run' }}
-        run: sleep 30
 
       - name: Resolve validation domain
         env:

--- a/.github/workflows/canary-k6.yml
+++ b/.github/workflows/canary-k6.yml
@@ -8,13 +8,13 @@ on:
     branches: [main]
 
 env:
-  K6_BASE_URL: ${{ vars.MVP_PUBLIC_API_BASE_URL }}
+  K6_BASE_URL: ${{ vars.PUBLIC_API_BASE_URL }}
   K6_SMOKE_TOKEN: ${{ secrets.K6_SMOKE_TOKEN }} # set in repo Secrets
   ALLOW_SHARED_MVP_LOAD_TESTS: ${{ vars.ALLOW_SHARED_MVP_LOAD_TESTS }}
 
 jobs:
   canary-k6:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && vars.ALLOW_SHARED_MVP_LOAD_TESTS == 'true' }}
     name: Run k6 canary tests
     runs-on: ubuntu-latest
     steps:
@@ -101,13 +101,14 @@ jobs:
             </details>
 
   canary-k6-chaos:
-    if: ${{ vars.ALLOW_SHARED_MVP_CHAOS_TESTS == 'true' }}
+    if: ${{ vars.ALLOW_SHARED_MVP_LOAD_TESTS == 'true' && vars.ALLOW_SHARED_MVP_CHAOS_TESTS == 'true' }}
     needs: [canary-k6]
     name: Run k6 chaos scenarios
     runs-on: ubuntu-latest
     env:
       CHAOS_ENABLED: "true"
-      K6_BASE_URL: ${{ vars.MVP_PUBLIC_API_BASE_URL }}
+      ALLOW_SHARED_MVP_LOAD_TESTS: ${{ vars.ALLOW_SHARED_MVP_LOAD_TESTS }}
+      K6_BASE_URL: ${{ vars.PUBLIC_API_BASE_URL }}
       K6_SMOKE_TOKEN: ${{ secrets.K6_SMOKE_TOKEN }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     env:
-      API_BASE_URL: ${{ vars.MVP_PUBLIC_API_BASE_URL }}
+      API_BASE_URL: ${{ vars.PUBLIC_API_BASE_URL }}
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Why

The first native redeploy succeeded, but three post-deploy workflows were not aligned with the retained runtime:

- Public gateway E2E used the retired preview Worker variable instead of the canonical production API variable.
- Shared k6 load tests failed when their explicit opt-in was absent.
- The legacy edge-cache validator ran automatically after native Worker deploys and expected `CF-Cache-Status` headers from the retired gateway path.

## Change

- Use `vars.PUBLIC_API_BASE_URL` for E2E and k6 connectivity.
- Run shared k6 jobs only when `ALLOW_SHARED_MVP_LOAD_TESTS=true`; chaos also requires its own opt-in.
- Keep legacy edge-cache validation manual/path-triggered instead of running after native Worker deployment.

## Scope

Workflow-only changes. No Worker code, secrets, provider resources, migrations, or Azure changes.