### PR TITLE
Redesign the Lythaus marketing homepage

### DIFF
--- a/apps/marketing-site/public/brand/lythaus-mark.svg
+++ b/apps/marketing-site/public/brand/lythaus-mark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-labelledby="title">
+  <title id="title">Lythaus</title>
+  <g fill="none" stroke="#fff" stroke-width="76" stroke-linecap="square" stroke-linejoin="round">
+    <circle cx="512" cy="512" r="452" />
+    <path d="M246 206v470c0 35 18 53 53 53h304" />
+    <path d="M382 273v383" />
+    <path d="M382 486h350" />
+    <path d="M732 329v491" />
+  </g>
+</svg>

--- a/apps/marketing-site/src/layouts/BaseLayout.astro
+++ b/apps/marketing-site/src/layouts/BaseLayout.astro
@@ -1,7 +1,7 @@
 ---
 const {
   title = 'Lythaus',
-  description = 'Invite-only beta for human-first publishing.',
+  description = 'A calm, human-first publishing network.',
   canonicalPath = '',
 } = Astro.props;
 const pageTitle = title ? `${title} | Lythaus` : 'Lythaus';
@@ -15,17 +15,16 @@ import '../styles/global.css';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <meta name="theme-color" content="#090a0b" />
     <title>{pageTitle}</title>
     <link rel="canonical" href={canonicalUrl} />
 
-    <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:site_name" content="Lythaus" />
 
-    <!-- Twitter Card -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content={pageTitle} />
     <meta name="twitter:description" content={description} />
@@ -33,36 +32,39 @@ import '../styles/global.css';
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fraunces:wght@400;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Manrope:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
   </head>
   <body>
-    <div class="orb orb--one" aria-hidden="true"></div>
-    <div class="orb orb--two" aria-hidden="true"></div>
     <header class="site-header">
-      <a class="logo" href="/">Lythaus</a>
-      <nav class="site-nav">
+      <a class="brand" href="/" aria-label="Lythaus home">
+        <img src="/brand/lythaus-mark.svg" alt="" width="34" height="34" />
+        <span>Lythaus</span>
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
         <a href="/features">Features</a>
         <a href="/about">About</a>
         <a href="/pricing">Pricing</a>
-        <a href="/#waitlist">Waitlist</a>
-        <a href="/terms">Terms</a>
-        <a href="/privacy">Privacy</a>
       </nav>
+      <a class="header-cta" href="/#waitlist">Request invite</a>
     </header>
+
     <main class="page">
       <slot />
     </main>
+
     <footer class="site-footer">
+      <a class="brand footer-brand" href="/" aria-label="Lythaus home">
+        <img src="/brand/lythaus-mark.svg" alt="" width="28" height="28" />
+        <span>Lythaus</span>
+      </a>
+      <p>A calmer place for human ideas.</p>
       <div class="footer-links">
         <a href="/terms">Terms</a>
         <a href="/privacy">Privacy</a>
         <a href="/invite">Redeem invite</a>
       </div>
-      <p class="footer-note">
-        Lythaus is an invite-only beta focused on authentic human content.
-      </p>
     </footer>
   </body>
 </html>

--- a/apps/marketing-site/src/pages/index.astro
+++ b/apps/marketing-site/src/pages/index.astro
@@ -2,61 +2,84 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout
-  title="Waitlist"
-  description="Join the Lythaus waitlist for the invite-only beta."
+  title="A calmer place to publish"
+  description="Lythaus is a calm, human-first publishing network for thoughtful posts and real conversation. Join the invite-only beta."
 >
-  <section class="hero">
+  <section class="hero" aria-labelledby="hero-title">
     <div class="hero-copy">
-      <span class="pill">Invite-only beta</span>
-      <h1>Human-first publishing with clarity, not chaos.</h1>
-      <p>
-        Lythaus is a calm space for real voices and thoughtful posts. We keep
-        the beta small so every signal matters.
+      <span class="eyebrow"><span class="status-dot"></span>Invite-only beta</span>
+      <h1 id="hero-title">A quieter place for ideas that deserve attention.</h1>
+      <p class="hero-lede">
+        Lythaus is a human-first publishing network built for thoughtful posts,
+        genuine conversation, and less noise.
       </p>
-      <p class="hero-footnote">
-        Invites roll out in small batches. Timing is not guaranteed.
-      </p>
+      <div class="hero-actions">
+        <a class="button primary" href="#waitlist">Request an invite</a>
+        <a class="text-link" href="/about">Why Lythaus <span aria-hidden="true">→</span></a>
+      </div>
+      <p class="hero-note">No engagement tricks. No infinite noise. Just people and their ideas.</p>
     </div>
-    <div class="hero-card" id="waitlist">
-      <h2>Join the waitlist</h2>
-      <p>
-        Leave your email and we will reach out when invites open again.
-      </p>
-      <form class="waitlist-form" data-waitlist>
-        <input type="email" placeholder="you@example.com" required />
-        <button class="button primary" type="submit">Request invite</button>
-        <span class="hero-footnote" data-waitlist-note>
-          We do not promise access timing.
-        </span>
-      </form>
+
+    <div class="hero-visual" aria-hidden="true">
+      <div class="logo-halo"></div>
+      <img src="/brand/lythaus-mark.svg" alt="" width="520" height="520" />
     </div>
   </section>
 
-  <section class="section">
-    <h3>What to expect</h3>
-    <div class="grid">
-      <div class="card">
-        <h4>Invite-only by design</h4>
-        <p>We keep the beta small to protect thoughtful discussion.</p>
-      </div>
-      <div class="card">
-        <h4>Appeals exist for every decision</h4>
-        <p>Community reviewers and moderators handle appeals together.</p>
-      </div>
-      <div class="card">
-        <h4>Calm, consistent moderation</h4>
-        <p>Decisions are transparent and logged for accountability.</p>
-      </div>
+  <section class="principles" aria-labelledby="principles-title">
+    <div class="section-heading">
+      <span class="section-kicker">Built with restraint</span>
+      <h2 id="principles-title">Publishing without the pressure.</h2>
+      <p>Lythaus removes the mechanics that turn expression into performance.</p>
     </div>
+
+    <div class="principle-grid">
+      <article class="principle">
+        <span class="principle-number">01</span>
+        <h3>Human by default</h3>
+        <p>Real voices, clear identity signals, and systems designed to protect authentic participation.</p>
+      </article>
+      <article class="principle">
+        <span class="principle-number">02</span>
+        <h3>Calm discovery</h3>
+        <p>A focused feed that helps good work surface without demanding constant attention.</p>
+      </article>
+      <article class="principle">
+        <span class="principle-number">03</span>
+        <h3>Accountable moderation</h3>
+        <p>Consistent decisions, meaningful appeals, and transparent processes built into the platform.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="waitlist-section" id="waitlist" aria-labelledby="waitlist-title">
+    <div class="waitlist-copy">
+      <span class="section-kicker">Early access</span>
+      <h2 id="waitlist-title">Help shape a more considered social space.</h2>
+      <p>
+        We are inviting small groups so we can listen closely, learn quickly,
+        and build with care.
+      </p>
+    </div>
+
+    <form class="waitlist-form" data-waitlist>
+      <label for="waitlist-email">Email address</label>
+      <div class="input-row">
+        <input id="waitlist-email" name="email" type="email" autocomplete="email" placeholder="you@example.com" required />
+        <button class="button primary" type="submit">Join waitlist</button>
+      </div>
+      <p class="form-note" data-waitlist-note>Invites are sent in small batches. No spam.</p>
+    </form>
   </section>
 
   <script>
     const form = document.querySelector('[data-waitlist]');
     const note = document.querySelector('[data-waitlist-note]');
-    if (form && note) {
+    if (form instanceof HTMLFormElement && note) {
       form.addEventListener('submit', (event) => {
         event.preventDefault();
-        note.textContent = 'Thanks. We will reach out when invites open again.';
+        note.textContent = 'You are on the list. We will be in touch when a place opens.';
+        form.reset();
       });
     }
   </script>

--- a/apps/marketing-site/src/styles/global.css
+++ b/apps/marketing-site/src/styles/global.css
@@ -1,311 +1,224 @@
 :root {
-  color-scheme: light;
-  --paper: #f7f1e8;
-  --ink: #1a1a15;
-  --accent: #f05a41;
-  --accent-dark: #d44731;
-  --forest: #0f3b35;
-  --sun: #f3c26c;
-  --mist: #fffaf2;
-  --line: rgba(26, 26, 21, 0.12);
-  --shadow: 0 24px 60px rgba(15, 16, 12, 0.12);
-  --radius-lg: 22px;
-  --radius-md: 14px;
-  --radius-sm: 10px;
+  color-scheme: dark;
+  --bg: #090a0b;
+  --surface: #111315;
+  --surface-soft: #17191c;
+  --text: #f3f4f1;
+  --muted: #a6aaa5;
+  --quiet: #747975;
+  --line: rgba(255, 255, 255, 0.10);
+  --line-strong: rgba(255, 255, 255, 0.18);
+  --accent: #dfe7dc;
+  --accent-ink: #101310;
+  --max-width: 1200px;
+  --radius: 18px;
 }
 
-* {
-  box-sizing: border-box;
-}
-
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: "Space Grotesk", sans-serif;
-  color: var(--ink);
+  font-family: "DM Sans", sans-serif;
+  color: var(--text);
   background:
-    radial-gradient(circle at 15% 10%, rgba(243, 194, 108, 0.45), transparent 55%),
-    radial-gradient(circle at 85% 15%, rgba(240, 90, 65, 0.2), transparent 55%),
-    radial-gradient(circle at 20% 80%, rgba(15, 59, 53, 0.12), transparent 50%),
-    linear-gradient(180deg, #fef7ee 0%, #f6eee2 45%, #f2eae2 100%);
-  overflow-x: hidden;
+    radial-gradient(circle at 78% 17%, rgba(181, 199, 182, 0.08), transparent 28rem),
+    linear-gradient(180deg, #090a0b 0%, #0b0d0e 100%);
+  -webkit-font-smoothing: antialiased;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+a { color: inherit; text-decoration: none; }
+button, input { font: inherit; }
 
-.orb {
-  position: fixed;
-  border-radius: 50%;
-  filter: blur(0);
-  opacity: 0.7;
-  z-index: 0;
-  pointer-events: none;
-  mix-blend-mode: multiply;
-}
-
-.orb--one {
-  width: 440px;
-  height: 440px;
-  top: -160px;
-  right: -120px;
-  background: radial-gradient(circle, rgba(240, 90, 65, 0.45), rgba(240, 90, 65, 0));
-  animation: float 14s ease-in-out infinite;
-}
-
-.orb--two {
-  width: 520px;
-  height: 520px;
-  bottom: -200px;
-  left: -160px;
-  background: radial-gradient(circle, rgba(15, 59, 53, 0.28), rgba(15, 59, 53, 0));
-  animation: float 18s ease-in-out infinite reverse;
+.site-header,
+.page,
+.site-footer {
+  width: min(calc(100% - 40px), var(--max-width));
+  margin-inline: auto;
 }
 
 .site-header {
-  position: relative;
-  z-index: 1;
-  display: flex;
+  min-height: 88px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
-  padding: 28px clamp(24px, 6vw, 80px) 0;
+  border-bottom: 1px solid var(--line);
 }
 
-.logo {
-  font-family: "Fraunces", serif;
-  font-size: 24px;
-  letter-spacing: 0.5px;
-}
-
-.site-nav {
-  display: flex;
-  gap: 20px;
-  font-size: 14px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-}
-
-.page {
-  position: relative;
-  z-index: 1;
-  padding: 60px clamp(24px, 6vw, 80px) 72px;
-}
-
-.site-footer {
-  position: relative;
-  z-index: 1;
-  border-top: 1px solid var(--line);
-  padding: 32px clamp(24px, 6vw, 80px) 48px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  font-size: 14px;
-}
-
-.footer-links {
-  display: flex;
-  gap: 18px;
-}
-
-.footer-note {
-  margin: 0;
-  color: rgba(26, 26, 21, 0.68);
-}
-
-.pill {
+.brand {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(15, 59, 53, 0.2);
-  background: rgba(255, 255, 255, 0.6);
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
+  gap: 11px;
+  width: fit-content;
+  font-family: "Manrope", sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.03em;
 }
+
+.brand img { display: block; }
+.site-nav { display: flex; gap: 30px; color: var(--muted); font-size: 14px; }
+.site-nav a, .footer-links a, .text-link { transition: color 160ms ease; }
+.site-nav a:hover, .footer-links a:hover, .text-link:hover { color: var(--text); }
+
+.header-cta {
+  justify-self: end;
+  padding: 10px 15px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  font-size: 14px;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+.header-cta:hover { background: var(--surface-soft); border-color: rgba(255,255,255,.3); }
 
 .hero {
+  min-height: 720px;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(28px, 4vw, 56px);
+  grid-template-columns: 1.08fr .92fr;
   align-items: center;
+  gap: clamp(40px, 8vw, 110px);
+  padding: 72px 0 90px;
 }
 
-.hero-copy h1 {
-  font-family: "Fraunces", serif;
-  font-size: clamp(36px, 4vw, 56px);
-  margin: 20px 0 16px;
-  line-height: 1.02;
+.eyebrow, .section-kicker {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .16em;
+  text-transform: uppercase;
 }
+.eyebrow { display: inline-flex; align-items: center; gap: 9px; }
+.status-dot { width: 7px; height: 7px; border-radius: 50%; background: #b8c8b4; box-shadow: 0 0 0 5px rgba(184,200,180,.08); }
 
-.hero-copy p {
-  font-size: 18px;
-  line-height: 1.6;
-  margin: 0 0 20px;
-  color: rgba(26, 26, 21, 0.78);
+h1, h2, h3 { font-family: "Manrope", sans-serif; }
+h1 {
+  max-width: 760px;
+  margin: 24px 0 24px;
+  font-size: clamp(48px, 6.2vw, 84px);
+  line-height: .98;
+  letter-spacing: -.06em;
+  font-weight: 600;
 }
-
-.hero-card {
-  background: var(--mist);
-  border-radius: var(--radius-lg);
-  padding: 28px;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(26, 26, 21, 0.08);
+.hero-lede {
+  max-width: 620px;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(18px, 2vw, 21px);
+  line-height: 1.65;
 }
-
-.hero-card h2 {
-  font-family: "Fraunces", serif;
-  margin: 0 0 12px;
-}
-
-.waitlist-form {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.waitlist-form input {
-  padding: 14px 16px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--line);
-  font-size: 16px;
-  background: #fff;
-}
-
+.hero-actions { display: flex; align-items: center; gap: 24px; margin-top: 36px; }
 .button {
+  min-height: 48px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 12px 18px;
+  padding: 0 20px;
+  border: 0;
   border-radius: 999px;
-  border: none;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
+.button.primary { background: var(--accent); color: var(--accent-ink); }
+.button.primary:hover { background: #f0f4ed; }
+.text-link { color: var(--muted); font-weight: 500; }
+.hero-note { margin: 24px 0 0; color: var(--quiet); font-size: 13px; }
 
-.button.primary {
-  background: var(--forest);
-  color: #fff;
-  box-shadow: 0 12px 28px rgba(15, 59, 53, 0.24);
+.hero-visual { position: relative; display: grid; place-items: center; min-height: 500px; }
+.hero-visual img { position: relative; z-index: 1; width: min(100%, 470px); height: auto; opacity: .94; filter: drop-shadow(0 30px 70px rgba(0,0,0,.45)); }
+.logo-halo { position: absolute; width: 78%; aspect-ratio: 1; border-radius: 50%; background: rgba(199,214,198,.07); filter: blur(55px); }
+
+.principles {
+  border-top: 1px solid var(--line);
+  padding: 108px 0 120px;
 }
-
-.button.secondary {
-  background: transparent;
-  border: 1px solid var(--line);
-  color: var(--ink);
-}
-
-.button:active {
-  transform: translateY(1px);
-}
-
-.hero-footnote {
-  font-size: 13px;
-  color: rgba(26, 26, 21, 0.62);
-}
-
-.section {
-  margin-top: 64px;
-}
-
-.section h3 {
-  font-family: "Fraunces", serif;
-  font-size: 28px;
-  margin-bottom: 16px;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 20px;
-}
-
-.card {
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(26, 26, 21, 0.1);
-  border-radius: var(--radius-md);
-  padding: 20px;
-  box-shadow: 0 16px 32px rgba(15, 16, 12, 0.08);
-}
-
-.card h4 {
-  margin: 0 0 10px;
-  font-size: 18px;
-}
-
-.card p {
+.section-heading { display: grid; grid-template-columns: .7fr 1.2fr .9fr; gap: 44px; align-items: start; }
+.section-heading h2, .waitlist-copy h2 {
   margin: 0;
-  color: rgba(26, 26, 21, 0.72);
+  font-size: clamp(34px, 4vw, 54px);
+  line-height: 1.08;
+  letter-spacing: -.045em;
+  font-weight: 600;
 }
+.section-heading p, .waitlist-copy p { margin: 4px 0 0; color: var(--muted); line-height: 1.7; }
+.principle-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; margin-top: 78px; background: var(--line); border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+.principle { min-height: 270px; padding: 30px; background: var(--surface); }
+.principle-number { color: var(--quiet); font-size: 12px; letter-spacing: .12em; }
+.principle h3 { margin: 70px 0 14px; font-size: 22px; letter-spacing: -.025em; }
+.principle p { margin: 0; color: var(--muted); line-height: 1.65; }
 
-.invite-panel {
-  max-width: 720px;
-  margin: 0 auto;
+.waitlist-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(50px, 10vw, 140px);
+  align-items: center;
+  margin-bottom: 110px;
+  padding: clamp(34px, 6vw, 72px);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: linear-gradient(135deg, #141719, #101213);
 }
-
-.status-panel {
-  background: rgba(255, 255, 255, 0.82);
-  border-radius: var(--radius-lg);
-  border: 1px solid rgba(26, 26, 21, 0.08);
-  padding: 28px;
-  box-shadow: var(--shadow);
+.waitlist-copy .section-kicker { display: block; margin-bottom: 20px; }
+.waitlist-copy p { max-width: 500px; margin-top: 22px; }
+.waitlist-form { display: grid; gap: 12px; }
+.waitlist-form label { font-size: 13px; color: var(--muted); }
+.input-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; }
+.waitlist-form input {
+  width: 100%;
+  min-width: 0;
+  height: 50px;
+  padding: 0 16px;
+  color: var(--text);
+  background: #0d0f10;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  outline: none;
 }
+.waitlist-form input:focus { border-color: rgba(223,231,220,.7); box-shadow: 0 0 0 3px rgba(223,231,220,.08); }
+.form-note { margin: 0 0 0 4px; color: var(--quiet); font-size: 12px; }
 
-.status-panel h1 {
-  font-family: "Fraunces", serif;
-  margin: 12px 0;
-}
-
-.status-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 18px;
-}
-
-.status-meta {
+.site-footer {
+  min-height: 130px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 24px;
+  border-top: 1px solid var(--line);
+  color: var(--quiet);
   font-size: 13px;
-  color: rgba(26, 26, 21, 0.6);
+}
+.footer-brand { color: var(--text); }
+.site-footer p { margin: 0; }
+.footer-links { justify-self: end; display: flex; gap: 22px; }
+
+@media (max-width: 900px) {
+  .site-header { grid-template-columns: 1fr auto; }
+  .site-nav { display: none; }
+  .hero { grid-template-columns: 1fr; min-height: auto; padding-top: 90px; }
+  .hero-visual { min-height: 370px; }
+  .hero-visual img { width: min(78vw, 390px); }
+  .section-heading { grid-template-columns: 1fr; gap: 20px; }
+  .principle-grid { grid-template-columns: 1fr; }
+  .principle { min-height: 220px; }
+  .principle h3 { margin-top: 48px; }
+  .waitlist-section { grid-template-columns: 1fr; }
+  .site-footer { grid-template-columns: 1fr; padding: 30px 0; }
+  .footer-links { justify-self: start; }
 }
 
-.legal {
-  max-width: 780px;
+@media (max-width: 560px) {
+  .site-header, .page, .site-footer { width: min(calc(100% - 28px), var(--max-width)); }
+  .site-header { min-height: 72px; }
+  .header-cta { padding: 8px 12px; font-size: 13px; }
+  h1 { font-size: clamp(42px, 13vw, 62px); }
+  .hero { padding: 64px 0 72px; gap: 28px; }
+  .hero-actions { align-items: flex-start; flex-direction: column; gap: 18px; }
+  .hero-visual { min-height: 300px; }
+  .principles { padding: 82px 0; }
+  .principle-grid { margin-top: 50px; }
+  .waitlist-section { padding: 28px 20px; margin-bottom: 72px; }
+  .input-row { grid-template-columns: 1fr; }
 }
 
-.legal h1 {
-  font-family: "Fraunces", serif;
-}
-
-.legal p {
-  line-height: 1.7;
-  color: rgba(26, 26, 21, 0.8);
-}
-
-@media (max-width: 960px) {
-  .hero {
-    grid-template-columns: 1fr;
-  }
-
-  .grid {
-    grid-template-columns: 1fr;
-  }
-
-  .site-nav {
-    display: none;
-  }
-}
-
-@keyframes float {
-  0%,
-  100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(18px);
-  }
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  * { transition: none !important; }
 }


### PR DESCRIPTION
## Summary
- redesigns the Lythaus homepage around a dark, charcoal visual system
- simplifies navigation and reduces decorative noise
- introduces a restrained hero, product principles, and focused waitlist section
- adds a white transparent Lythaus logo asset for dark surfaces
- improves responsive behaviour and reduced-motion support

## Design direction
- near-black and charcoal surfaces
- soft off-white text with muted secondary tones
- minimal borders, restrained depth, no card clutter
- clear hierarchy and concise calls to action

## Notes
The waitlist interaction remains client-side only, matching the existing implementation.