### PR TITLE
Update Lythaus repository identity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,54 +1,36 @@
-# Copilot Instructions
+# Copilot instructions
 
-## Branding (IMPORTANT)
-- **User-facing product name = Lythaus** (UI labels, store listings, marketing copy, emails).
-- **Internal/infra name = Asora** (repo, Azure resources, Terraform, package IDs).
-- When generating code, use "Lythaus" for UI strings and user-visible text.
-- Do **not** rename Azure resources (`asora-*`), package identifiers (`com.asora.app`), or internal imports without explicit instruction.
-- Full branding guide: `docs/branding/lythaus-transition.md`
+## Product and runtime
 
-## Native runtime (authoritative)
+- Product and internal name: Lythaus.
+- Do not introduce the retired product name in active code, paths, identifiers, packages, infrastructure, documentation, or metadata.
+- Azure was fully deleted on 6 August 2026. Do not add Azure dependencies, deployment paths, credentials, or fallbacks.
+- Cloudflare Workers under `apps/lythaus-*` are the only backend services.
+- PlanetScale PostgreSQL `lythaus/lythaus-core` is canonical and is accessed through Hyperdrive.
+- Email and guest access are the only initial authentication flows.
+- Hive, Google sign-in, Apple sign-in, World ID, Entra, B2C, and generic OAuth provider selection are prohibited.
+- Authenticity logic belongs in provider-neutral Lythaus-owned code under `packages/authenticity/`.
 
-- Start with `docs/architecture/lythaus-domain-architecture.md` and `docs/adr/ADR-007-cloudflare-planetscale-runtime.md` for the current runtime and cutover gates.
-- Native services are Cloudflare Workers under `apps/lythaus-*`; PlanetScale Postgres `main` is accessed only through Hyperdrive.
-- The structural database probe, authenticated acceptance, budget hard-stop, and sanitized evidence gates are mandatory before authenticated launch.
-- `lib/`, `functions/`, Cosmos, and Azure deployment workflows are historical Alpha material unless a task explicitly targets them.
+## Development
 
-## Historical architecture details
-- Start with `docs/ADR_001_TLDR.md` for the product vision, target KPIs, and how the Flutter front end aligns with Azure Functions + Cosmos.
-- The repo is split: Flutter app in `lib/` (Riverpod-based clean architecture) and Node.js 22 Azure Functions in `functions/` (TypeScript → CJS build output under `dist/`).
+- Follow `AGENTS.md` and the current architecture in `docs/architecture/lythaus-domain-architecture.md`.
+- Flutter features live under `lib/features/<feature>` with domain, application, and presentation layers.
+- Shared Worker code belongs under `packages/`; do not import from deleted or compatibility workspaces.
+- Use Cloudflare bindings for platform services and Hyperdrive for PostgreSQL.
+- Use application-generated UUIDv7 values stored in native PostgreSQL `uuid` columns.
+- Never hard-code secrets or place secret values in source, examples, evidence, logs, or generated artifacts.
 
-## Historical architecture hot points
-- **Flutter**: Features live under `lib/features/<feature>` with `domain/`, `application/`, `presentation/` layers. Navigation is gated by `lib/features/auth/presentation/auth_gate.dart`. Critical security/privacy flows sit in `lib/p1_modules/` and must keep ≥80 % coverage (enforced via `check_p1_coverage.sh`).
-- **Azure Functions (Flex Consumption)**: Source in `functions/src/`, compiled via `npm run build` to `dist/`. Entrypoint wiring is handled by `functions/index.js` (generated during deploy). Shared helpers (auth, Cosmos, validation) live under `functions/shared/`.
-- **Data**: Cosmos DB connection string is injected at deploy time (see workflow env `COSMOS_CONNECTION_STRING`). Redis is accessed via services in `lib/services/cache/`.
-- **Moderation pipeline**: Hive AI (primary) then Azure Content Safety fallback; workflows and components live under `lib/features/moderation/` with a demo screen at `lib/screens/moderation_demo_page.dart`.
+## Validation
 
-## Build, test, and debug
-- **Flutter**: `flutter test --coverage` (then `bash check_p1_coverage.sh`). Use `lib/debug_sql.dart` for SQL visualization when debugging feeds.
-- **Functions**: From `functions/`, run `npm ci && npm run build` to produce `dist/`, `npm test` for Jest, `npm start` for the local runtime (7072). Avoid ESM—`package.json` is locked to CommonJS.
-- **CI helpers**: `quick-check.sh` executes format + targeted tests; `quick_coverage_demo.sh` is a minimal coverage smoke.
+```powershell
+npm ci --ignore-scripts
+npm run typecheck:native
+npm run test:native-architecture
+npm run validate:native-workers
+npm run validate:planetscale-migrations
+flutter pub get
+flutter analyze
+flutter test
+```
 
-## Historical Azure deployment workflow essentials
-- `.github/workflows/deploy-asora-function-dev.yml` builds from `functions/`, uploads to blob storage, and deploys to Flex Consumption via ARM `/publish` API (no Kudu). Uses storage-based deployment with OIDC authentication. The PATCH step merges `functionAppConfig` to preserve `deployment.storage` and other critical fields. Flex apps must **not** set `FUNCTIONS_WORKER_RUNTIME`, `WEBSITE_RUN_FROM_PACKAGE`, or Kudu-related settings; runtime is configured via ARM PATCH (`node@22`, `instanceMemoryMB: 2048`).
-- Scripts like `.github/scripts/normalize_flex.sh` and `fix-flex-settings.sh` exist to clean legacy settings—rely on ARM patches rather than app-setting writes.
-- PR validations: `canary.yml` handles prerelease tagging, `e2e-integration.yml` fetches admin keys post-deploy and runs smoke requests.
-
-## Patterns worth copying
-- Services expose typed methods via providers in `lib/services/service_providers.dart`; prefer composing new features by wiring providers instead of manual singletons.
-- API clients live under `lib/core/network/` using Dio with pinned certs—extend `dio_client.dart` for new HTTP stacks.
-- For Functions, each endpoint is structured as `<feature>/<trigger>.function.ts` exporting a handler registered in `functions/src/index.ts`. New endpoints should follow existing logging/error handling helpers in `functions/shared/logger.ts` and `functions/shared/errors.ts`.
-
-## Useful references
-- `docs/architecture/lythaus-domain-architecture.md` - authoritative native runtime and acceptance gates.
-- `docs/runbooks/adr-003-authenticated-acceptance.md` - authenticated launch suite and sanitized evidence requirements.
-- `docs/runbooks/cloudflared-tunnel-credential-rotation.md` - rotated tunnel credential and local service handoff.
-- `infrastructure/cloudflare/native-hyperdrive-production.json` - explicit production binding and `main` proof contract.
-- `functions/jest.config.ts` – Jest + ts-jest setup mirroring the build pipeline.
-- `docs/FEED_IMPLEMENTATION.md` – Explains feed ranking, Redis usage, and moderation hooks.
-- `AZURE_FUNCTIONS_V4_PITFALLS.md` – Historical pitfalls; skim to avoid reverting to forbidden settings.
-- `scripts/diagnostics-v4.sh` – One-stop commands for tailing logs, querying runtime config, and checking admin host health.
-
-## Tooling tips
-- If a terminal command returns no output via the automation tools, fall back to `run_in_terminal` followed by `get_terminal_output` (or request user pasteback) as noted in `AGENTS.md`.
-- Secrets are managed through Azure Key Vault references; never hard-code secrets in Functions—use the `@Microsoft.KeyVault(...)` pattern visible in existing app settings.
+Historical commits and files under `docs/history/` may retain accurate retired terminology. Do not copy historical implementation guidance into active code.

--- a/docs/product/reputation-rewards-public-feed-spec-v1.md
+++ b/docs/product/reputation-rewards-public-feed-spec-v1.md
@@ -4,8 +4,8 @@
 
 **Status:** Product/architecture specification — draft approved for implementation planning
 **Date:** 26 May 2026
-**Product:** Lythaus, formerly Asora
-**Repository:** AsoraKK/Asora
+**Product:** Lythaus
+**Repository:** AsoraKK/Lythaus
 **Owner:** Product / Platform
 **Related areas:** reputation, rewards, moderation, AI transparency, public feed ranking, subscriptions, Editorial, user profile transparency
 

--- a/docs/runbooks/launch-readiness.md
+++ b/docs/runbooks/launch-readiness.md
@@ -21,13 +21,13 @@ Each item is tagged:
 
 | Workflow | Badge |
 |---|---|
-| CI | `![CI](https://github.com/AsoraKK/Asora/actions/workflows/ci.yml/badge.svg?branch=main)` |
-| Flutter CI | `![Flutter CI](https://github.com/AsoraKK/Asora/actions/workflows/flutter-ci.yml/badge.svg?branch=main)` |
-| OpenAPI | `![OpenAPI](https://github.com/AsoraKK/Asora/actions/workflows/openapi.yml/badge.svg?branch=main)` |
-| Mobile Release | `![Mobile Release](https://github.com/AsoraKK/Asora/actions/workflows/mobile-release-build.yml/badge.svg?branch=main)` |
-| Launch Readiness Gate | `![Launch Gate](https://github.com/AsoraKK/Asora/actions/workflows/launch-readiness-gate.yml/badge.svg)` |
-| Canary SLO | `![Canary SLO](https://github.com/AsoraKK/Asora/actions/workflows/canary-k6.yml/badge.svg)` |
-| Infra | `![Infra](https://github.com/AsoraKK/Asora/actions/workflows/infra.yml/badge.svg?branch=main)` |
+| CI | `![CI](https://github.com/AsoraKK/Lythaus/actions/workflows/ci.yml/badge.svg?branch=main)` |
+| Flutter CI | `![Flutter CI](https://github.com/AsoraKK/Lythaus/actions/workflows/flutter-ci.yml/badge.svg?branch=main)` |
+| OpenAPI | `![OpenAPI](https://github.com/AsoraKK/Lythaus/actions/workflows/openapi.yml/badge.svg?branch=main)` |
+| Mobile Release | `![Mobile Release](https://github.com/AsoraKK/Lythaus/actions/workflows/mobile-release-build.yml/badge.svg?branch=main)` |
+| Launch Readiness Gate | `![Launch Gate](https://github.com/AsoraKK/Lythaus/actions/workflows/launch-readiness-gate.yml/badge.svg)` |
+| Canary SLO | `![Canary SLO](https://github.com/AsoraKK/Lythaus/actions/workflows/canary-k6.yml/badge.svg)` |
+| Native Workers | `![Native Workers](https://github.com/AsoraKK/Lythaus/actions/workflows/native-workers-validation.yml/badge.svg?branch=main)` |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "openapi:bundle": "redocly bundle api/openapi/openapi.yaml -o api/openapi/dist/openapi.json --config=api/openapi/redocly.yaml",
     "openapi:validate:examples": "ts-node tools/openapi/validate-examples.ts",
     "openapi:check:bundle": "node scripts/check-git-diff-clean.js api/openapi/dist/openapi.json",
-    "openapi:gen:dart": "node scripts/clean-openapi-dart-generated.mjs && openapi-generator-cli generate -g dart-dio -i api/openapi/dist/openapi.json -o lib/generated/api_client --additional-properties=pubName=asora_api_client,nullableFields=true,repositoryUrl=https://github.com/AsoraKK/Asora,hideGenerationTimestamp=true && node scripts/trim-trailing-whitespace.js lib/generated/api_client",
+    "openapi:gen:dart": "node scripts/clean-openapi-dart-generated.mjs && openapi-generator-cli generate -g dart-dio -i api/openapi/dist/openapi.json -o lib/generated/api_client --additional-properties=pubName=asora_api_client,nullableFields=true,repositoryUrl=https://github.com/AsoraKK/Lythaus,hideGenerationTimestamp=true && node scripts/trim-trailing-whitespace.js lib/generated/api_client",
     "openapi:test:dart": "node scripts/validate-openapi-dart-client.mjs",
     "openapi:check:dart": "node scripts/check-git-diff-clean.js lib/generated/api_client --ignore lib/generated/api_client/.openapi-generator/FILES",
     "openapi:test:contract": "jest -c jest.contract.config.cjs --runInBand",

--- a/scripts/validate-signing-material.sh
+++ b/scripts/validate-signing-material.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-SECRETS_URL="https://github.com/AsoraKK/Asora/settings/secrets/actions"
+SECRETS_URL="https://github.com/AsoraKK/Lythaus/settings/secrets/actions"
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/scripts/validate-store-submission-evidence.sh
+++ b/scripts/validate-store-submission-evidence.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 EVIDENCE_FILE="docs/runbooks/store-submission-evidence.md"
 CONSOLE_URL="https://play.google.com/console"
 ASC_URL="https://appstoreconnect.apple.com"
-SECRETS_URL="https://github.com/AsoraKK/Asora/settings/secrets/actions"
+SECRETS_URL="https://github.com/AsoraKK/Lythaus/settings/secrets/actions"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
﻿## What changed

- updates active repository URLs to `AsoraKK/Lythaus`
- replaces Copilot guidance that preserved retired branding and Azure architecture
- refreshes launch badges and product metadata
- updates live GitHub label descriptions for Authenticity AI and Cloudflare/PlanetScale

## GitHub administration

- repository renamed in place from `AsoraKK/Asora` to `AsoraKK/Lythaus`
- local `origin` updated to the canonical URL
- description, homepage, and topics updated
- owner namespace intentionally remains `AsoraKK`

## Validation

- active URL scan passed for the changed files
- package metadata assertion passed
- live label descriptions verified

## Stack

Base: #524
