### PR TITLE
feat: port backend capabilities to native Workers

### DIFF
--- a/apps/lythaus-admin-api/src/index.ts
+++ b/apps/lythaus-admin-api/src/index.ts
@@ -48,6 +48,121 @@ async function readJson<T>(request: Request): Promise<T> {
   return JSON.parse(new TextDecoder().decode(await request.arrayBuffer())) as T;
 }
 
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function enforceAdminRateLimit(request: Request, env: Env, actorId: string): Promise<void> {
+  const subjectHash = await sha256Hex(`admin:${actorId}`);
+  const windowStartedAt = new Date(Math.floor(Date.now() / 60_000) * 60_000).toISOString();
+  const result = await query(env.DB_ADMIN_FRESH,
+    `INSERT INTO system.rate_limit_windows (scope, subject_hash, window_started_at, request_count, expires_at)
+     VALUES ('admin-api', $1, $2, 1, $2::timestamptz + interval '2 minutes')
+     ON CONFLICT (scope, subject_hash, window_started_at)
+     DO UPDATE SET request_count = system.rate_limit_windows.request_count + 1
+     WHERE system.rate_limit_windows.request_count < 120
+     RETURNING request_count`, [subjectHash, windowStartedAt]);
+  if (result.rowCount !== 1) throw new Error('rate_limit_exceeded');
+}
+
+async function listModerationCases(env: Env): Promise<unknown[]> {
+  const result = await query(env.DB_ADMIN_FRESH,
+    `SELECT c.id, c.content_type, c.content_id, c.state, c.policy_version, c.created_at,
+            count(f.id)::integer AS flag_count
+     FROM moderation.cases c
+     LEFT JOIN moderation.content_flags f ON f.content_type = c.content_type AND f.content_id = c.content_id
+     GROUP BY c.id, c.content_type, c.content_id, c.state, c.policy_version, c.created_at
+     ORDER BY (c.state = 'open') DESC, c.created_at ASC LIMIT 200`);
+  return result.rows;
+}
+
+async function searchUsers(request: Request, env: Env): Promise<Response> {
+  const search = new URL(request.url).searchParams.get('q')?.trim() ?? '';
+  if (search.length < 2 || search.length > 120) throw new Error('invalid_user_search');
+  const result = await query(env.DB_ADMIN_FRESH,
+    `SELECT u.id, u.display_name, u.status, u.created_at, h.handle,
+            COALESCE(e.subscription_tier, 'free') AS subscription_tier
+     FROM identity.users u
+     LEFT JOIN identity.handles h ON h.user_id = u.id
+     LEFT JOIN identity.user_entitlements e ON e.user_id = u.id
+     WHERE u.id::text = $1 OR u.display_name ILIKE $2 OR h.handle_normalized ILIKE $2
+     ORDER BY u.created_at DESC LIMIT 50`, [search, `%${search.toLowerCase()}%`]);
+  return json({ items: result.rows }, { headers: { 'cache-control': 'private, no-store' } });
+}
+
+async function setUserTier(request: Request, env: Env, actor: { userId: string; role: string }, userId: string, correlation: string): Promise<Response> {
+  if (actor.role !== 'administrator') throw new Error('admin_role_required');
+  const input = await readJson<{ tier?: 'free' | 'premium' | 'black'; reasonCode?: string }>(request);
+  if (!input.tier || !['free', 'premium', 'black'].includes(input.tier)) throw new Error('invalid_subscription_tier');
+  if (!input.reasonCode || !/^[A-Z0-9_.:-]{2,80}$/.test(input.reasonCode)) throw new Error('reason_code_required');
+  await transaction(env.DB_ADMIN_FRESH, async (client) => {
+    await client.query(
+      `INSERT INTO identity.user_entitlements (user_id, subscription_tier, updated_by)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (user_id) DO UPDATE SET subscription_tier = EXCLUDED.subscription_tier,
+         updated_by = EXCLUDED.updated_by, updated_at = now()`, [userId, input.tier, actor.userId]);
+    await client.query(
+      `INSERT INTO system.audit_events (id, actor_id, action, target_type, target_id, reason_code, correlation_id, metadata)
+       VALUES ($1, $2, 'user.tier_changed', 'user', $3, $4, $5, $6::jsonb)`,
+      [uuidv7(), actor.userId, userId, input.reasonCode, correlation, JSON.stringify({ tier: input.tier })]);
+  });
+  return json({ userId, tier: input.tier }, { headers: { 'x-correlation-id': correlation, 'cache-control': 'private, no-store' } });
+}
+
+async function legalHolds(request: Request, env: Env, actor: { userId: string; role: string }, correlation: string): Promise<Response> {
+  if (!['privacy_operator', 'administrator'].includes(actor.role)) throw new Error('admin_role_required');
+  if (request.method === 'GET') {
+    const result = await query(env.DB_PRIVACY_FRESH,
+      `SELECT id, subject_id, reason, active, created_at, released_at
+       FROM privacy.legal_holds ORDER BY created_at DESC LIMIT 200`);
+    return json({ items: result.rows }, { headers: { 'cache-control': 'private, no-store' } });
+  }
+  const input = await readJson<{ subjectId?: string; reason?: string }>(request);
+  const reason = input.reason?.trim() ?? '';
+  if (!input.subjectId || !reason || reason.length > 1000) throw new Error('invalid_legal_hold');
+  const holdId = uuidv7();
+  await transaction(env.DB_PRIVACY_FRESH, async (client) => {
+    await client.query(`INSERT INTO privacy.legal_holds (id, subject_id, reason) VALUES ($1, $2, $3)`, [holdId, input.subjectId, reason]);
+    await client.query(
+      `INSERT INTO system.audit_events (id, actor_id, action, target_type, target_id, reason_code, correlation_id)
+       VALUES ($1, $2, 'privacy.legal_hold_placed', 'legal_hold', $3, 'LEGAL_HOLD', $4)`,
+      [uuidv7(), actor.userId, holdId, correlation]);
+  });
+  return json({ id: holdId, subjectId: input.subjectId, active: true }, { status: 201, headers: { 'x-correlation-id': correlation, 'cache-control': 'private, no-store' } });
+}
+
+async function clearLegalHold(env: Env, actor: { userId: string; role: string }, holdId: string, correlation: string): Promise<Response> {
+  if (!['privacy_operator', 'administrator'].includes(actor.role)) throw new Error('admin_role_required');
+  await transaction(env.DB_PRIVACY_FRESH, async (client) => {
+    const updated = await client.query(`UPDATE privacy.legal_holds SET active = false, released_at = now() WHERE id = $1 AND active = true RETURNING id`, [holdId]);
+    if (updated.rowCount !== 1) throw new Error('legal_hold_not_found');
+    await client.query(
+      `INSERT INTO system.audit_events (id, actor_id, action, target_type, target_id, reason_code, correlation_id)
+       VALUES ($1, $2, 'privacy.legal_hold_cleared', 'legal_hold', $3, 'LEGAL_HOLD_CLEAR', $4)`,
+      [uuidv7(), actor.userId, holdId, correlation]);
+  });
+  return json({ id: holdId, active: false }, { headers: { 'x-correlation-id': correlation, 'cache-control': 'private, no-store' } });
+}
+
+async function publishEditorial(request: Request, env: Env, actor: { userId: string; role: string }, correlation: string): Promise<Response> {
+  if (actor.role !== 'administrator') throw new Error('admin_role_required');
+  const input = await readJson<{ title?: string; postId?: string }>(request);
+  const title = input.title?.trim() ?? '';
+  if (!title || title.length > 240) throw new Error('invalid_editorial_publication');
+  const publicationId = uuidv7();
+  await transaction(env.DB_ADMIN_FRESH, async (client) => {
+    await client.query(
+      `INSERT INTO editorial.publications (id, membership_user_id, title, post_id, published_at)
+       VALUES ($1, $2, $3, $4, now())`, [publicationId, actor.userId, title, input.postId ?? null]);
+    await client.query(
+      `INSERT INTO system.audit_events (id, actor_id, action, target_type, target_id, reason_code, correlation_id)
+       VALUES ($1, $2, 'editorial.publication_created', 'editorial_publication', $3, 'NEWS_BOARD_PUBLISH', $4)`,
+      [uuidv7(), actor.userId, publicationId, correlation]);
+  });
+  return json({ id: publicationId, published: true }, { status: 201, headers: { 'x-correlation-id': correlation, 'cache-control': 'private, no-store' } });
+}
+
 async function decideModeration(request: Request, env: Env, actor: { userId: string; role: string }, caseId: string, correlation: string): Promise<Response> {
   const input = await readJson<{ outcome?: 'allow' | 'block' | 'queue'; reasonCode?: string; publicLabel?: string }>(request);
   if (!input.outcome || !['allow', 'block', 'queue'].includes(input.outcome)) throw new Error('invalid_moderation_outcome');
@@ -136,6 +251,7 @@ export default {
         }, { headers: { 'cache-control': 'private, no-store' } });
       }
       const actor = await requireAdmin(request, env);
+      await enforceAdminRateLimit(request, env, actor.userId);
       if (request.method === 'GET' && url.pathname === '/api/admin/health') {
         const result = await query(env.DB_ADMIN_FRESH, `SELECT current_timestamp AS database_time`);
         return json({ status: 'ok', database: result.rows[0] }, { headers: { 'x-correlation-id': id, 'cache-control': 'private, no-store' } });
@@ -144,10 +260,26 @@ export default {
         const result = await query(env.DB_PRIVACY_FRESH, `SELECT id, subject_id, request_type, state, created_at FROM privacy.requests ORDER BY created_at DESC LIMIT 100`);
         return json({ items: result.rows }, { headers: { 'x-correlation-id': id, 'cache-control': 'private, no-store' } });
       }
+      if (request.method === 'GET' && url.pathname === '/api/admin/moderation/cases') {
+        return json({ items: await listModerationCases(env) }, { headers: { 'x-correlation-id': id, 'cache-control': 'private, no-store' } });
+      }
+      if (request.method === 'GET' && url.pathname === '/api/admin/audit') {
+        const result = await query(env.DB_ADMIN_FRESH,
+          `SELECT id, actor_id, action, target_type, target_id, reason_code, correlation_id, metadata, created_at
+           FROM system.audit_events ORDER BY created_at DESC LIMIT 200`);
+        return json({ items: result.rows }, { headers: { 'x-correlation-id': id, 'cache-control': 'private, no-store' } });
+      }
+      if (request.method === 'GET' && url.pathname === '/api/admin/users/search') return await searchUsers(request, env);
+      if (url.pathname === '/api/admin/privacy/legal-holds' && ['GET', 'POST'].includes(request.method)) return await legalHolds(request, env, actor, id);
+      const legalHoldClear = url.pathname.match(/^\/api\/admin\/privacy\/legal-holds\/([^/]+)\/clear$/);
+      if (request.method === 'POST' && legalHoldClear) return await clearLegalHold(env, actor, legalHoldClear[1], id);
+      if (request.method === 'POST' && url.pathname === '/api/admin/editorial/publications') return await publishEditorial(request, env, actor, id);
       const moderation = url.pathname.match(/^\/api\/admin\/moderation\/cases\/([^/]+)\/decision$/);
       if (request.method === 'POST' && moderation) return await decideModeration(request, env, actor, moderation[1], id);
       const accountStatus = url.pathname.match(/^\/api\/admin\/users\/([^/]+)\/status$/);
       if (request.method === 'POST' && accountStatus) return await updateAccountStatus(request, env, actor, accountStatus[1], id);
+      const accountTier = url.pathname.match(/^\/api\/admin\/users\/([^/]+)\/tier$/);
+      if (request.method === 'POST' && accountTier) return await setUserTier(request, env, actor, accountTier[1], id);
       return json({ error: 'not_found', correlationId: id }, { status: 404 });
     } catch (error) {
       const code = error instanceof Error ? error.message : 'admin_request_failed';

--- a/apps/lythaus-public-api/src/index.ts
+++ b/apps/lythaus-public-api/src/index.ts
@@ -1,6 +1,6 @@
 import { databaseExpectationsFromEnv, databaseReadinessResponse, inspectDatabaseIdentity, transaction, query, type HyperdriveBinding } from '@lythaus/db';
 import type { EnvBindings } from '@lythaus/cloudflare-env';
-import type { CreatePostInput, EmailDeliveryReference, TransactionalEmailProvider } from '@lythaus/contracts';
+import { REWARD_CATALOG, TIER_POLICIES, normalizeUserTier, type CreatePostInput, type EmailDeliveryReference, type TransactionalEmailProvider, type UserTier } from '@lythaus/contracts';
 import { createPresignedPutUrl, ALLOWED_IMAGE_TYPES, MAX_IMAGE_BYTES, type AllowedImageType } from '@lythaus/media';
 import { assertExpectedHostname, correlationId, json, logEvent } from '@lythaus/observability';
 import { constantTimeEqual, decryptField, encryptField, hashPassword, hashResetToken, hmacLookup, needsPasswordRehash, randomToken, signAccessToken, uuidv7, verifyAccessToken, verifyPassword, type PasswordHash, type Principal } from '@lythaus/security';
@@ -40,6 +40,54 @@ function base64Url(bytes: Uint8Array): string {
 
 async function pkceChallenge(verifier: string): Promise<string> {
   return base64Url(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))));
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function enforceRateLimit(request: Request, env: Env, scope: string, limit: number): Promise<void> {
+  const subject = request.headers.get('cf-connecting-ip')
+    ?? request.headers.get('authorization')
+    ?? 'anonymous';
+  const subjectHash = await sha256Hex(`${scope}:${subject}`);
+  const windowStartedAt = new Date(Math.floor(Date.now() / 60_000) * 60_000).toISOString();
+  const result = await query(env.DB_APP_FRESH,
+    `INSERT INTO system.rate_limit_windows (scope, subject_hash, window_started_at, request_count, expires_at)
+     VALUES ($1, $2, $3, 1, $3::timestamptz + interval '2 minutes')
+     ON CONFLICT (scope, subject_hash, window_started_at)
+     DO UPDATE SET request_count = system.rate_limit_windows.request_count + 1
+     WHERE system.rate_limit_windows.request_count < $4
+     RETURNING request_count`,
+    [scope, subjectHash, windowStartedAt, limit]);
+  if (result.rowCount !== 1) throw new Error('rate_limit_exceeded');
+}
+
+async function tierForUser(env: Env, userId: string): Promise<UserTier> {
+  const result = await query<{ subscription_tier: string }>(env.DB_APP_FRESH,
+    `SELECT subscription_tier FROM identity.user_entitlements WHERE user_id = $1`, [userId]);
+  return normalizeUserTier(result.rows[0]?.subscription_tier);
+}
+
+async function enforceDailyAction(
+  env: Env,
+  userId: string,
+  action: 'post' | 'comment' | 'reaction' | 'appeal',
+): Promise<void> {
+  const tier = await tierForUser(env, userId);
+  const policy = TIER_POLICIES[tier];
+  const definitions = {
+    post: { table: 'content.posts', column: 'author_id', limit: policy.dailyPosts },
+    comment: { table: 'content.comments', column: 'author_id', limit: policy.dailyComments },
+    reaction: { table: 'social.reactions', column: 'user_id', limit: policy.dailyReactions },
+    appeal: { table: 'moderation.appeals', column: 'appellant_id', limit: policy.dailyAppeals },
+  } as const;
+  const definition = definitions[action];
+  const result = await query<{ count: string }>(env.DB_APP_FRESH,
+    `SELECT count(*)::text AS count FROM ${definition.table}
+     WHERE ${definition.column} = $1 AND created_at >= date_trunc('day', now())`, [userId]);
+  if (Number(result.rows[0]?.count ?? 0) >= definition.limit) throw new Error(`${action}_daily_limit_reached`);
 }
 
 function requireAuthSecrets(env: Env): { pepper: string; encryptionKey: string; hmacKey: string; privateKey: string; keyId: string } {
@@ -539,6 +587,7 @@ async function idempotentMutation(
 }
 
 async function createPost(request: Request, env: Env, user: Principal): Promise<Response> {
+  await enforceDailyAction(env, user.userId, 'post');
   const input = await readJson<CreatePostInput>(request, 64 * 1024);
   if (!input.body?.trim() || !['human', 'ai_assisted', 'ai_generated'].includes(input.declaredCreationMode)) {
     throw new Error('invalid_post');
@@ -773,6 +822,12 @@ async function updateProfile(request: Request, env: Env, user: Principal): Promi
        ON CONFLICT (user_id) DO UPDATE SET public_visibility = EXCLUDED.public_visibility,
          trust_passport_visibility = EXCLUDED.trust_passport_visibility, updated_at = now()`,
       [user.userId, visibility !== 'private', visibility]);
+    if (displayName !== undefined || bio !== undefined) {
+      await client.query(
+        `INSERT INTO system.outbox_events (id, event_type, aggregate_type, aggregate_id, actor_id, payload)
+         VALUES ($1, 'content.profile.updated', 'profile', $2, $2, $3::jsonb)`,
+        [uuidv7(), user.userId, JSON.stringify({ userId: user.userId, displayName, bio })]);
+    }
   });
   return getUserProfile(request, env, user.userId, true);
 }
@@ -818,6 +873,7 @@ async function setBookmark(request: Request, env: Env, user: Principal, postId: 
 }
 
 async function createComment(request: Request, env: Env, user: Principal, postId: string): Promise<Response> {
+  await enforceDailyAction(env, user.userId, 'comment');
   const input = await readJson<{ body?: string; parentId?: string }>(request, 32 * 1024);
   const body = input.body?.trim();
   if (!body) throw new Error('invalid_comment');
@@ -830,6 +886,7 @@ async function createComment(request: Request, env: Env, user: Principal, postId
 }
 
 async function createReaction(request: Request, env: Env, user: Principal, postId: string): Promise<Response> {
+  await enforceDailyAction(env, user.userId, 'reaction');
   const input = await readJson<{ reactionType?: string }>(request, 8 * 1024);
   if (!input.reactionType || !/^[a-z0-9:_-]{1,32}$/i.test(input.reactionType)) throw new Error('invalid_reaction');
   await query(env.DB_APP_FRESH, `INSERT INTO social.reactions (user_id, post_id, reaction_type) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`, [user.userId, postId, input.reactionType]);
@@ -845,6 +902,7 @@ async function createFlag(request: Request, env: Env, user: Principal): Promise<
 }
 
 async function createAppeal(request: Request, env: Env, user: Principal): Promise<Response> {
+  await enforceDailyAction(env, user.userId, 'appeal');
   const input = await readJson<{ caseId?: string }>(request, 16 * 1024);
   if (!input.caseId) throw new Error('case_id_required');
   const eligible = await query<{ id: string }>(env.DB_APP_FRESH,
@@ -960,6 +1018,245 @@ async function updateRetentionRule(request: Request, env: Env, user: Principal):
   return privateResponse(request, env, { contentType, retentionDays: input.retentionDays });
 }
 
+async function listCustomFeeds(request: Request, env: Env, user: Principal): Promise<Response> {
+  const result = await query(env.DB_APP_FRESH,
+    `SELECT f.id, f.name, f.created_at,
+            COALESCE(jsonb_agg(r.rule ORDER BY r.created_at) FILTER (WHERE r.id IS NOT NULL), '[]'::jsonb) AS rules
+     FROM social.custom_feeds f
+     LEFT JOIN social.custom_feed_rules r ON r.feed_id = f.id
+     WHERE f.user_id = $1
+     GROUP BY f.id, f.name, f.created_at
+     ORDER BY f.created_at DESC`, [user.userId]);
+  return privateResponse(request, env, { items: result.rows });
+}
+
+async function createCustomFeed(request: Request, env: Env, user: Principal): Promise<Response> {
+  const input = await readJson<{ name?: string; rules?: unknown[] }>(request, 32 * 1024);
+  const name = input.name?.trim() ?? '';
+  if (!name || name.length > 120 || !Array.isArray(input.rules)) throw new Error('invalid_custom_feed');
+  const rules = input.rules.slice(0, 20);
+  const tier = await tierForUser(env, user.userId);
+  const existing = await query<{ count: string }>(env.DB_APP_FRESH,
+    `SELECT count(*)::text AS count FROM social.custom_feeds WHERE user_id = $1`, [user.userId]);
+  if (Number(existing.rows[0]?.count ?? 0) >= TIER_POLICIES[tier].maxCustomFeeds) throw new Error('custom_feed_limit_reached');
+  const feedId = uuidv7();
+  await transaction(env.DB_APP_FRESH, async (client) => {
+    await client.query(`INSERT INTO social.custom_feeds (id, user_id, name) VALUES ($1, $2, $3)`, [feedId, user.userId, name]);
+    for (const rule of rules) {
+      await client.query(`INSERT INTO social.custom_feed_rules (id, feed_id, rule) VALUES ($1, $2, $3::jsonb)`, [uuidv7(), feedId, JSON.stringify(rule)]);
+    }
+  });
+  return privateResponse(request, env, { id: feedId, name, rules }, { status: 201 });
+}
+
+async function customFeed(request: Request, env: Env, user: Principal, feedId: string): Promise<Response> {
+  const owned = await query<{ id: string; name: string; rules: unknown[] }>(env.DB_APP_FRESH,
+    `SELECT f.id, f.name,
+            COALESCE(jsonb_agg(r.rule ORDER BY r.created_at) FILTER (WHERE r.id IS NOT NULL), '[]'::jsonb) AS rules
+     FROM social.custom_feeds f
+     LEFT JOIN social.custom_feed_rules r ON r.feed_id = f.id
+     WHERE f.id = $1 AND f.user_id = $2
+     GROUP BY f.id, f.name`, [feedId, user.userId]);
+  if (!owned.rows[0]) throw new Error('custom_feed_not_found');
+  if (request.method === 'GET') return privateResponse(request, env, owned.rows[0]);
+  if (request.method === 'DELETE') {
+    await query(env.DB_APP_FRESH, `DELETE FROM social.custom_feeds WHERE id = $1 AND user_id = $2`, [feedId, user.userId]);
+    return privateResponse(request, env, { id: feedId, deleted: true });
+  }
+  const input = await readJson<{ name?: string; rules?: unknown[] }>(request, 32 * 1024);
+  const name = input.name?.trim() ?? owned.rows[0].name;
+  const rules = Array.isArray(input.rules) ? input.rules.slice(0, 20) : owned.rows[0].rules;
+  if (!name || name.length > 120) throw new Error('invalid_custom_feed');
+  await transaction(env.DB_APP_FRESH, async (client) => {
+    await client.query(`UPDATE social.custom_feeds SET name = $1 WHERE id = $2 AND user_id = $3`, [name, feedId, user.userId]);
+    if (Array.isArray(input.rules)) {
+      await client.query(`DELETE FROM social.custom_feed_rules WHERE feed_id = $1`, [feedId]);
+      for (const rule of rules) {
+        await client.query(`INSERT INTO social.custom_feed_rules (id, feed_id, rule) VALUES ($1, $2, $3::jsonb)`, [uuidv7(), feedId, JSON.stringify(rule)]);
+      }
+    }
+  });
+  return privateResponse(request, env, { id: feedId, name, rules });
+}
+
+async function customFeedItems(request: Request, env: Env, user: Principal, feedId: string): Promise<Response> {
+  const owned = await query<{ rules: unknown[] }>(env.DB_APP_FRESH,
+    `SELECT COALESCE(jsonb_agg(r.rule) FILTER (WHERE r.id IS NOT NULL), '[]'::jsonb) AS rules
+     FROM social.custom_feeds f LEFT JOIN social.custom_feed_rules r ON r.feed_id = f.id
+     WHERE f.id = $1 AND f.user_id = $2 GROUP BY f.id`, [feedId, user.userId]);
+  if (!owned.rows[0]) throw new Error('custom_feed_not_found');
+  const result = await query<{ id: string; author_id: string; body: string; published_at: string; topic: string | null; region_code: string | null }>(env.DB_APP_FRESH,
+    `SELECT p.id, p.author_id, p.body, p.published_at, d.topic, d.region_code
+     FROM content.posts p LEFT JOIN feed.discovery_candidates d ON d.post_id = p.id
+     WHERE p.visibility = 'public' AND p.moderation_state = 'allowed'
+     ORDER BY p.published_at DESC NULLS LAST LIMIT 100`);
+  const rules = owned.rows[0].rules as Array<{ topic?: string; regionCode?: string }>;
+  const items = rules.length === 0 ? result.rows : result.rows.filter((item) =>
+    rules.some((rule) => (!rule.topic || item.topic === rule.topic) && (!rule.regionCode || item.region_code === rule.regionCode)));
+  return privateResponse(request, env, { items: items.slice(0, 50) });
+}
+
+async function getEntitlements(request: Request, env: Env, user: Principal): Promise<Response> {
+  const tier = await tierForUser(env, user.userId);
+  return privateResponse(request, env, { tier, entitlements: TIER_POLICIES[tier] });
+}
+
+async function getNewsBoard(request: Request, env: Env, user?: Principal): Promise<Response> {
+  const tier = user ? await tierForUser(env, user.userId) : 'free';
+  const access = TIER_POLICIES[tier].newsBoardAccess;
+  const result = await query(env.DB_APP_FRESH,
+    `SELECT publication.id, publication.title, publication.post_id, publication.published_at,
+            post.body, post.author_id
+     FROM editorial.publications publication
+     LEFT JOIN content.posts post ON post.id = publication.post_id
+     WHERE publication.published_at IS NOT NULL
+     ORDER BY publication.published_at DESC LIMIT $1`, [access === 'full' ? 50 : 5]);
+  return response(request, env, { access, items: result.rows });
+}
+
+async function notifications(request: Request, env: Env, user: Principal): Promise<Response> {
+  const result = await query(env.DB_APP_FRESH,
+    `SELECT id, notification_type, entity_id, read_at, created_at
+     FROM feed.notifications WHERE recipient_id = $1 AND dismissed_at IS NULL
+     ORDER BY created_at DESC LIMIT 100`, [user.userId]);
+  return privateResponse(request, env, { items: result.rows });
+}
+
+async function notificationAction(request: Request, env: Env, user: Principal, notificationId: string, action: 'read' | 'dismiss'): Promise<Response> {
+  const column = action === 'read' ? 'read_at' : 'dismissed_at';
+  const result = await query(env.DB_APP_FRESH,
+    `UPDATE feed.notifications SET ${column} = now() WHERE id = $1 AND recipient_id = $2 RETURNING id`, [notificationId, user.userId]);
+  if (result.rowCount !== 1) throw new Error('notification_not_found');
+  return privateResponse(request, env, { id: notificationId, action });
+}
+
+async function notificationPreferences(request: Request, env: Env, user: Principal): Promise<Response> {
+  if (request.method === 'GET') {
+    const result = await query(env.DB_APP_FRESH,
+      `SELECT email_enabled, push_enabled, replies_enabled, moderation_enabled, rewards_enabled, updated_at
+       FROM feed.notification_preferences WHERE user_id = $1`, [user.userId]);
+    return privateResponse(request, env, result.rows[0] ?? {
+      email_enabled: true, push_enabled: true, replies_enabled: true, moderation_enabled: true, rewards_enabled: true,
+    });
+  }
+  const input = await readJson<Record<string, unknown>>(request, 8 * 1024);
+  const values = ['emailEnabled', 'pushEnabled', 'repliesEnabled', 'moderationEnabled', 'rewardsEnabled']
+    .map((key) => typeof input[key] === 'boolean' ? input[key] : true);
+  const result = await query(env.DB_APP_FRESH,
+    `INSERT INTO feed.notification_preferences
+       (user_id, email_enabled, push_enabled, replies_enabled, moderation_enabled, rewards_enabled)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (user_id) DO UPDATE SET
+       email_enabled = EXCLUDED.email_enabled, push_enabled = EXCLUDED.push_enabled,
+       replies_enabled = EXCLUDED.replies_enabled, moderation_enabled = EXCLUDED.moderation_enabled,
+       rewards_enabled = EXCLUDED.rewards_enabled, updated_at = now()
+     RETURNING email_enabled, push_enabled, replies_enabled, moderation_enabled, rewards_enabled, updated_at`,
+    [user.userId, ...values]);
+  return privateResponse(request, env, result.rows[0]);
+}
+
+async function notificationDevices(request: Request, env: Env, user: Principal): Promise<Response> {
+  if (request.method === 'GET') {
+    const result = await query(env.DB_APP_FRESH,
+      `SELECT id, platform, active, created_at, revoked_at FROM feed.notification_devices
+       WHERE user_id = $1 ORDER BY created_at DESC`, [user.userId]);
+    return privateResponse(request, env, { items: result.rows });
+  }
+  const input = await readJson<{ platform?: string; token?: string }>(request, 8 * 1024);
+  if (!input.token || !input.platform || !['android', 'ios', 'web'].includes(input.platform)) throw new Error('invalid_notification_device');
+  const secrets = requireAuthSecrets(env);
+  const deviceId = uuidv7();
+  const encryptedToken = await encryptField(input.token, secrets.encryptionKey, 'v1');
+  await query(env.DB_APP_FRESH,
+    `INSERT INTO feed.notification_devices (id, user_id, platform, token_ciphertext, token_hmac)
+     VALUES ($1, $2, $3, decode($4, 'base64'), decode($5, 'base64'))
+     ON CONFLICT (token_hmac) DO UPDATE SET user_id = EXCLUDED.user_id, platform = EXCLUDED.platform, active = true, revoked_at = NULL`,
+    [deviceId, user.userId, input.platform, encryptedToken.ciphertext, hmacLookup(input.token, secrets.hmacKey)]);
+  return privateResponse(request, env, { id: deviceId, platform: input.platform }, { status: 201 });
+}
+
+async function reputationSummary(request: Request, env: Env, userId: string, privateView: boolean): Promise<Response> {
+  const result = await query<{ points: string }>(env.DB_APP_FRESH,
+    `SELECT points::text AS points FROM trust.reputation_balances WHERE user_id = $1`, [userId]);
+  const points = Number(result.rows[0]?.points ?? 0);
+  const reputationLevel = Math.max(1, Math.min(5, Math.floor(points / 100) + 1));
+  const payload: Record<string, unknown> = {
+    userId, reputationLevel, reputationStatus: 'active',
+    reputationBand: reputationLevel >= 4 ? 'high' : reputationLevel >= 2 ? 'established' : 'new',
+  };
+  if (privateView) Object.assign(payload, { points, rewardEligibilityStatus: 'eligible' });
+  return privateResponse(request, env, payload);
+}
+
+async function reputationLedger(request: Request, env: Env, user: Principal): Promise<Response> {
+  const result = await query(env.DB_APP_FRESH,
+    `SELECT id, content_id, event_type, policy_version, created_at
+     FROM trust.reputation_events WHERE subject_user_id = $1
+     ORDER BY created_at DESC LIMIT 100`, [user.userId]);
+  return privateResponse(request, env, { items: result.rows });
+}
+
+async function rewardsSnapshot(request: Request, env: Env, user: Principal): Promise<Response> {
+  const tier = await tierForUser(env, user.userId);
+  const policy = TIER_POLICIES[tier];
+  const [balance, account, history] = await Promise.all([
+    query<{ points: string }>(env.DB_APP_FRESH, `SELECT points::text AS points FROM trust.reputation_balances WHERE user_id = $1`, [user.userId]),
+    query<{ created_at: string }>(env.DB_APP_FRESH, `SELECT created_at FROM identity.users WHERE id = $1`, [user.userId]),
+    query<{ id: string; reward_id: string; reward_level: number; reward_title: string; redeemed_at: string; status: string }>(env.DB_APP_FRESH,
+      `SELECT id, reward_id, reward_level, reward_title, redeemed_at, status
+       FROM trust.reward_redemptions WHERE user_id = $1 ORDER BY redeemed_at DESC`, [user.userId]),
+  ]);
+  const points = Number(balance.rows[0]?.points ?? 0);
+  const reputationLevel = Math.max(1, Math.min(5, Math.floor(points / 100) + 1));
+  const accountAgeMs = Date.now() - new Date(account.rows[0]?.created_at ?? Date.now()).getTime();
+  const mature = accountAgeMs >= 7 * 24 * 60 * 60 * 1000;
+  const redeemed = new Set(history.rows.map((item) => item.reward_id));
+  const offers = REWARD_CATALOG.map((offer) => {
+    const locked = !mature || offer.rewardLevel > reputationLevel || offer.rewardLevel > policy.rewardLevelCap;
+    return {
+      ...offer,
+      locked,
+      lockReason: !mature ? 'Account maturity requirement not met.'
+        : offer.rewardLevel > reputationLevel ? 'Reputation level requirement not met.'
+          : offer.rewardLevel > policy.rewardLevelCap ? 'Subscription tier does not include this reward level.' : undefined,
+      redeemed: redeemed.has(offer.id),
+    };
+  });
+  return privateResponse(request, env, {
+    subscriptionTier: tier,
+    reputationLevel,
+    reputationBand: reputationLevel >= 4 ? 'high' : reputationLevel >= 2 ? 'established' : 'new',
+    availableRewardLevels: Array.from({ length: policy.rewardLevelCap }, (_, index) => index + 1),
+    maxOptionsPerLevel: policy.rewardOptionsPerLevel ?? REWARD_CATALOG.length,
+    redemptionStatus: mature ? 'active' : 'restricted',
+    fraudRiskStatus: 'normal',
+    offers,
+    redemptionHistory: history.rows,
+    affiliateDisclosure: 'Reward availability and partner relationships are disclosed before redemption.',
+  });
+}
+
+async function redeemReward(request: Request, env: Env, user: Principal, rewardId: string): Promise<Response> {
+  const offer = REWARD_CATALOG.find((candidate) => candidate.id === rewardId);
+  if (!offer) throw new Error('reward_not_found');
+  const tier = await tierForUser(env, user.userId);
+  const balance = await query<{ points: string; created_at: string }>(env.DB_APP_FRESH,
+    `SELECT COALESCE(b.points, 0)::text AS points, u.created_at
+     FROM identity.users u LEFT JOIN trust.reputation_balances b ON b.user_id = u.id WHERE u.id = $1`, [user.userId]);
+  const points = Number(balance.rows[0]?.points ?? 0);
+  const level = Math.max(1, Math.min(5, Math.floor(points / 100) + 1));
+  const mature = Date.now() - new Date(balance.rows[0]?.created_at ?? Date.now()).getTime() >= 7 * 24 * 60 * 60 * 1000;
+  if (!mature || offer.rewardLevel > level || offer.rewardLevel > TIER_POLICIES[tier].rewardLevelCap) throw new Error('reward_locked');
+  const redemptionId = uuidv7();
+  const result = await query(env.DB_APP_FRESH,
+    `INSERT INTO trust.reward_redemptions (id, user_id, reward_id, reward_level, reward_title)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (user_id, reward_id) DO NOTHING RETURNING redeemed_at`,
+    [redemptionId, user.userId, offer.id, offer.rewardLevel, offer.title]);
+  if (result.rowCount !== 1) throw new Error('reward_already_redeemed');
+  return privateResponse(request, env, { id: redemptionId, rewardId: offer.id, rewardLevel: offer.rewardLevel, rewardTitle: offer.title, status: 'redeemed' }, { status: 201 });
+}
+
 async function getPersonalFeed(request: Request, env: Env, user: Principal): Promise<Response> {
   const result = await query(env.DB_APP_FRESH,
     `SELECT p.id, p.author_id, p.body, p.declared_creation_mode, p.visibility, p.moderation_state,
@@ -1009,11 +1306,16 @@ export default {
         return response(request, env, { status: 'ready', service: 'lythaus-public-api' });
       }
       if (request.method === 'GET' && url.pathname === '/.well-known/jwks.json') return new Response(env.JWT_PUBLIC_JWKS ?? '{"keys":[]}', { headers: { 'content-type': 'application/json', 'cache-control': 'public, max-age=300' } });
+      await enforceRateLimit(request, env, url.pathname.startsWith('/api/auth') ? 'auth' : 'public-api', url.pathname.startsWith('/api/auth') ? 10 : 120);
       if (request.method === 'GET' && url.pathname === '/api/feed/discover') {
         const result = await query(env.DB_APP_FRESH, `SELECT id, author_id, body, published_at FROM content.posts WHERE visibility = 'public' AND moderation_state = 'allowed' ORDER BY published_at DESC LIMIT 50`);
         const resultResponse = response(request, env, { items: result.rows });
         resultResponse.headers.set('cache-control', 'public, s-maxage=30, stale-while-revalidate=60');
         return resultResponse;
+      }
+      if (request.method === 'GET' && (url.pathname === '/api/feed/news' || url.pathname === '/api/news-board')) {
+        const user = request.headers.has('authorization') ? await principal(request, env) : undefined;
+        return await getNewsBoard(request, env, user);
       }
       if (request.method === 'GET' && url.pathname === '/api/feed') return await getPersonalFeed(request, env, await principal(request, env));
       const post = url.pathname.match(/^\/api\/posts\/([^/]+)$/);
@@ -1027,6 +1329,20 @@ export default {
       }
       const publicProfile = url.pathname.match(/^\/api\/users\/([^/]+)$/);
       if (request.method === 'GET' && publicProfile) return await getUserProfile(request, env, publicProfile[1]);
+      if (request.method === 'GET' && url.pathname === '/api/subscription/status') return await getEntitlements(request, env, await principal(request, env));
+      if (url.pathname === '/api/custom-feeds') {
+        const user = await principal(request, env);
+        if (request.method === 'GET') return await listCustomFeeds(request, env, user);
+        if (request.method === 'POST') return await idempotentMutation(request, env, user.userId, 'custom-feed.create', () => createCustomFeed(request, env, user));
+      }
+      const customFeedItemsRoute = url.pathname.match(/^\/api\/custom-feeds\/([^/]+)\/items$/);
+      if (request.method === 'GET' && customFeedItemsRoute) return await customFeedItems(request, env, await principal(request, env), customFeedItemsRoute[1]);
+      const customFeedRoute = url.pathname.match(/^\/api\/custom-feeds\/([^/]+)$/);
+      if (customFeedRoute && ['GET', 'PUT', 'PATCH', 'DELETE'].includes(request.method)) {
+        const user = await principal(request, env);
+        if (request.method === 'GET') return await customFeed(request, env, user, customFeedRoute[1]);
+        return await idempotentMutation(request, env, user.userId, `custom-feed.${request.method.toLowerCase()}`, () => customFeed(request, env, user, customFeedRoute[1]));
+      }
       if (request.method === 'POST' && (url.pathname === '/api/follows' || url.pathname === '/api/users/follow')) {
         const user = await principal(request, env);
         return await idempotentMutation(request, env, user.userId, 'follow.create', () => createFollow(request, env, user));
@@ -1089,6 +1405,42 @@ export default {
       }
       const appeal = url.pathname.match(/^\/api\/appeals\/([^/]+)$/);
       if (request.method === 'GET' && appeal) return await getAppeal(request, env, await principal(request, env), appeal[1]);
+      if (request.method === 'GET' && url.pathname === '/api/reputation/me') {
+        const user = await principal(request, env);
+        return await reputationSummary(request, env, user.userId, true);
+      }
+      if (request.method === 'GET' && url.pathname === '/api/reputation/me/ledger') return await reputationLedger(request, env, await principal(request, env));
+      const reputationUser = url.pathname.match(/^\/api\/reputation\/(?:users|user)\/([^/]+)$/);
+      if (request.method === 'GET' && reputationUser) return await reputationSummary(request, env, reputationUser[1], false);
+      if (request.method === 'GET' && url.pathname === '/api/rewards/me') return await rewardsSnapshot(request, env, await principal(request, env));
+      const rewardRedeem = url.pathname.match(/^\/api\/rewards\/([^/]+)\/redeem$/);
+      if (request.method === 'POST' && rewardRedeem) {
+        const user = await principal(request, env);
+        return await idempotentMutation(request, env, user.userId, 'reward.redeem', () => redeemReward(request, env, user, rewardRedeem[1]));
+      }
+      if (request.method === 'GET' && url.pathname === '/api/notifications') return await notifications(request, env, await principal(request, env));
+      if (request.method === 'GET' && url.pathname === '/api/notifications/unread-count') {
+        const user = await principal(request, env);
+        const result = await query<{ count: string }>(env.DB_APP_FRESH,
+          `SELECT count(*)::text AS count FROM feed.notifications WHERE recipient_id = $1 AND read_at IS NULL AND dismissed_at IS NULL`, [user.userId]);
+        return privateResponse(request, env, { count: Number(result.rows[0]?.count ?? 0) });
+      }
+      const notificationRoute = url.pathname.match(/^\/api\/notifications\/([^/]+)\/(read|dismiss)$/);
+      if (request.method === 'POST' && notificationRoute) {
+        const user = await principal(request, env);
+        return await idempotentMutation(request, env, user.userId, `notification.${notificationRoute[2]}`, () => notificationAction(request, env, user, notificationRoute[1], notificationRoute[2] as 'read' | 'dismiss'));
+      }
+      if (url.pathname === '/api/notifications/preferences' && ['GET', 'PUT', 'PATCH'].includes(request.method)) return await notificationPreferences(request, env, await principal(request, env));
+      if (url.pathname === '/api/notifications/devices' && ['GET', 'POST'].includes(request.method)) return await notificationDevices(request, env, await principal(request, env));
+      const notificationDeviceRevoke = url.pathname.match(/^\/api\/notifications\/devices\/([^/]+)\/revoke$/);
+      if (request.method === 'POST' && notificationDeviceRevoke) {
+        const user = await principal(request, env);
+        const result = await query(env.DB_APP_FRESH,
+          `UPDATE feed.notification_devices SET active = false, revoked_at = now() WHERE id = $1 AND user_id = $2 RETURNING id`,
+          [notificationDeviceRevoke[1], user.userId]);
+        if (result.rowCount !== 1) throw new Error('notification_device_not_found');
+        return privateResponse(request, env, { id: notificationDeviceRevoke[1], revoked: true });
+      }
       if (request.method === 'GET' && url.pathname === '/api/privacy/requests') {
         return await getPrivacyRequestStatus(request, env, await principal(request, env));
       }

--- a/database/planetscale/migrations/0010_native_runtime_parity.sql
+++ b/database/planetscale/migrations/0010_native_runtime_parity.sql
@@ -1,0 +1,60 @@
+CREATE TABLE identity.user_entitlements (
+  user_id uuid PRIMARY KEY REFERENCES identity.users(id) ON DELETE CASCADE,
+  subscription_tier text NOT NULL DEFAULT 'free'
+    CHECK (subscription_tier IN ('free', 'premium', 'black')),
+  updated_by uuid REFERENCES identity.users(id),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE system.rate_limit_windows (
+  scope text NOT NULL,
+  subject_hash text NOT NULL,
+  window_started_at timestamptz NOT NULL,
+  request_count integer NOT NULL DEFAULT 1 CHECK (request_count > 0),
+  expires_at timestamptz NOT NULL,
+  PRIMARY KEY (scope, subject_hash, window_started_at)
+);
+
+CREATE INDEX rate_limit_expiry_idx ON system.rate_limit_windows (expires_at);
+
+ALTER TABLE feed.notifications
+  ADD COLUMN dismissed_at timestamptz;
+
+CREATE TABLE feed.notification_preferences (
+  user_id uuid PRIMARY KEY REFERENCES identity.users(id) ON DELETE CASCADE,
+  email_enabled boolean NOT NULL DEFAULT true,
+  push_enabled boolean NOT NULL DEFAULT true,
+  replies_enabled boolean NOT NULL DEFAULT true,
+  moderation_enabled boolean NOT NULL DEFAULT true,
+  rewards_enabled boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE feed.notification_devices (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES identity.users(id) ON DELETE CASCADE,
+  platform text NOT NULL CHECK (platform IN ('android', 'ios', 'web')),
+  token_ciphertext bytea NOT NULL,
+  token_hmac bytea NOT NULL UNIQUE,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz
+);
+
+CREATE INDEX notification_devices_user_idx
+  ON feed.notification_devices (user_id, active, created_at DESC);
+
+CREATE TABLE trust.reward_redemptions (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES identity.users(id) ON DELETE CASCADE,
+  reward_id text NOT NULL,
+  reward_level integer NOT NULL CHECK (reward_level BETWEEN 1 AND 5),
+  reward_title text NOT NULL,
+  status text NOT NULL DEFAULT 'confirmed'
+    CHECK (status IN ('confirmed', 'revoked')),
+  redeemed_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, reward_id)
+);
+
+CREATE INDEX reward_redemptions_user_idx
+  ON trust.reward_redemptions (user_id, redeemed_at DESC);

--- a/docs/architecture/native-worker-capability-parity.md
+++ b/docs/architecture/native-worker-capability-parity.md
@@ -1,0 +1,44 @@
+# Native Worker capability parity
+
+Status: implementation complete in the repository; deployment gated by
+`0010_native_runtime_parity.sql` and the remaining authentication and
+Authenticity AI changes.
+
+This comparison treats Cloudflare Workers and PlanetScale PostgreSQL as the
+only current runtime. Azure trigger, binding, queue, and SDK behaviour is not a
+capability and is not eligible for porting.
+
+| Capability | Native owner | Status |
+| --- | --- | --- |
+| Email and guest authentication | public API | Live; social providers are removed separately |
+| User and profile management | public API | Live; display-name and biography changes emit a moderation event |
+| Posts and comments | public API and jobs | Live with tier limits, idempotency, and moderation queueing |
+| Discovery and personal feeds | public API | Live |
+| Custom feeds | public API | Live with tier-count enforcement |
+| Tier enforcement | contracts, public API, admin API | Live through `identity.user_entitlements` and shared policies |
+| Editorial and News Board | public API and admin API | Live with preview/full tier policy |
+| Moderation and appeals | public API, admin API, jobs | Live |
+| Reputation and rewards | public API | Live on PostgreSQL ledgers and redemptions |
+| Notifications | public API and jobs | API and durable records live; delivery remains provider-configured |
+| Privacy export and deletion | public API and jobs workflows | Live |
+| Legal holds | admin API and jobs | Live |
+| Media processing | public API and jobs | Live behind the existing default-off release gate |
+| Administrative actions | admin API | Live for moderation, account status, tiering, privacy, editorial, and audit |
+| Audit logging | admin API and jobs | Live in `system.audit_events` |
+| Rate limits | public and admin APIs | Live using PostgreSQL atomic windows |
+
+## Functions deletion gate
+
+The Functions workspace may be deleted after all of these repository gates
+pass:
+
+1. PostgreSQL 17 validates migration `0010_native_runtime_parity.sql` from the
+   exact approved baseline.
+2. Lythaus Authenticity AI replaces the remaining Hive implementation in the
+   jobs Worker.
+3. Google, Apple, World ID, and provider-only OAuth callback paths are removed.
+4. Native type checking, architecture tests, migration validation, OpenAPI
+   checks, Flutter tests, and both frontend builds pass.
+
+Migration `0010` is repository-only in this change. It has not been applied to
+PlanetScale `main`.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -49,3 +49,73 @@ export interface UploadSessionResponse {
   maxBytes: number;
   checksumSha256: string;
 }
+
+export type UserTier = 'free' | 'premium' | 'black';
+
+export interface TierPolicy {
+  dailyPosts: number;
+  dailyComments: number;
+  dailyReactions: number;
+  dailyAppeals: number;
+  exportCooldownDays: number;
+  maxCustomFeeds: number;
+  newsBoardAccess: 'preview' | 'full';
+  rewardLevelCap: number;
+  rewardOptionsPerLevel: number | null;
+}
+
+export const TIER_POLICIES: Readonly<Record<UserTier, TierPolicy>> = {
+  free: {
+    dailyPosts: 5,
+    dailyComments: 20,
+    dailyReactions: 100,
+    dailyAppeals: 1,
+    exportCooldownDays: 30,
+    maxCustomFeeds: 1,
+    newsBoardAccess: 'preview',
+    rewardLevelCap: 3,
+    rewardOptionsPerLevel: 1,
+  },
+  premium: {
+    dailyPosts: 20,
+    dailyComments: 100,
+    dailyReactions: 1000,
+    dailyAppeals: 3,
+    exportCooldownDays: 7,
+    maxCustomFeeds: 2,
+    newsBoardAccess: 'full',
+    rewardLevelCap: 5,
+    rewardOptionsPerLevel: 1,
+  },
+  black: {
+    dailyPosts: 50,
+    dailyComments: 300,
+    dailyReactions: 1500,
+    dailyAppeals: 10,
+    exportCooldownDays: 1,
+    maxCustomFeeds: 3,
+    newsBoardAccess: 'full',
+    rewardLevelCap: 5,
+    rewardOptionsPerLevel: null,
+  },
+};
+
+export function normalizeUserTier(value: unknown): UserTier {
+  return value === 'premium' || value === 'black' ? value : 'free';
+}
+
+export interface RewardCatalogItem {
+  id: string;
+  rewardLevel: number;
+  title: string;
+  description: string;
+  partnerName: string;
+}
+
+export const REWARD_CATALOG: readonly RewardCatalogItem[] = [
+  { id: 'level-1-learning', rewardLevel: 1, title: 'Learning access', description: 'Curated learning material for responsible publishing.', partnerName: 'Lythaus Learning' },
+  { id: 'level-2-source-tools', rewardLevel: 2, title: 'Source toolkit', description: 'Source tracking and citation workflow tools.', partnerName: 'Lythaus Research' },
+  { id: 'level-3-community', rewardLevel: 3, title: 'Community sessions', description: 'Priority registration for selected community sessions.', partnerName: 'Lythaus Community' },
+  { id: 'level-4-editorial', rewardLevel: 4, title: 'Editorial toolkit', description: 'Advanced editorial and long-form publishing tools.', partnerName: 'Lythaus Editorial' },
+  { id: 'level-5-professional', rewardLevel: 5, title: 'Professional suite', description: 'Professional tooling for established contributors.', partnerName: 'Lythaus Professional' },
+];

--- a/scripts/tests/native-architecture-invariants.test.js
+++ b/scripts/tests/native-architecture-invariants.test.js
@@ -455,3 +455,24 @@ test('privacy workflows reconcile the subject-data locator before export or dele
   assert.match(grants, /GRANT EXECUTE ON FUNCTION privacy\.reconcile_subject_data_locations\(uuid\) TO lythaus_privacy/);
   assert.equal((jobs.match(/privacy\.reconcile_subject_data_locations/g) ?? []).length, 2);
 });
+
+test('native APIs cover the provider-neutral Functions capability set', () => {
+  const publicApi = fs.readFileSync(path.join(root, 'apps/lythaus-public-api/src/index.ts'), 'utf8');
+  const adminApi = fs.readFileSync(path.join(root, 'apps/lythaus-admin-api/src/index.ts'), 'utf8');
+  const migration = fs.readFileSync(path.join(root, 'database/planetscale/migrations/0010_native_runtime_parity.sql'), 'utf8');
+  for (const route of [
+    '/api/custom-feeds', '/api/feed/news', '/api/subscription/status',
+    '/api/reputation/me', '/api/rewards/me', '/api/notifications',
+  ]) assert.match(publicApi, new RegExp(route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  for (const route of [
+    '/api/admin/moderation/cases', '/api/admin/audit', '/api/admin/users/search',
+    '/api/admin/privacy/legal-holds', '/api/admin/editorial/publications',
+  ]) assert.match(adminApi, new RegExp(route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(publicApi, /enforceDailyAction/);
+  assert.match(publicApi, /enforceRateLimit/);
+  assert.match(adminApi, /enforceAdminRateLimit/);
+  assert.match(migration, /identity\.user_entitlements/);
+  assert.match(migration, /system\.rate_limit_windows/);
+  assert.match(migration, /feed\.notification_devices/);
+  assert.match(migration, /trust\.reward_redemptions/);
+});


### PR DESCRIPTION
## Summary
- port provider-neutral Functions capabilities into the native public and admin Workers
- add custom feeds, tier limits, News Board, notifications, reputation, rewards, audit, legal-hold, and editorial routes
- add atomic PostgreSQL-backed request and daily action limits
- add forward migration `0010_native_runtime_parity.sql` for entitlement, notification device/preference, rate-limit, and reward state
- document the source-backed Functions deletion gate

## Validation
- `npm run typecheck:native`
- `npm run test:native-architecture` (34 passed)
- `npm run validate:planetscale-migrations` (10 files, 79 launch tables)
- `npm run validate:no-retired-provider-dependencies`

## Gate
Migration `0010` is not applied to PlanetScale `main`. Local PostgreSQL 17 execution was unavailable because Docker Desktop is not running; provider application remains a separate explicit approval gate.