### PR TITLE
fix: reconcile unapplied PlanetScale schema safely

### DIFF
--- a/scripts/ci/planetscale-migration-reconciliation.mjs
+++ b/scripts/ci/planetscale-migration-reconciliation.mjs
@@ -205,6 +205,8 @@ export function assertCompleteMigrationPostconditions(state) {
   throw new Error(`canonical postcondition verification failed for ${state.name}: ${missing.join(', ')}`);
 }
 
+const missingSchemaArtifactCodes = new Set(['42P01', '42703']);
+
 export async function classifyMigrationState(client, names = Object.keys(artifacts)) {
   const states = [];
   for (const name of names) {
@@ -215,6 +217,10 @@ export async function classifyMigrationState(client, names = Object.keys(artifac
       try {
         result = await client.query(sql);
       } catch (error) {
+        if (error && typeof error === 'object' && missingSchemaArtifactCodes.has(error.code)) {
+          results.push({ artifact, present: false });
+          continue;
+        }
         throw new Error(`postcondition query failed for ${name}/${artifact}`, { cause: error });
       }
       results.push({ artifact, present: result.rows[0]?.present === true });

--- a/scripts/tests/planetscale-production-migrations.test.mjs
+++ b/scripts/tests/planetscale-production-migrations.test.mjs
@@ -50,6 +50,34 @@ test('requires complete canonical relation, function and data postconditions bef
   }
 });
 
+test('treats missing pre-migration tables or columns as absent postconditions and still fails unexpected query errors', async () => {
+  for (const code of ['42P01', '42703']) {
+    const client = {
+      async query() {
+        const error = new Error('schema artifact is not present yet');
+        error.code = code;
+        throw error;
+      },
+    };
+    const [state] = await classifyMigrationState(client, ['0012_product_integrity_v2.sql']);
+    assert.equal(state.state, 'NOT_APPLIED');
+    assert.ok(state.artifacts.length > 0);
+    assert.ok(state.artifacts.every(({ present }) => present === false));
+  }
+
+  const unexpectedClient = {
+    async query() {
+      const error = new Error('permission denied');
+      error.code = '42501';
+      throw error;
+    },
+  };
+  await assert.rejects(
+    classifyMigrationState(unexpectedClient, ['0012_product_integrity_v2.sql']),
+    /postcondition query failed for 0012_product_integrity_v2\.sql\//,
+  );
+});
+
 test('permits incremental release and resume only from an exact canonical prefix', () => {
   const prefix = APPROVED_MIGRATIONS.slice(0, 9).map(({ name, appliedSha256 }) => ({ version: name, checksum: appliedSha256 }));
   assert.equal(exactRegistryPrefix(prefix, '0008_legacy_relink_status.sql'), true);


### PR DESCRIPTION
Production migration run #4 attempt 2 confirmed the protected PlanetScale admin credential is now available, but reconciliation failed before DDL because 0012 postcondition probes referenced columns that do not exist until 0012 is applied. PostgreSQL returned 42703 for trust.reputation_events.impact.

This change keeps reconciliation fail-closed while treating only PostgreSQL undefined-table (42P01) and undefined-column (42703) errors from migration postcondition probes as `present: false`. Permission, connectivity, syntax, and other errors continue to fail the release.

Tests cover both expected missing-schema codes and verify unexpected permission errors still reject.

No migration file, checksum, production database object, secret, or deployment is changed by this PR.