### PR TITLE
fix: avoid poisoned read-only PlanetScale reconciliation transaction

### DIFF
--- a/scripts/ci/reconcile-planetscale-migration-state.mjs
+++ b/scripts/ci/reconcile-planetscale-migration-state.mjs
@@ -17,17 +17,22 @@ if (connection.searchParams.get('sslrootcert') === 'system') connection.searchPa
 const client = new Client({ connectionString: connection.toString(), ssl: { rejectUnauthorized: true } });
 await client.connect();
 try {
-  await client.query('BEGIN READ ONLY');
+  // Keep every catalog probe read-only, but do not wrap the entire reconciliation in
+  // one explicit transaction. PostgreSQL marks a transaction failed after an expected
+  // undefined-table/undefined-column probe, which would poison all later probes even
+  // though classifyMigrationState correctly classifies that artifact as not applied.
+  // Session-level read-only mode preserves the safety boundary while letting each
+  // statement autocommit independently.
+  await client.query('SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY');
+  const readOnly = await client.query('SHOW transaction_read_only');
+  if (readOnly.rows[0]?.transaction_read_only !== 'on') throw new Error('migration reconciliation session is not read-only');
+
   const registryExists = await client.query("SELECT to_regclass('system.schema_migrations') AS registry");
   const registry = registryExists.rows[0]?.registry
     ? await client.query('SELECT version, checksum FROM system.schema_migrations ORDER BY version')
     : { rows: [] };
   const states = await classifyMigrationState(client, APPROVED_MIGRATIONS.slice(9).map(({ name }) => name));
-  await client.query('ROLLBACK');
   console.log(JSON.stringify({ branch, registry: registry.rows, migrations: states }, null, 2));
-} catch (error) {
-  await client.query('ROLLBACK').catch(() => undefined);
-  throw error;
 } finally {
   await client.end();
 }

--- a/scripts/tests/planetscale-production-migrations.test.mjs
+++ b/scripts/tests/planetscale-production-migrations.test.mjs
@@ -78,6 +78,14 @@ test('treats missing pre-migration tables or columns as absent postconditions an
   );
 });
 
+test('production catalog reconciliation keeps read-only safety without one poisonable transaction', async () => {
+  const source = await (await import('node:fs/promises')).readFile('scripts/ci/reconcile-planetscale-migration-state.mjs', 'utf8');
+  assert.match(source, /SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY/);
+  assert.match(source, /SHOW transaction_read_only/);
+  assert.doesNotMatch(source, /BEGIN READ ONLY/);
+  assert.doesNotMatch(source, /client\.query\('ROLLBACK'\)/);
+});
+
 test('permits incremental release and resume only from an exact canonical prefix', () => {
   const prefix = APPROVED_MIGRATIONS.slice(0, 9).map(({ name, appliedSha256 }) => ({ version: name, checksum: appliedSha256 }));
   assert.equal(exactRegistryPrefix(prefix, '0008_legacy_relink_status.sql'), true);


### PR DESCRIPTION
Production migration run #5 confirmed the previous missing-column classification fix works, but exposed PostgreSQL transaction semantics: once an expected undefined-column probe fails inside `BEGIN READ ONLY`, the transaction remains aborted and later probes fail with `25P02`.

This change keeps reconciliation read-only at the session level with `SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY`, verifies `transaction_read_only=on`, and lets each catalog probe autocommit independently. Expected 42P01/42703 postcondition misses can therefore be classified as absent without poisoning later probes.

A regression test requires session-level read-only mode and forbids the single explicit `BEGIN READ ONLY`/`ROLLBACK` wrapper.

No migration file, checksum, production database object, secret, or deployment is changed by this PR.