### PR TITLE
fix: distinguish vacuous migration invariants from applied schema

### DIFF
--- a/scripts/ci/planetscale-migration-reconciliation.mjs
+++ b/scripts/ci/planetscale-migration-reconciliation.mjs
@@ -180,13 +180,13 @@ const contractArtifacts = Object.fromEntries(
 const artifacts = {
   ...contractArtifacts,
   '0013_marketing_waitlist.sql': [
-    { artifact: 'waitlist_table', sql: "SELECT to_regclass('marketing.waitlist_signups') IS NOT NULL AS present" },
-    { artifact: 'waitlist_purge_after', sql: "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND column_name = 'purge_after') AS present" },
-    { artifact: 'waitlist_hold', sql: "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND column_name = 'retention_hold') AS present" },
-    { artifact: 'waitlist_unique_hmac', sql: "SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'waitlist_signups_email_lookup_hmac_unique' AND contype = 'u') AS present" },
-    { artifact: 'waitlist_cursor_index', sql: "SELECT to_regclass('marketing.waitlist_signups_created_cursor_idx') IS NOT NULL AS present" },
-    { artifact: 'waitlist_purge_index', sql: "SELECT to_regclass('marketing.waitlist_signups_due_purge_idx') IS NOT NULL AS present" },
-    { artifact: 'waitlist_no_plaintext_columns', sql: "SELECT NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND column_name IN ('email', 'plain_email', 'raw_ip', 'ip_address', 'user_agent', 'turnstile_token')) AS present" },
+    { artifact: 'waitlist_table', kind: 'schema_artifact', sql: "SELECT to_regclass('marketing.waitlist_signups') IS NOT NULL AS present" },
+    { artifact: 'waitlist_purge_after', kind: 'schema_artifact', sql: "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND column_name = 'purge_after') AS present" },
+    { artifact: 'waitlist_hold', kind: 'schema_artifact', sql: "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND column_name = 'retention_hold') AS present" },
+    { artifact: 'waitlist_unique_hmac', kind: 'schema_artifact', sql: "SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'waitlist_signups_email_lookup_hmac_unique' AND contype = 'u') AS present" },
+    { artifact: 'waitlist_cursor_index', kind: 'schema_artifact', sql: "SELECT to_regclass('marketing.waitlist_signups_created_cursor_idx') IS NOT NULL AS present" },
+    { artifact: 'waitlist_purge_index', kind: 'schema_artifact', sql: "SELECT to_regclass('marketing.waitlist_signups_due_purge_idx') IS NOT NULL AS present" },
+    { artifact: 'waitlist_no_plaintext_columns', kind: 'data_invariant', sql: "SELECT NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND column_name IN ('email', 'plain_email', 'raw_ip', 'ip_address', 'user_agent', 'turnstile_token')) AS present" },
   ],
 };
 
@@ -195,8 +195,11 @@ export const migrationPostconditions = Object.fromEntries(
 );
 
 export function classifyArtifacts(results) {
-  const present = results.filter((artifact) => artifact.present).length;
-  return present === 0 ? 'NOT_APPLIED' : present === results.length ? 'FULLY_APPLIED' : 'PARTIALLY_APPLIED';
+  if (results.length === 0) return 'NOT_APPLIED';
+  if (results.every((artifact) => artifact.present)) return 'FULLY_APPLIED';
+  const structural = results.filter(({ kind }) => kind !== 'data_invariant');
+  if (structural.length > 0 && structural.every((artifact) => !artifact.present)) return 'NOT_APPLIED';
+  return 'PARTIALLY_APPLIED';
 }
 
 export function assertCompleteMigrationPostconditions(state) {
@@ -212,18 +215,18 @@ export async function classifyMigrationState(client, names = Object.keys(artifac
   for (const name of names) {
     const checks = artifacts[name] ?? [];
     const results = [];
-    for (const { artifact, sql } of checks) {
+    for (const { artifact, kind = 'legacy_probe', sql } of checks) {
       let result;
       try {
         result = await client.query(sql);
       } catch (error) {
         if (error && typeof error === 'object' && missingSchemaArtifactCodes.has(error.code)) {
-          results.push({ artifact, present: false });
+          results.push({ artifact, kind, present: false });
           continue;
         }
         throw new Error(`postcondition query failed for ${name}/${artifact}`, { cause: error });
       }
-      results.push({ artifact, present: result.rows[0]?.present === true });
+      results.push({ artifact, kind, present: result.rows[0]?.present === true });
     }
     states.push({ name, state: classifyArtifacts(results), artifacts: results });
   }

--- a/scripts/tests/planetscale-production-migrations.test.mjs
+++ b/scripts/tests/planetscale-production-migrations.test.mjs
@@ -11,10 +11,12 @@ test('loads the immutable canonical migration payload and checksum set', () => {
   assert.equal(manifest.migrations.at(-1)?.name, '0013_marketing_waitlist.sql');
 });
 
-test('classifies catalog evidence without treating a partial state as applied', () => {
-  assert.equal(classifyArtifacts([{ present: false }, { present: false }]), 'NOT_APPLIED');
-  assert.equal(classifyArtifacts([{ present: true }, { present: true }]), 'FULLY_APPLIED');
-  assert.equal(classifyArtifacts([{ present: true }, { present: false }]), 'PARTIALLY_APPLIED');
+test('classifies catalog evidence without treating vacuous data invariants as applied structure', () => {
+  assert.equal(classifyArtifacts([{ kind: 'schema_artifact', present: false }, { kind: 'schema_artifact', present: false }]), 'NOT_APPLIED');
+  assert.equal(classifyArtifacts([{ kind: 'schema_artifact', present: true }, { kind: 'data_invariant', present: true }]), 'FULLY_APPLIED');
+  assert.equal(classifyArtifacts([{ kind: 'schema_artifact', present: true }, { kind: 'schema_artifact', present: false }]), 'PARTIALLY_APPLIED');
+  assert.equal(classifyArtifacts([{ kind: 'schema_artifact', present: false }, { kind: 'data_invariant', present: true }]), 'NOT_APPLIED');
+  assert.equal(classifyArtifacts([]), 'NOT_APPLIED');
 });
 
 test('requires complete canonical relation, function and data postconditions before recording 0009 through 0012', async () => {
@@ -48,6 +50,18 @@ test('requires complete canonical relation, function and data postconditions bef
     assert.equal(state.artifacts.find(({ artifact }) => artifact === missingArtifact)?.present, false);
     assert.throws(() => assertCompleteMigrationPostconditions(state), new RegExp(missingArtifact.replace(/[().]/g, '\\$&')));
   }
+});
+
+test('pre-migration waitlist absence stays NOT_APPLIED when no-plaintext invariant is vacuously true', async () => {
+  const client = {
+    async query(sql) {
+      return { rows: [{ present: sql.includes("column_name IN ('email', 'plain_email', 'raw_ip', 'ip_address', 'user_agent', 'turnstile_token')") }] };
+    },
+  };
+  const [state] = await classifyMigrationState(client, ['0013_marketing_waitlist.sql']);
+  assert.equal(state.state, 'NOT_APPLIED');
+  assert.equal(state.artifacts.find(({ artifact }) => artifact === 'waitlist_no_plaintext_columns')?.present, true);
+  assert.ok(state.artifacts.filter(({ kind }) => kind !== 'data_invariant').every(({ present }) => present === false));
 });
 
 test('treats missing pre-migration tables or columns as absent postconditions and still fails unexpected query errors', async () => {


### PR DESCRIPTION
Production migration run #7 successfully authenticated and reconciled the PlanetScale main catalog, then stopped at the rollback-anchor gate before any DDL. Its sanitized reconciliation evidence exposed a second issue: negative data invariants such as “no legacy auth flags” or “no plaintext waitlist columns” can be true before their migration has run, so they must not by themselves classify a migration as PARTIALLY_APPLIED.

This change keeps the fail-closed contract:
- FULLY_APPLIED still requires every structural and data postcondition.
- NOT_APPLIED is allowed only when no structural artifact for the migration exists, even if a negative data invariant is vacuously true.
- PARTIALLY_APPLIED remains any state where at least one structural artifact exists but the full postcondition set is incomplete.
- 0013 waitlist checks now explicitly distinguish structural schema evidence from the no-plaintext data invariant.
- Regression tests cover the exact pre-migration waitlist case observed in run #7.

No migration SQL, checksum, registry row, production database object, secret, backup setting, or deployment is changed by this PR.