### PR TITLE
fix: normalize historical function source line endings

### DIFF
--- a/scripts/ci/planetscale-migration-reconciliation.mjs
+++ b/scripts/ci/planetscale-migration-reconciliation.mjs
@@ -144,7 +144,7 @@ SELECT EXISTS (
      AND procedure_language.lanname = 'plpgsql'
      AND procedure_entry.prosecdef IS TRUE
      AND pg_get_function_result(procedure_entry.oid) = '${contract.resultType}'
-     AND procedure_entry.prosrc = ${dollarQuote(contract.canonicalBody)}
+     AND replace(procedure_entry.prosrc, E'\\r\\n', E'\\n') = ${dollarQuote(contract.canonicalBody)}
      AND cardinality(procedure_entry.proconfig) = 1
      AND split_part(procedure_entry.proconfig[1], '=', 1) = 'search_path'
      AND regexp_replace(split_part(procedure_entry.proconfig[1], '=', 2), '[[:space:]]+', '', 'g') = '${normalizedSearchPath}'

--- a/scripts/tests/planetscale-production-migrations.test.mjs
+++ b/scripts/tests/planetscale-production-migrations.test.mjs
@@ -65,7 +65,7 @@ test('function postconditions verify canonical PL/pgSQL semantics without pg_get
   const functionQueries = queries.filter((sql) => sql.includes('migration-artifact:function:privacy.'));
   assert.equal(functionQueries.length, 2);
   for (const sql of functionQueries) {
-    assert.match(sql, /procedure_entry\.prosrc = \$lythaus_function_contract\$/);
+    assert.ok(sql.includes("replace(procedure_entry.prosrc, E'\\r\\n', E'\\n')"));
     assert.match(sql, /procedure_entry\.prosecdef IS TRUE/);
     assert.match(sql, /pg_get_function_result\(procedure_entry\.oid\)/);
     assert.match(sql, /cardinality\(procedure_entry\.proconfig\) = 1/);


### PR DESCRIPTION
Production run #10 reached the incremental 0012 apply, but its postcondition verifier rejected only the renamed pre-integrity privacy function. The function itself was created from the historical 0004 applied payload, whose approved bytes preserve CRLF line endings in the PL/pgSQL body, while the verifier canonical body is LF-normalized.

This change normalizes CRLF to LF on PostgreSQL `pg_proc.prosrc` before the exact canonical body comparison. It retains the existing language, SECURITY DEFINER, return type, and normalized search_path checks, so the contract remains fail-closed apart from line-ending representation.

A regression test covers the normalization. No immutable migration SQL is changed.

Production state after run #10: migrations 0009-0011 remain committed; 0012 rolled back atomically after postcondition verification failed; 0013 did not run.