### PR TITLE
feat: activate production waitlist through protected cutover

### DIFF
--- a/.github/workflows/deploy-marketing-preview.yml
+++ b/.github/workflows/deploy-marketing-preview.yml
@@ -83,7 +83,10 @@ jobs:
           npm ci
           npm run build
           node ../../scripts/cloudflare/validate-marketing-output.mjs dist
-          ! rg -n -i 'TURNSTILE_SECRET|PII_ENCRYPTION_KEY|PII_HMAC_KEY' dist
+          if rg -n -i 'TURNSTILE_SECRET|PII_ENCRYPTION_KEY|PII_HMAC_KEY' dist; then
+            echo 'Sensitive binding name leaked into the marketing artifact.' >&2
+            exit 1
+          fi
           if [[ "${{ inputs.deployment_class }}" = "production" ]]; then
             rg -F 'challenges.cloudflare.com/turnstile/v0/api.js' dist/index.html
             rg -F 'waitlist_signup' dist/index.html

--- a/.github/workflows/deploy-marketing-preview.yml
+++ b/.github/workflows/deploy-marketing-preview.yml
@@ -29,8 +29,8 @@ jobs:
     env:
       PAGES_PROJECT: lythaus-marketing
       PAGES_BRANCH: ${{ inputs.deployment_class == 'production' && 'main' || 'codex/lythaus-domain-migration' }}
-      PUBLIC_API_BASE_URL: ${{ vars.PRODUCTION_PUBLIC_API_BASE_URL }}
-      PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.PUBLIC_TURNSTILE_SITE_KEY }}
+      PUBLIC_API_BASE_URL: https://api.lythaus.co
+      PUBLIC_TURNSTILE_SITE_KEY: ''
     steps:
       - uses: actions/checkout@v7
         with:
@@ -60,6 +60,13 @@ jobs:
           cache: npm
           cache-dependency-path: apps/marketing-site/package-lock.json
 
+      - name: Resolve production Turnstile sitekey from Cloudflare
+        if: inputs.deployment_class == 'production'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: node scripts/cloudflare/waitlist-turnstile.mjs resolve
+
       - name: Install preview validation prerequisites
         run: |
           sudo apt-get update
@@ -70,15 +77,17 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${{ inputs.deployment_class }}" = "production" ]]; then
-            test -n "$PUBLIC_API_BASE_URL" || { echo "PRODUCTION_PUBLIC_API_BASE_URL is required" >&2; exit 1; }
-            test -n "$PUBLIC_TURNSTILE_SITE_KEY" || { echo "PUBLIC_TURNSTILE_SITE_KEY is required" >&2; exit 1; }
-            node -e "const url = new URL(process.env.PUBLIC_API_BASE_URL); if (url.protocol !== 'https:' || url.hostname !== 'api.lythaus.co' || url.pathname !== '/') throw new Error('PRODUCTION_PUBLIC_API_BASE_URL must be https://api.lythaus.co');"
+            node -e "const url = new URL(process.env.PUBLIC_API_BASE_URL); if (url.protocol !== 'https:' || url.hostname !== 'api.lythaus.co' || url.pathname !== '/') throw new Error('PUBLIC_API_BASE_URL must be https://api.lythaus.co');"
             node -e "if (!/^[A-Za-z0-9_-]{20,}$/.test(process.env.PUBLIC_TURNSTILE_SITE_KEY)) throw new Error('PUBLIC_TURNSTILE_SITE_KEY is invalid');"
           fi
           npm ci
           npm run build
           node ../../scripts/cloudflare/validate-marketing-output.mjs dist
           ! rg -n -i 'TURNSTILE_SECRET|PII_ENCRYPTION_KEY|PII_HMAC_KEY' dist
+          if [[ "${{ inputs.deployment_class }}" = "production" ]]; then
+            rg -F 'challenges.cloudflare.com/turnstile/v0/api.js' dist/index.html
+            rg -F 'waitlist_signup' dist/index.html
+          fi
 
       - name: Deploy exact marketing artifact
         id: deploy
@@ -132,6 +141,10 @@ jobs:
             'Content-Security-Policy:'; do
             rg -F -i "$header" headers.txt
           done
+          if [[ "${{ inputs.deployment_class }}" = "production" ]]; then
+            rg -F 'challenges.cloudflare.com/turnstile/v0/api.js' preview-pages/_root.html
+            rg -F 'waitlist_signup' preview-pages/_root.html
+          fi
 
       - name: Write sanitized preview evidence
         if: success()
@@ -144,8 +157,9 @@ jobs:
             --arg project "$PAGES_PROJECT" \
             --arg branch "$PAGES_BRANCH" \
             --arg previewUrl "$PREVIEW_URL" \
+            --arg turnstileSitekey "$PUBLIC_TURNSTILE_SITE_KEY" \
             --arg createdAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{schemaVersion: 1, commitSha: $commitSha, project: $project, branch: $branch, previewUrl: $previewUrl, routeCount: 10, customDomainsChanged: false, createdAt: $createdAt}' \
+            '{schemaVersion: 1, commitSha: $commitSha, project: $project, branch: $branch, previewUrl: $previewUrl, turnstileSitekey: ($turnstileSitekey | select(length > 0)), routeCount: 10, customDomainsChanged: false, createdAt: $createdAt}' \
             > marketing-preview-evidence.json
 
       - name: Upload preview evidence

--- a/.github/workflows/deploy-public-waitlist.yml
+++ b/.github/workflows/deploy-public-waitlist.yml
@@ -1,0 +1,240 @@
+name: Deploy Lythaus public waitlist
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact reviewed current main SHA to deploy
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lythaus-public-waitlist-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+    env:
+      PUBLIC_WORKER: lythaus-public-api-development
+      PRODUCTION_PUBLIC_API_BASE_URL: https://api.lythaus.co
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Require exact reviewed current main SHA
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full 40-character commit SHA' >&2; exit 1; }
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          test "$(git rev-parse origin/main)" = "$RELEASE_SHA" || {
+            echo 'Refusing production deployment: release_sha is not current origin/main.' >&2
+            exit 1
+          }
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - name: Validate public waitlist release candidate
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ZONE_ID: 7bc572c8b7cd3c00be9c655176c29382
+          CLOUDFLARE_ENVIRONMENT: production
+          MATERIALIZE_PUBLIC_WAITLIST_CONFIG: 'true'
+        run: |
+          set -euo pipefail
+          npm run validate:native-workers
+          npm run validate:native-scope:production
+          npm run validate:planetscale-migrations
+          npm run validate:planetscale-extensions
+          npm run validate:no-retired-provider-dependencies
+          node scripts/ci/materialize-public-waitlist-deploy.mjs
+          npx wrangler types --check apps/lythaus-public-api/src/worker-configuration.d.ts --config apps/lythaus-public-api/wrangler.jsonc
+
+      - name: Prove Hyperdrive targets PlanetScale main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PLANETSCALE_API_TOKEN: ${{ secrets.PLANETSCALE_API_TOKEN }}
+          PLANETSCALE_ORGANIZATION: lythaus
+          PLANETSCALE_DATABASE: lythaus-core
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PLANETSCALE_DEVELOPMENT_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_DEVELOPMENT_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_BRANCH_NAME: main
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/waitlist-cutover"
+          node scripts/ci/verify-cloudflare-hyperdrive-targets.mjs > "$RUNNER_TEMP/waitlist-cutover/hyperdrive-targets.json"
+
+      - name: Verify production schema and waitlist grants read-only
+        env:
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_BRANCH_NAME: main
+          REQUIRE_PRODUCT_INTEGRITY_MIGRATION: 'true'
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+          EXPECTED_DATABASE_SCHEMA_FINGERPRINT: ${{ vars.PRODUCT_INTEGRITY_DATABASE_SCHEMA_FINGERPRINT }}
+          EXPECTED_DATABASE_RELATION_COUNT: ${{ vars.PRODUCT_INTEGRITY_DATABASE_RELATION_COUNT }}
+        run: node scripts/ci/verify-planetscale-production-schema.mjs
+
+      - name: Verify existing public Worker PII secrets are present
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx wrangler secret list --name "$PUBLIC_WORKER" --format json > "$RUNNER_TEMP/public-worker-secrets.json"
+          for required in PII_ENCRYPTION_KEY_V1 PII_HMAC_KEY_V1; do
+            jq -e --arg name "$required" 'any(.[]; .name == $name and .type == "secret_text")' "$RUNNER_TEMP/public-worker-secrets.json" >/dev/null || {
+              echo "Required public Worker secret is missing: $required" >&2
+              exit 1
+            }
+          done
+          rm -f "$RUNNER_TEMP/public-worker-secrets.json"
+
+      - name: Capture predeployment public Worker state
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/waitlist-cutover"
+          npx wrangler deployments status --name "$PUBLIC_WORKER" --json > "$RUNNER_TEMP/waitlist-cutover/public-before.json"
+          node scripts/ci/resolve-worker-version-state.mjs rollback "$RUNNER_TEMP/waitlist-cutover/public-before.json" unused PUBLIC
+          echo 'PUBLIC_ROLLBACK_CAPTURED=true' >> "$GITHUB_ENV"
+
+      - name: Provision or validate production Turnstile widget
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TURNSTILE_SECRET_FILE: ${{ runner.temp }}/waitlist-turnstile-secret.json
+          TURNSTILE_EVIDENCE_PATH: ${{ runner.temp }}/waitlist-cutover/turnstile.json
+        run: node scripts/cloudflare/waitlist-turnstile.mjs ensure
+
+      - name: Upload immutable public Worker candidate
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx wrangler versions upload \
+            --config apps/lythaus-public-api/wrangler.jsonc \
+            --tag "$RELEASE_SHA" \
+            --message "Lythaus public waitlist candidate $RELEASE_SHA" \
+            --secrets-file "$RUNNER_TEMP/waitlist-turnstile-secret.json" \
+            --strict
+          rm -f "$RUNNER_TEMP/waitlist-turnstile-secret.json"
+          npx wrangler versions list --name "$PUBLIC_WORKER" --json > "$RUNNER_TEMP/waitlist-cutover/public-versions.json"
+          node scripts/ci/resolve-latest-worker-version.mjs "$RUNNER_TEMP/waitlist-cutover/public-versions.json" "$RELEASE_SHA" PUBLIC
+
+      - name: Probe candidate without production traffic
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          PRODUCTION_WORKER_SCOPE: lythaus-public-api-development
+          PRODUCTION_WORKER_VERSION_ID: ${{ env.PUBLIC_WORKER_VERSION_ID }}
+          PRODUCTION_PUBLIC_API_BASE_URL: https://api.lythaus.co
+          PRODUCTION_WORKER_EVIDENCE_PATH: ${{ runner.temp }}/waitlist-cutover/public-candidate.json
+        run: node scripts/ci/probe-public-waitlist-candidate.mjs
+
+      - name: Reverify production schema before activation
+        env:
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_BRANCH_NAME: main
+          REQUIRE_PRODUCT_INTEGRITY_MIGRATION: 'true'
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+          EXPECTED_DATABASE_SCHEMA_FINGERPRINT: ${{ vars.PRODUCT_INTEGRITY_DATABASE_SCHEMA_FINGERPRINT }}
+          EXPECTED_DATABASE_RELATION_COUNT: ${{ vars.PRODUCT_INTEGRITY_DATABASE_RELATION_COUNT }}
+        run: node scripts/ci/verify-planetscale-production-schema.mjs
+
+      - name: Activate exact public Worker candidate
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx wrangler versions deploy "${PUBLIC_WORKER_VERSION_ID}@100" \
+            --name "$PUBLIC_WORKER" \
+            --yes \
+            --message "Activate reviewed Lythaus public waitlist $RELEASE_SHA"
+          echo 'PUBLIC_WORKER_DEPLOYED=true' >> "$GITHUB_ENV"
+
+      - name: Verify live route fails closed before browser token
+        shell: bash
+        run: |
+          set -euo pipefail
+          body="$RUNNER_TEMP/waitlist-cutover/live-missing-token.json"
+          headers="$RUNNER_TEMP/waitlist-cutover/live-missing-token.headers"
+          status="$(curl --silent --show-error --max-time 20 \
+            --dump-header "$headers" \
+            --output "$body" \
+            --write-out '%{http_code}' \
+            --request POST 'https://api.lythaus.co/api/waitlist' \
+            --header 'content-type: application/json' \
+            --header 'origin: https://lythaus.co' \
+            --data '{"email":"candidate-probe@example.invalid","turnstileToken":"","consentVersion":"waitlist-v1","source":"lythaus.co"}')"
+          test "$status" = 400
+          jq -e '.error == "turnstile_required"' "$body" >/dev/null
+          grep -F -i 'cache-control: private, no-store' "$headers"
+          grep -F -i 'access-control-allow-origin: https://lythaus.co' "$headers"
+          rm -f "$body" "$headers"
+
+      - name: Write sanitized cutover evidence
+        if: success()
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        shell: bash
+        run: |
+          jq -n \
+            --arg releaseSha "$RELEASE_SHA" \
+            --arg worker "$PUBLIC_WORKER" \
+            --arg versionId "$PUBLIC_WORKER_VERSION_ID" \
+            --arg sitekey "$PUBLIC_TURNSTILE_SITE_KEY" \
+            --arg capturedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{schemaVersion:1,releaseSha:$releaseSha,worker:$worker,workerVersionId:$versionId,turnstileSitekey:$sitekey,status:"activated",capturedAt:$capturedAt}' \
+            > "$RUNNER_TEMP/waitlist-cutover/cutover.json"
+
+      - name: Roll back public Worker on failure
+        if: failure() && env.PUBLIC_WORKER_DEPLOYED == 'true' && env.PUBLIC_ROLLBACK_CAPTURED == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set +e
+          npx wrangler versions deploy $PUBLIC_ROLLBACK_SPECS \
+            --name "$PUBLIC_WORKER" \
+            --yes \
+            --message 'Restore exact pre-waitlist public Worker deployment'
+
+      - name: Remove temporary Turnstile secret material
+        if: always()
+        shell: bash
+        run: rm -f "$RUNNER_TEMP/waitlist-turnstile-secret.json"
+
+      - name: Upload sanitized waitlist cutover evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: public-waitlist-cutover-${{ inputs.release_sha }}
+          path: ${{ runner.temp }}/waitlist-cutover
+          if-no-files-found: warn

--- a/.github/workflows/native-workers-validation.yml
+++ b/.github/workflows/native-workers-validation.yml
@@ -12,6 +12,10 @@ on:
       - 'scripts/validate-no-retired-provider-dependencies.mjs'
       - 'scripts/ci/apply-planetscale-production-migrations.mjs'
       - 'scripts/ci/verify-planetscale-production-schema.mjs'
+      - 'scripts/ci/materialize-public-waitlist-deploy.mjs'
+      - 'scripts/ci/probe-public-waitlist-candidate.mjs'
+      - 'scripts/ci/resolve-latest-worker-version.mjs'
+      - 'scripts/cloudflare/waitlist-turnstile.mjs'
       - 'scripts/validate-production-gates.mjs'
       - 'infrastructure/cloudflare/production-gates.json'
       - 'scripts/validate-planetscale-extensions.mjs'
@@ -28,12 +32,15 @@ on:
       - 'scripts/tests/native-architecture-invariants.test.js'
       - 'scripts/tests/production-gates.test.mjs'
       - 'scripts/tests/product-integrity-runtime-invariants.test.mjs'
+      - 'scripts/tests/public-waitlist-cutover.test.mjs'
       - 'scripts/critical-coverage-gate.mjs'
       - 'scripts/critical-coverage-manifest.json'
       - 'tsconfig.native.json'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/native-workers-validation.yml'
+      - '.github/workflows/deploy-public-waitlist.yml'
+      - '.github/workflows/deploy-marketing-preview.yml'
   push:
     branches: [main, development]
     paths:
@@ -44,6 +51,10 @@ on:
       - 'scripts/validate-no-retired-provider-dependencies.mjs'
       - 'scripts/ci/apply-planetscale-production-migrations.mjs'
       - 'scripts/ci/verify-planetscale-production-schema.mjs'
+      - 'scripts/ci/materialize-public-waitlist-deploy.mjs'
+      - 'scripts/ci/probe-public-waitlist-candidate.mjs'
+      - 'scripts/ci/resolve-latest-worker-version.mjs'
+      - 'scripts/cloudflare/waitlist-turnstile.mjs'
       - 'scripts/validate-production-gates.mjs'
       - 'infrastructure/cloudflare/production-gates.json'
       - 'scripts/validate-planetscale-extensions.mjs'
@@ -59,11 +70,15 @@ on:
       - 'scripts/tests/native-architecture-invariants.test.js'
       - 'scripts/tests/production-gates.test.mjs'
       - 'scripts/tests/product-integrity-runtime-invariants.test.mjs'
+      - 'scripts/tests/public-waitlist-cutover.test.mjs'
       - 'scripts/critical-coverage-gate.mjs'
       - 'scripts/critical-coverage-manifest.json'
       - 'tsconfig.native.json'
       - 'package.json'
       - 'package-lock.json'
+      - '.github/workflows/native-workers-validation.yml'
+      - '.github/workflows/deploy-public-waitlist.yml'
+      - '.github/workflows/deploy-marketing-preview.yml'
 
 permissions:
   contents: read
@@ -90,6 +105,7 @@ jobs:
       - run: npm run test:native-architecture
       - run: node --test scripts/tests/production-gates.test.mjs
       - run: npm run test:product-integrity-runtime
+      - run: node --test scripts/tests/public-waitlist-cutover.test.mjs
       - run: npm run test:critical-coverage
       - run: npm run test:database-identity
       - run: npm run test:budget

--- a/scripts/ci/materialize-public-waitlist-deploy.mjs
+++ b/scripts/ci/materialize-public-waitlist-deploy.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import { approvedPost0013Expectation } from './product-integrity-schema-contract.mjs';
+
+const configPath = 'apps/lythaus-public-api/wrangler.jsonc';
+const materialize = process.env.MATERIALIZE_PUBLIC_WAITLIST_CONFIG === 'true';
+const expectation = approvedPost0013Expectation(
+  process.env.PRODUCT_INTEGRITY_DATABASE_SCHEMA_FINGERPRINT ?? '',
+  process.env.PRODUCT_INTEGRITY_DATABASE_RELATION_COUNT ?? '',
+);
+
+const fingerprintPlaceholder = 'REPLACE_WITH_POST_0013_SCHEMA_FINGERPRINT';
+const relationCountPlaceholder = 'REPLACE_WITH_POST_0013_RELATION_COUNT';
+
+function productionValue(source, key) {
+  const production = source.slice(0, source.indexOf('"env"') === -1 ? source.length : source.indexOf('"env"'));
+  return production.match(new RegExp(`"${key}"\\s*:\\s*"([^"]+)"`))?.[1] ?? '';
+}
+
+const committedSource = fs.readFileSync(configPath, 'utf8');
+if (productionValue(committedSource, 'EXPECTED_DATABASE_SCHEMA_FINGERPRINT') !== fingerprintPlaceholder) {
+  throw new Error('public Worker must retain the canonical database fingerprint placeholder before release materialization');
+}
+if (productionValue(committedSource, 'EXPECTED_DATABASE_RELATION_COUNT') !== relationCountPlaceholder) {
+  throw new Error('public Worker must retain the canonical database relation-count placeholder before release materialization');
+}
+if (productionValue(committedSource, 'EXPECTED_DATABASE_SCHEMA_VERSION') !== '0013_marketing_waitlist.sql') {
+  throw new Error('public waitlist deployment requires migration 0013');
+}
+if (productionValue(committedSource, 'EXPECTED_DATABASE_BUDGET_LEDGER_APPLIED') !== 'true') {
+  throw new Error('public waitlist deployment requires the production budget ledger');
+}
+if (productionValue(committedSource, 'EXPECTED_DATABASE_TARGET') !== 'main') {
+  throw new Error('public waitlist deployment must target PlanetScale main');
+}
+if (productionValue(committedSource, 'TURNSTILE_REQUIRED') !== 'true') {
+  throw new Error('public waitlist deployment must require Turnstile');
+}
+if (productionValue(committedSource, 'TURNSTILE_EXPECTED_HOSTNAMES') !== 'lythaus.co,www.lythaus.co') {
+  throw new Error('public waitlist Turnstile hostnames do not match the approved production contract');
+}
+if (productionValue(committedSource, 'HYPERDRIVE_QUERY_CACHE_MODE') !== 'disabled') {
+  throw new Error('public waitlist deployment requires Hyperdrive query caching to remain disabled');
+}
+const origins = new Set(productionValue(committedSource, 'CORS_ALLOWED_ORIGINS').split(',').map((value) => value.trim()).filter(Boolean));
+for (const requiredOrigin of ['https://lythaus.co', 'https://www.lythaus.co', 'https://app.lythaus.co']) {
+  if (!origins.has(requiredOrigin)) throw new Error(`public waitlist CORS is missing ${requiredOrigin}`);
+}
+
+const source = committedSource
+  .replace(`"${fingerprintPlaceholder}"`, `"${expectation.fingerprint}"`)
+  .replace(`"${relationCountPlaceholder}"`, `"${expectation.relationCount}"`);
+
+if (productionValue(source, 'EXPECTED_DATABASE_SCHEMA_FINGERPRINT') !== expectation.fingerprint) {
+  throw new Error('public waitlist database fingerprint materialization failed');
+}
+if (productionValue(source, 'EXPECTED_DATABASE_RELATION_COUNT') !== String(expectation.relationCount)) {
+  throw new Error('public waitlist database relation-count materialization failed');
+}
+if (productionValue(source, 'AUTHENTICATED_ACCEPTANCE_PROVEN') !== 'false') {
+  throw new Error('public waitlist cutover must not falsely assert full authenticated acceptance');
+}
+if (/REPLACE_WITH_POST_0013_/.test(source.slice(0, source.indexOf('"env"')))) {
+  throw new Error('public waitlist production database identity contains an unresolved placeholder');
+}
+
+if (materialize) fs.writeFileSync(configPath, source, 'utf8');
+console.log(JSON.stringify({
+  status: 'pass',
+  materialized: materialize,
+  schemaVersion: '0013_marketing_waitlist.sql',
+  relationCount: expectation.relationCount,
+  fingerprint: expectation.fingerprint,
+  authenticatedAcceptanceProven: false,
+}));

--- a/scripts/ci/probe-public-waitlist-candidate.mjs
+++ b/scripts/ci/probe-public-waitlist-candidate.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const releaseSha = process.env.RELEASE_SHA ?? '';
+const workerName = process.env.PRODUCTION_WORKER_SCOPE ?? 'lythaus-public-api-development';
+const workerVersionId = process.env.PRODUCTION_WORKER_VERSION_ID ?? '';
+const baseUrl = process.env.PRODUCTION_PUBLIC_API_BASE_URL || 'https://api.lythaus.co';
+const evidencePath = process.env.PRODUCTION_WORKER_EVIDENCE_PATH ?? '';
+
+if (!/^[0-9a-f]{40}$/.test(releaseSha)) throw new Error('RELEASE_SHA must be the exact merged main commit');
+if (workerName !== 'lythaus-public-api-development') throw new Error('public waitlist probe requires the canonical public Worker');
+if (!/^[0-9a-f-]{36}$/i.test(workerVersionId)) throw new Error('PRODUCTION_WORKER_VERSION_ID is required');
+const base = new URL(baseUrl);
+if (base.protocol !== 'https:' || base.hostname !== 'api.lythaus.co' || base.pathname !== '/') {
+  throw new Error('PRODUCTION_PUBLIC_API_BASE_URL must be https://api.lythaus.co');
+}
+
+function versionHeaders(extra = {}) {
+  return {
+    ...extra,
+    'Cloudflare-Workers-Version-Overrides': `${workerName}="${workerVersionId}"`,
+  };
+}
+
+async function request(path, init = {}) {
+  return fetch(new URL(path, base), {
+    ...init,
+    headers: versionHeaders(init.headers),
+    signal: AbortSignal.timeout(15_000),
+  });
+}
+
+for (const path of ['/health', '/ready']) {
+  const response = await request(path, { headers: { accept: 'application/json' } });
+  if (!response.ok) throw new Error(`${path} returned HTTP ${response.status}`);
+}
+
+const routeProbe = await request('/api/waitlist', {
+  method: 'POST',
+  headers: {
+    accept: 'application/json',
+    'content-type': 'application/json',
+    origin: 'https://lythaus.co',
+  },
+  body: JSON.stringify({
+    email: 'candidate-probe@example.invalid',
+    turnstileToken: '',
+    consentVersion: 'waitlist-v1',
+    source: 'lythaus.co',
+  }),
+});
+const routeBody = await routeProbe.json().catch(() => null);
+if (routeProbe.status !== 400 || routeBody?.error !== 'turnstile_required') {
+  throw new Error('candidate /api/waitlist did not fail closed on a missing Turnstile token');
+}
+if (routeProbe.headers.get('cache-control') !== 'private, no-store') {
+  throw new Error('candidate /api/waitlist error response must be private, no-store');
+}
+if (routeProbe.headers.get('access-control-allow-origin') !== 'https://lythaus.co') {
+  throw new Error('candidate /api/waitlist CORS contract failed');
+}
+if (!routeProbe.headers.get('x-correlation-id')) {
+  throw new Error('candidate /api/waitlist response is missing the correlation identifier');
+}
+
+const evidence = {
+  schemaVersion: 1,
+  releaseSha,
+  worker: workerName,
+  workerVersionId,
+  baseUrl: base.origin,
+  health: 'pass',
+  ready: 'pass',
+  waitlistRoute: 'present_fail_closed',
+  turnstileMissingTokenStatus: routeProbe.status,
+  cacheControl: routeProbe.headers.get('cache-control'),
+  corsOrigin: routeProbe.headers.get('access-control-allow-origin'),
+  capturedAt: new Date().toISOString(),
+};
+if (evidencePath) fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+console.log(JSON.stringify({ status: 'pass', worker: workerName, workerVersionId, waitlistRoute: evidence.waitlistRoute }));

--- a/scripts/ci/resolve-latest-worker-version.mjs
+++ b/scripts/ci/resolve-latest-worker-version.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const [inputPath, expectedTag, variablePrefix] = process.argv.slice(2);
+const githubEnv = process.env.GITHUB_ENV ?? '';
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+if (!inputPath || !/^[0-9a-f]{40}$/.test(expectedTag ?? '') || !/^[A-Z][A-Z0-9_]*$/.test(variablePrefix ?? '')) {
+  throw new Error('usage: resolve-latest-worker-version.mjs <versions.json> <release-sha> <VARIABLE_PREFIX>');
+}
+if (!githubEnv) throw new Error('GITHUB_ENV is required');
+
+const versions = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+if (!Array.isArray(versions)) throw new Error('Worker version list must be an array');
+const matches = versions.filter((version) => version?.annotations?.['workers/tag'] === expectedTag);
+if (matches.length === 0) throw new Error(`no Worker version is tagged ${expectedTag}`);
+const latest = [...matches].sort((left, right) => {
+  const leftTime = Date.parse(left?.created_on ?? left?.createdAt ?? left?.created_at ?? '');
+  const rightTime = Date.parse(right?.created_on ?? right?.createdAt ?? right?.created_at ?? '');
+  if (!Number.isFinite(leftTime) || !Number.isFinite(rightTime)) return 0;
+  return rightTime - leftTime;
+})[0];
+if (!uuid.test(latest?.id ?? '')) throw new Error('latest tagged Worker version has an invalid ID');
+fs.appendFileSync(githubEnv, `${variablePrefix}_WORKER_VERSION_ID=${latest.id}\n`, 'utf8');
+console.log(JSON.stringify({ status: 'pass', variablePrefix, versionId: latest.id, releaseSha: expectedTag, matchingVersions: matches.length }));

--- a/scripts/cloudflare/waitlist-turnstile.mjs
+++ b/scripts/cloudflare/waitlist-turnstile.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const command = process.argv[2] ?? 'resolve';
+if (!['ensure', 'resolve'].includes(command)) throw new Error('usage: waitlist-turnstile.mjs <ensure|resolve>');
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
+const apiToken = process.env.CLOUDFLARE_API_TOKEN ?? '';
+const githubEnv = process.env.GITHUB_ENV ?? '';
+const evidencePath = process.env.TURNSTILE_EVIDENCE_PATH ?? '';
+const secretFile = process.env.TURNSTILE_SECRET_FILE ?? '';
+
+const widgetName = 'Lythaus Website Waitlist';
+const expectedDomains = Object.freeze(['lythaus.co', 'www.lythaus.co']);
+const expectedMode = 'managed';
+const apiBase = `https://api.cloudflare.com/client/v4/accounts/${accountId}/challenges/widgets`;
+
+if (!/^[0-9a-f]{32}$/.test(accountId)) throw new Error('CLOUDFLARE_ACCOUNT_ID is invalid');
+if (!apiToken) throw new Error('CLOUDFLARE_API_TOKEN is required');
+if (command === 'ensure' && !secretFile) throw new Error('TURNSTILE_SECRET_FILE is required for ensure');
+
+function normalizedDomains(domains) {
+  if (!Array.isArray(domains)) return [];
+  return domains
+    .map((value) => typeof value === 'string' ? value : value?.name ?? value?.domain ?? '')
+    .map((value) => String(value).trim().toLowerCase())
+    .filter(Boolean)
+    .sort();
+}
+
+function sameValues(left, right) {
+  return JSON.stringify([...left].sort()) === JSON.stringify([...right].sort());
+}
+
+async function cloudflare(path = '', init = {}) {
+  const headers = new Headers(init.headers);
+  headers.set('authorization', `Bearer ${apiToken}`);
+  if (init.body) headers.set('content-type', 'application/json');
+  const response = await fetch(`${apiBase}${path}`, {
+    ...init,
+    headers,
+    signal: AbortSignal.timeout(20_000),
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.success !== true) {
+    const codes = Array.isArray(payload?.errors)
+      ? payload.errors.map((error) => error?.code).filter((value) => value !== undefined).join(',')
+      : '';
+    throw new Error(`Cloudflare Turnstile API request failed (${response.status}${codes ? `; codes=${codes}` : ''})`);
+  }
+  return payload.result;
+}
+
+async function listExactWidgets() {
+  const query = new URLSearchParams({ per_page: '1000', filter: `name:${widgetName}` });
+  const result = await cloudflare(`?${query}`);
+  if (!Array.isArray(result)) throw new Error('Cloudflare Turnstile list response is invalid');
+  return result.filter((widget) => widget?.name === widgetName);
+}
+
+function validateWidget(widget) {
+  const sitekey = typeof widget?.sitekey === 'string' ? widget.sitekey : '';
+  if (!/^[A-Za-z0-9_-]{20,64}$/.test(sitekey)) throw new Error('production waitlist Turnstile sitekey is invalid');
+  if (widget?.name !== widgetName) throw new Error('production waitlist Turnstile widget name mismatch');
+  if (widget?.mode !== expectedMode) throw new Error('production waitlist Turnstile widget must use managed mode');
+  const domains = normalizedDomains(widget?.domains);
+  if (!sameValues(domains, expectedDomains)) {
+    throw new Error('production waitlist Turnstile widget hostnames do not match the approved contract');
+  }
+  return { sitekey, domains };
+}
+
+let created = false;
+let matches = await listExactWidgets();
+if (matches.length > 1) throw new Error('multiple production waitlist Turnstile widgets have the approved display name');
+
+if (matches.length === 0) {
+  if (command !== 'ensure') throw new Error('production waitlist Turnstile widget does not exist');
+  const createdWidget = await cloudflare('', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: widgetName,
+      domains: expectedDomains,
+      mode: expectedMode,
+      clearance_level: 'no_clearance',
+    }),
+  });
+  matches = [createdWidget];
+  created = true;
+}
+
+const listed = matches[0];
+const sitekey = listed?.sitekey;
+const detailed = await cloudflare(`/${encodeURIComponent(sitekey)}`);
+const { domains } = validateWidget(detailed);
+const secret = typeof detailed?.secret === 'string' ? detailed.secret : '';
+
+if (command === 'ensure') {
+  if (!secret) throw new Error('Cloudflare did not return the production Turnstile secret');
+  fs.writeFileSync(secretFile, `${JSON.stringify({ TURNSTILE_SECRET_KEY: secret })}\n`, { encoding: 'utf8', mode: 0o600 });
+  fs.chmodSync(secretFile, 0o600);
+}
+
+if (githubEnv) fs.appendFileSync(githubEnv, `PUBLIC_TURNSTILE_SITE_KEY=${detailed.sitekey}\n`, 'utf8');
+
+const evidence = {
+  schemaVersion: 1,
+  widgetName,
+  sitekey: detailed.sitekey,
+  mode: detailed.mode,
+  domains,
+  created,
+  lifecycle: 'active',
+  capturedAt: new Date().toISOString(),
+};
+if (evidencePath) fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+console.log(JSON.stringify({ status: 'pass', widgetName, sitekey: detailed.sitekey, mode: detailed.mode, domains, created }));

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const turnstile = fs.readFileSync('scripts/cloudflare/waitlist-turnstile.mjs', 'utf8');
+const materializer = fs.readFileSync('scripts/ci/materialize-public-waitlist-deploy.mjs', 'utf8');
+const probe = fs.readFileSync('scripts/ci/probe-public-waitlist-candidate.mjs', 'utf8');
+const cutover = fs.readFileSync('.github/workflows/deploy-public-waitlist.yml', 'utf8');
+const marketing = fs.readFileSync('.github/workflows/deploy-marketing-preview.yml', 'utf8');
+
+test('Turnstile provisioning is exact, idempotent, and secret-safe', () => {
+  assert.match(turnstile, /Lythaus Website Waitlist/);
+  assert.match(turnstile, /lythaus\.co/);
+  assert.match(turnstile, /www\.lythaus\.co/);
+  assert.match(turnstile, /expectedMode = 'managed'/);
+  assert.match(turnstile, /clearance_level: 'no_clearance'/);
+  assert.match(turnstile, /multiple production waitlist Turnstile widgets/);
+  assert.match(turnstile, /TURNSTILE_SECRET_FILE/);
+  assert.doesNotMatch(turnstile, /console\.log\([^\n]*secret/);
+});
+
+test('public materializer keeps full authenticated acceptance fail closed', () => {
+  assert.match(materializer, /0013_marketing_waitlist\.sql/);
+  assert.match(materializer, /TURNSTILE_REQUIRED/);
+  assert.match(materializer, /lythaus\.co,www\.lythaus\.co/);
+  assert.match(materializer, /AUTHENTICATED_ACCEPTANCE_PROVEN/);
+  assert.match(materializer, /must not falsely assert full authenticated acceptance/);
+});
+
+test('candidate probe proves the route exists without writing a signup', () => {
+  assert.match(probe, /candidate-probe@example\.invalid/);
+  assert.match(probe, /turnstileToken: ''/);
+  assert.match(probe, /routeProbe\.status !== 400/);
+  assert.match(probe, /turnstile_required/);
+  assert.match(probe, /private, no-store/);
+  assert.match(probe, /access-control-allow-origin/);
+});
+
+test('protected cutover verifies database, preserves secrets, and has rollback', () => {
+  assert.match(cutover, /environment: production/);
+  assert.match(cutover, /Require exact reviewed current main SHA/);
+  assert.match(cutover, /PSCALE_ROLE_IDENTIFIERS: \$\{\{ secrets\.PSCALE_ROLE_IDENTIFIERS \}\}/);
+  assert.match(cutover, /verify-planetscale-production-schema\.mjs/);
+  assert.match(cutover, /verify-cloudflare-hyperdrive-targets\.mjs/);
+  assert.match(cutover, /PII_ENCRYPTION_KEY_V1 PII_HMAC_KEY_V1/);
+  assert.match(cutover, /waitlist-turnstile\.mjs ensure/);
+  assert.match(cutover, /--secrets-file/);
+  assert.match(cutover, /probe-public-waitlist-candidate\.mjs/);
+  assert.match(cutover, /Restore exact pre-waitlist public Worker deployment/);
+});
+
+test('production marketing resolves the public sitekey from Cloudflare', () => {
+  assert.match(marketing, /PUBLIC_API_BASE_URL: https:\/\/api\.lythaus\.co/);
+  assert.match(marketing, /waitlist-turnstile\.mjs resolve/);
+  assert.match(marketing, /challenges\.cloudflare\.com\/turnstile\/v0\/api\.js/);
+  assert.match(marketing, /waitlist_signup/);
+  assert.doesNotMatch(marketing, /vars\.PUBLIC_TURNSTILE_SITE_KEY/);
+});


### PR DESCRIPTION
Closes #563 after production acceptance.

This change introduces a narrowly scoped public-waitlist cutover instead of weakening the full native three-Worker deployment gate.

Key changes:
- idempotent Cloudflare Turnstile provisioning/validation for `Lythaus Website Waitlist`;
- canonical post-0013 materialization for the public Worker only, while keeping full authenticated-acceptance readiness fail closed;
- protected exact-main-SHA public Worker workflow with PlanetScale read-only schema/grant verification, Hyperdrive-main verification, existing PII-secret inventory checks, candidate version probing, activation, rollback and sanitized evidence;
- production marketing deployment resolves the public Turnstile sitekey directly from Cloudflare rather than relying on a manually copied GitHub variable;
- regression coverage and native validation path coverage.

No migration SQL, Access policy, admin Worker, jobs Worker, database DDL or public PII logging is changed.