### PR TITLE
fix: unblock protected waitlist cutover type validation

### DIFF
--- a/.github/workflows/deploy-public-waitlist.yml
+++ b/.github/workflows/deploy-public-waitlist.yml
@@ -63,8 +63,8 @@ jobs:
           npm run validate:planetscale-migrations
           npm run validate:planetscale-extensions
           npm run validate:no-retired-provider-dependencies
-          node scripts/ci/materialize-public-waitlist-deploy.mjs
           npx wrangler types --check apps/lythaus-public-api/src/worker-configuration.d.ts --config apps/lythaus-public-api/wrangler.jsonc
+          node scripts/ci/materialize-public-waitlist-deploy.mjs
 
       - name: Prove Hyperdrive targets PlanetScale main
         env:

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -47,6 +47,9 @@ test('protected cutover verifies database, preserves secrets, and has rollback',
   assert.match(cutover, /--secrets-file/);
   assert.match(cutover, /probe-public-waitlist-candidate\.mjs/);
   assert.match(cutover, /Restore exact pre-waitlist public Worker deployment/);
+  const typesCheck = cutover.indexOf('wrangler types --check');
+  const materialize = cutover.indexOf('materialize-public-waitlist-deploy.mjs');
+  assert.ok(typesCheck >= 0 && materialize >= 0 && typesCheck < materialize, 'Wrangler types must be checked before deployment-only config materialization');
 });
 
 test('production marketing resolves the public sitekey from Cloudflare', () => {


### PR DESCRIPTION
The first protected `Deploy Lythaus public waitlist` run failed before any Cloudflare or PlanetScale mutation because the workflow materialized production-only literal values into `wrangler.jsonc` before running `wrangler types --check` against the committed pre-materialization type file.

This PR reorders those two operations so Wrangler validates the committed configuration contract first, then the deployment-only materializer substitutes the canonical post-0013 database identity. Regression coverage asserts this order.

No Turnstile widget, Worker version, traffic allocation, database schema, marketing copy, Access policy, or secret value is changed by this PR.