### PR TITLE
fix: expose safe Cloudflare Hyperdrive cutover diagnostics

### DIFF
--- a/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
+++ b/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
@@ -64,18 +64,54 @@ if (mainOrigin.scheme !== 'postgres' || !mainOrigin.host.endsWith('.psdb.cloud')
 const mainFingerprint = fingerprint(mainOrigin);
 if (mainFingerprint !== manifest.expectedMainOriginFingerprint) throw new Error('PlanetScale main origin fingerprint changed without a reviewed manifest update');
 
-async function cloudflareConfig(id) {
-  const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/hyperdrive/configs/${id}`, {
+function sanitizeCloudflareErrors(envelope) {
+  return Array.isArray(envelope?.errors)
+    ? envelope.errors.map((error) => ({
+        code: error?.code ?? null,
+        message: typeof error?.message === 'string' ? error.message.slice(0, 240) : null,
+      }))
+    : [];
+}
+
+async function cloudflareRequest(resourcePath) {
+  const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}${resourcePath}`, {
     headers: { authorization: `Bearer ${apiToken}`, accept: 'application/json' },
   });
-  const envelope = await response.json();
-  if (!response.ok || envelope.success !== true || !envelope.result) throw new Error(`Cloudflare Hyperdrive lookup failed for ${id}`);
-  return envelope.result;
+  let envelope = null;
+  try {
+    envelope = await response.json();
+  } catch {
+    envelope = null;
+  }
+  return { response, envelope };
+}
+
+async function cloudflareConfig(id, expectedConfigName) {
+  const lookup = await cloudflareRequest(`/hyperdrive/configs/${id}`);
+  if (lookup.response.ok && lookup.envelope?.success === true && lookup.envelope?.result) return lookup.envelope.result;
+
+  const list = await cloudflareRequest('/hyperdrive/configs?per_page=100');
+  const nameMatches = list.response.ok && list.envelope?.success === true && Array.isArray(list.envelope?.result)
+    ? list.envelope.result
+        .filter((config) => config?.name === expectedConfigName)
+        .map((config) => ({ id: config?.id ?? null, name: config?.name ?? null }))
+    : [];
+
+  const diagnostic = {
+    requestedId: id,
+    expectedConfigName,
+    lookupStatus: lookup.response.status,
+    lookupErrors: sanitizeCloudflareErrors(lookup.envelope),
+    listStatus: list.response.status,
+    listErrors: sanitizeCloudflareErrors(list.envelope),
+    nameMatches,
+  };
+  throw new Error(`Cloudflare Hyperdrive lookup failed: ${JSON.stringify(diagnostic)}`);
 }
 
 const results = [];
 for (const entry of manifest.bindings) {
-  const config = await cloudflareConfig(entry.hyperdriveId);
+  const config = await cloudflareConfig(entry.hyperdriveId, entry.expectedConfigName);
   const origin = config.origin ?? {};
   const observedFingerprint = fingerprint(origin);
   const cacheDisabled = config.caching?.disabled === true;

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -52,6 +52,11 @@ test('protected cutover verifies database, preserves secrets, and has rollback',
   assert.doesNotMatch(cutover, /PLANETSCALE_API_TOKEN/);
   assert.match(hyperdriveProof, /manifest\.expectedMainOriginFingerprint/);
   assert.match(hyperdriveProof, /observedFingerprint === mainFingerprint/);
+  assert.match(hyperdriveProof, /sanitizeCloudflareErrors/);
+  assert.match(hyperdriveProof, /lookupStatus: lookup\.response\.status/);
+  assert.match(hyperdriveProof, /listStatus: list\.response\.status/);
+  assert.match(hyperdriveProof, /nameMatches/);
+  assert.match(hyperdriveProof, /expectedConfigName/);
   assert.doesNotMatch(hyperdriveProof, /PLANETSCALE_DEVELOPMENT_SCHEMA_READ_DATABASE_URL/);
   assert.doesNotMatch(hyperdriveProof, /PLANETSCALE_API_TOKEN/);
   const typesCheck = cutover.indexOf('wrangler types --check');


### PR DESCRIPTION
The protected waitlist cutover run #3 fails safely before any production mutation at the first Cloudflare Hyperdrive GET, but the verifier currently discards Cloudflare's HTTP status and API error envelope.

This PR keeps the gate fail-closed and secret-safe while making the next protected run decisive:
- records only Cloudflare HTTP status plus whitelisted error code/message;
- performs a read-only Hyperdrive list lookup after a failed ID lookup;
- reports only unique ID/name matches for the reviewed expected config name;
- never prints API tokens, database credentials, usernames, passwords or connection strings;
- never auto-substitutes a different Hyperdrive ID;
- adds regression assertions for the sanitized diagnostics.

No Cloudflare, PlanetScale, Worker, Turnstile, routing, secret or database state is mutated by this PR.