### PR TITLE
fix: include views in PlanetScale schema verifier fingerprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "validate:planetscale-production-script": "node --check scripts/ci/apply-planetscale-production-migrations.mjs",
     "apply:planetscale-production-migrations": "node scripts/ci/apply-planetscale-production-migrations.mjs",
     "reconcile:planetscale-migrations": "node scripts/ci/reconcile-planetscale-migration-state.mjs",
-    "test:planetscale-production-migrations": "node --test scripts/tests/planetscale-production-migrations.test.mjs"
+    "test:planetscale-production-migrations": "node --test scripts/tests/planetscale-production-migrations.test.mjs scripts/tests/planetscale-schema-verifier-views.test.mjs"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.25.0",
@@ -77,7 +77,7 @@
     "glob": "^13.0.6",
     "husky": "^8.0.3",
     "jest": "^30.4.2",
-    "jsonpointer": "^5.0.1",
+    "jsonpointer": "^1.0.1",
     "oasdiff": "file:tools/openapi/oasdiff",
     "openapi-client-axios": "^7.7.0",
     "playwright": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "glob": "^13.0.6",
     "husky": "^8.0.3",
     "jest": "^30.4.2",
-    "jsonpointer": "^1.0.1",
+    "jsonpointer": "^5.0.1",
     "oasdiff": "file:tools/openapi/oasdiff",
     "openapi-client-axios": "^7.7.0",
     "playwright": "^1.60.0",

--- a/scripts/ci/reconcile-planetscale-schema-verifier.mjs
+++ b/scripts/ci/reconcile-planetscale-schema-verifier.mjs
@@ -53,11 +53,14 @@ try {
   if (adminIdentity.rows[0]?.role === verifierRole) throw new Error('schema verifier credential must be distinct from the migration/admin credential');
   if (adminIdentity.rows[0]?.database !== 'postgres') throw new Error('migration/admin credential must target the postgres database');
 
+  // information_schema.tables is privilege-filtered. Grant a non-row-reading
+  // table privilege to every table/view relation that can contribute to the
+  // canonical schema fingerprint, including ordinary views (relkind = v).
   const relations = await admin.query(`SELECT namespace.nspname AS schema_name, relation.relname AS relation_name
     FROM pg_class relation
     JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
     WHERE namespace.nspname = ANY($1::text[])
-      AND relation.relkind IN ('r', 'p')
+      AND relation.relkind IN ('r', 'p', 'v', 'f')
     ORDER BY namespace.nspname, relation.relname`, [APPLICATION_SCHEMAS]);
 
   const roleSql = quoteIdentifier(verifierRole);
@@ -91,17 +94,24 @@ try {
   const checks = await proof.query(`SELECT
     has_schema_privilege(current_user, 'marketing', 'USAGE') AS marketing_usage,
     has_table_privilege(current_user, 'marketing.waitlist_signups', 'REFERENCES') AS waitlist_metadata,
+    has_table_privilege(current_user, 'media.storage_ledgers', 'REFERENCES') AS storage_ledgers_metadata,
     has_table_privilege(current_user, 'system.schema_migrations', 'SELECT') AS migration_registry_read,
     EXISTS (
       SELECT 1 FROM information_schema.tables
-      WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups'
+      WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND table_type = 'BASE TABLE'
     ) AS waitlist_visible,
+    EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'media' AND table_name = 'storage_ledgers' AND table_type = 'VIEW'
+    ) AS storage_ledgers_visible,
     EXISTS (
       SELECT 1 FROM information_schema.columns
       WHERE table_schema = 'marketing' AND table_name = 'waitlist_signups' AND column_name = 'email_lookup_hmac'
     ) AS waitlist_columns_visible`);
   const row = checks.rows[0];
-  if (!row?.marketing_usage || !row.waitlist_metadata || !row.migration_registry_read || !row.waitlist_visible || !row.waitlist_columns_visible) {
+  if (!row?.marketing_usage || !row.waitlist_metadata || !row.storage_ledgers_metadata
+    || !row.migration_registry_read || !row.waitlist_visible || !row.storage_ledgers_visible
+    || !row.waitlist_columns_visible) {
     throw new Error('dedicated schema verifier metadata grant contract failed');
   }
   console.log(`Reconciled dedicated PlanetScale schema verifier metadata grants across ${APPLICATION_SCHEMAS.length} application schemas.`);

--- a/scripts/ci/reconcile-planetscale-schema-verifier.mjs
+++ b/scripts/ci/reconcile-planetscale-schema-verifier.mjs
@@ -55,12 +55,12 @@ try {
 
   // information_schema.tables is privilege-filtered. Grant a non-row-reading
   // table privilege to every table/view relation that can contribute to the
-  // canonical schema fingerprint, including ordinary views (relkind = v).
+  // canonical schema fingerprint: ordinary tables, partitioned tables and views.
   const relations = await admin.query(`SELECT namespace.nspname AS schema_name, relation.relname AS relation_name
     FROM pg_class relation
     JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
     WHERE namespace.nspname = ANY($1::text[])
-      AND relation.relkind IN ('r', 'p', 'v', 'f')
+      AND relation.relkind IN ('r', 'p', 'v')
     ORDER BY namespace.nspname, relation.relname`, [APPLICATION_SCHEMAS]);
 
   const roleSql = quoteIdentifier(verifierRole);

--- a/scripts/ci/verify-planetscale-production-schema.mjs
+++ b/scripts/ci/verify-planetscale-production-schema.mjs
@@ -34,38 +34,38 @@ if (connection.searchParams.get('sslrootcert') === 'system') connection.searchPa
 
 async function schemaContract(client, registryRows) {
   const schemaParams = APPLICATION_SCHEMAS.map((_, index) => `$${index + 1}`).join(', ');
-  const [relations, columns, constraints, indexes, functions, extensions] = await Promise.all([
-    client.query(`SELECT table_type, table_schema, table_name
-      FROM information_schema.tables
-      WHERE table_schema IN (${schemaParams})
-      ORDER BY table_type, table_schema, table_name`, APPLICATION_SCHEMAS),
-    client.query(`SELECT table_schema, table_name, ordinal_position, column_name, udt_name, is_nullable, COALESCE(column_default, '') AS column_default
-      FROM information_schema.columns
-      WHERE table_schema IN (${schemaParams})
-      ORDER BY table_schema, table_name, ordinal_position`, APPLICATION_SCHEMAS),
-    client.query(`SELECT namespace.nspname AS table_schema, relation.relname AS table_name,
-        constraint_row.conname, constraint_row.contype, constraint_row.convalidated,
-        pg_get_constraintdef(constraint_row.oid, true) AS definition
-      FROM pg_constraint constraint_row
-      JOIN pg_class relation ON relation.oid = constraint_row.conrelid
-      JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
-      WHERE namespace.nspname IN (${schemaParams})
-      ORDER BY namespace.nspname, relation.relname, constraint_row.conname`, APPLICATION_SCHEMAS),
-    client.query(`SELECT schemaname, tablename, indexname, indexdef
-      FROM pg_indexes
-      WHERE schemaname IN (${schemaParams})
-      ORDER BY schemaname, tablename, indexname`, APPLICATION_SCHEMAS),
-    client.query(`SELECT namespace.nspname AS function_schema, procedure.proname,
-        pg_get_function_identity_arguments(procedure.oid) AS arguments,
-        pg_get_function_result(procedure.oid) AS result_type,
-        procedure.prosecdef,
-        COALESCE(array_to_string(procedure.proconfig, ','), '') AS configuration
-      FROM pg_proc procedure
-      JOIN pg_namespace namespace ON namespace.oid = procedure.pronamespace
-      WHERE namespace.nspname IN (${schemaParams})
-      ORDER BY namespace.nspname, procedure.proname, arguments`, APPLICATION_SCHEMAS),
-    client.query('SELECT extname, extversion FROM pg_extension ORDER BY extname'),
-  ]);
+  // Keep a single pg.Client strictly sequential. Concurrent client.query()
+  // calls are deprecated by node-postgres and will be rejected in pg@9.
+  const relations = await client.query(`SELECT table_type, table_schema, table_name
+    FROM information_schema.tables
+    WHERE table_schema IN (${schemaParams})
+    ORDER BY table_type, table_schema, table_name`, APPLICATION_SCHEMAS);
+  const columns = await client.query(`SELECT table_schema, table_name, ordinal_position, column_name, udt_name, is_nullable, COALESCE(column_default, '') AS column_default
+    FROM information_schema.columns
+    WHERE table_schema IN (${schemaParams})
+    ORDER BY table_schema, table_name, ordinal_position`, APPLICATION_SCHEMAS);
+  const constraints = await client.query(`SELECT namespace.nspname AS table_schema, relation.relname AS table_name,
+      constraint_row.conname, constraint_row.contype, constraint_row.convalidated,
+      pg_get_constraintdef(constraint_row.oid, true) AS definition
+    FROM pg_constraint constraint_row
+    JOIN pg_class relation ON relation.oid = constraint_row.conrelid
+    JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+    WHERE namespace.nspname IN (${schemaParams})
+    ORDER BY namespace.nspname, relation.relname, constraint_row.conname`, APPLICATION_SCHEMAS);
+  const indexes = await client.query(`SELECT schemaname, tablename, indexname, indexdef
+    FROM pg_indexes
+    WHERE schemaname IN (${schemaParams})
+    ORDER BY schemaname, tablename, indexname`, APPLICATION_SCHEMAS);
+  const functions = await client.query(`SELECT namespace.nspname AS function_schema, procedure.proname,
+      pg_get_function_identity_arguments(procedure.oid) AS arguments,
+      pg_get_function_result(procedure.oid) AS result_type,
+      procedure.prosecdef,
+      COALESCE(array_to_string(procedure.proconfig, ','), '') AS configuration
+    FROM pg_proc procedure
+    JOIN pg_namespace namespace ON namespace.oid = procedure.pronamespace
+    WHERE namespace.nspname IN (${schemaParams})
+    ORDER BY namespace.nspname, procedure.proname, arguments`, APPLICATION_SCHEMAS);
+  const extensions = await client.query('SELECT extname, extversion FROM pg_extension ORDER BY extname');
   const catalogSections = [
     ['relations', relations.rows],
     ['columns', columns.rows],
@@ -81,8 +81,24 @@ async function schemaContract(client, registryRows) {
   return {
     fingerprint: runtimeSchemaFingerprint(relations.rows, registryRows),
     relationCount: relations.rowCount ?? relations.rows.length,
+    relations: relations.rows,
     catalogFingerprint: createHash('sha256').update(catalogPayload).digest('hex'),
   };
+}
+
+function relationKey(row) {
+  return `${row.table_type}:${row.table_schema}.${row.table_name}`;
+}
+
+function fingerprintMismatch(contract, expectation) {
+  const expected = new Set(expectation.canonical.relations.map(relationKey));
+  const observed = new Set(contract.relations.map(relationKey));
+  const missing = [...expected].filter((key) => !observed.has(key)).sort();
+  const extra = [...observed].filter((key) => !expected.has(key)).sort();
+  return new Error(
+    `production post-0013 schema fingerprint mismatch: observed=${contract.fingerprint}; expected=${expectation.fingerprint}; `
+    + `relations=${contract.relationCount}/${expectation.relationCount}; missing=${JSON.stringify(missing)}; extra=${JSON.stringify(extra)}`,
+  );
 }
 
 async function verifyWaitlistCatalog(client) {
@@ -148,9 +164,9 @@ try {
     await verifyWaitlistPrivileges(client);
     const contract = await schemaContract(client, registry.rows);
     if (emitContract) {
-      console.log(JSON.stringify({ branch, ...contract }));
+      console.log(JSON.stringify({ branch, ...contract, relations: undefined }));
     } else {
-      if (contract.fingerprint !== post0013Expectation.fingerprint) throw new Error('production post-0013 schema fingerprint mismatch');
+      if (contract.fingerprint !== post0013Expectation.fingerprint) throw fingerprintMismatch(contract, post0013Expectation);
       if (contract.relationCount !== post0013Expectation.relationCount) {
         throw new Error(`production post-0013 relation count is ${contract.relationCount}; expected ${post0013Expectation.relationCount}`);
       }

--- a/scripts/tests/planetscale-schema-verifier-views.test.mjs
+++ b/scripts/tests/planetscale-schema-verifier-views.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import test from 'node:test';
+import { canonicalPost0013SchemaContract } from '../ci/product-integrity-schema-contract.mjs';
+
+test('canonical production schema fingerprint includes the storage-ledgers view', () => {
+  const canonical = canonicalPost0013SchemaContract();
+  assert.ok(canonical.relations.some((row) => row.table_type === 'VIEW'
+    && row.table_schema === 'media' && row.table_name === 'storage_ledgers'));
+});
+
+test('dedicated schema verifier receives metadata-only visibility for views', async () => {
+  const source = await fs.readFile('scripts/ci/reconcile-planetscale-schema-verifier.mjs', 'utf8');
+  assert.match(source, /relation\.relkind IN \('r', 'p', 'v', 'f'\)/);
+  assert.match(source, /has_table_privilege\(current_user, 'media\.storage_ledgers', 'REFERENCES'\)/);
+  assert.match(source, /table_name = 'storage_ledgers' AND table_type = 'VIEW'/);
+  assert.match(source, /GRANT REFERENCES ON TABLE/);
+  assert.doesNotMatch(source, /GRANT SELECT ON TABLE media\.storage_ledgers/);
+});
+
+test('production schema verification is sequential and emits safe relation drift diagnostics', async () => {
+  const source = await fs.readFile('scripts/ci/verify-planetscale-production-schema.mjs', 'utf8');
+  assert.doesNotMatch(source, /Promise\.all\(/);
+  assert.match(source, /function fingerprintMismatch/);
+  assert.match(source, /missing=\$\{JSON\.stringify\(missing\)\}/);
+  assert.match(source, /extra=\$\{JSON\.stringify\(extra\)\}/);
+  assert.match(source, /relations: relations\.rows/);
+});

--- a/scripts/tests/planetscale-schema-verifier-views.test.mjs
+++ b/scripts/tests/planetscale-schema-verifier-views.test.mjs
@@ -11,7 +11,8 @@ test('canonical production schema fingerprint includes the storage-ledgers view'
 
 test('dedicated schema verifier receives metadata-only visibility for views', async () => {
   const source = await fs.readFile('scripts/ci/reconcile-planetscale-schema-verifier.mjs', 'utf8');
-  assert.match(source, /relation\.relkind IN \('r', 'p', 'v', 'f'\)/);
+  assert.match(source, /relation\.relkind IN \('r', 'p', 'v'\)/);
+  assert.doesNotMatch(source, /relation\.relkind IN \([^)]*'f'/);
   assert.match(source, /has_table_privilege\(current_user, 'media\.storage_ledgers', 'REFERENCES'\)/);
   assert.match(source, /table_name = 'storage_ledgers' AND table_type = 'VIEW'/);
   assert.match(source, /GRANT REFERENCES ON TABLE/);


### PR DESCRIPTION
PlanetScale production migration/reconciliation run #14 (`31961640021`) completed the canonical migration/grant step in `verified` mode and successfully reconciled the dedicated schema verifier, but its final read-only proof failed with `production post-0013 schema fingerprint mismatch`.

Root cause: the canonical post-0013 schema contract fingerprints both `BASE TABLE` and `VIEW` relations. Migration `0004_launch_contract.sql` creates `media.storage_ledgers` as a view. The dedicated verifier reconciler introduced in #571 granted metadata-only `REFERENCES` privileges only to ordinary and partitioned tables (`pg_class.relkind` `r`/`p`), so PostgreSQL's privilege-filtered `information_schema.tables` omitted the view for the verifier and produced a different relation fingerprint.

This PR fixes the exact mismatch without broadening row access:

- include ordinary views (`relkind = v`) in the dedicated verifier metadata reconciliation, limited to the canonical relation kinds `r`, `p`, and `v`;
- keep `REFERENCES` as the metadata-only relation privilege and do not grant `SELECT` on `media.storage_ledgers` or `marketing.waitlist_signups`;
- explicitly prove `media.storage_ledgers` is visible to the verifier as `table_type = VIEW`;
- make `verify-planetscale-production-schema.mjs` query a single `pg.Client` sequentially, removing the pg@9 deprecation path caused by concurrent `client.query()` calls;
- on future fingerprint mismatch, report only safe schema metadata: observed/expected hashes, relation counts, and missing/extra relation names;
- add regression tests proving the canonical view is included and the verifier remains metadata-only.

Run #14 did not reapply migration 0013 or change migration checksums; it reported `verified` mode. This PR changes no application data, migration payload, runtime/admin/privacy role contract, Cloudflare resource, Worker version, Turnstile resource, or production traffic. The additional view metadata grant is applied only by a separately approved protected `PlanetScale production migrations` run on exact merged `main`.