### PR TITLE
fix: use deployment token for Hyperdrive proof

### DIFF
--- a/.github/workflows/deploy-public-waitlist.yml
+++ b/.github/workflows/deploy-public-waitlist.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Prove Hyperdrive targets PlanetScale main
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_AUDIT_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
           PSCALE_BRANCH_NAME: main

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -50,13 +50,14 @@ test('protected cutover verifies database, preserves secrets, and has rollback',
   assert.match(cutover, /Restore exact pre-waitlist public Worker deployment/);
   assert.doesNotMatch(cutover, /PLANETSCALE_DEVELOPMENT_SCHEMA_READ_DATABASE_URL/);
   assert.doesNotMatch(cutover, /PLANETSCALE_API_TOKEN/);
+  assert.doesNotMatch(cutover, /CLOUDFLARE_AUDIT_API_TOKEN/);
 
   const proofStart = cutover.indexOf('- name: Prove Hyperdrive targets PlanetScale main');
   const proofEnd = cutover.indexOf('- name: Verify production schema and waitlist grants read-only');
   assert.ok(proofStart >= 0 && proofEnd > proofStart, 'Hyperdrive proof step must remain explicit');
   const proofStep = cutover.slice(proofStart, proofEnd);
-  assert.match(proofStep, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_AUDIT_API_TOKEN \}\}/);
-  assert.doesNotMatch(proofStep, /secrets\.CLOUDFLARE_API_TOKEN/);
+  assert.match(proofStep, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
+  assert.doesNotMatch(proofStep, /CLOUDFLARE_AUDIT_API_TOKEN/);
   assert.match(cutover.slice(proofEnd), /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
 
   assert.match(hyperdriveProof, /manifest\.expectedMainOriginFingerprint/);


### PR DESCRIPTION
## Why
The public waitlist cutover currently maps `CLOUDFLARE_AUDIT_API_TOKEN` into the Hyperdrive proof step. That audit token is now returning HTTP 401, while the freshly re-saved deployment token has been independently proven to read all four reviewed Hyperdrive configs and has also been proven to have Turnstile write authorization.

## Change
- Use `secrets.CLOUDFLARE_API_TOKEN` for the Hyperdrive proof step.
- Update the public-waitlist regression test so the cutover must not depend on `CLOUDFLARE_AUDIT_API_TOKEN`.

## Safety
- No Hyperdrive verifier logic is weakened.
- Exact reviewed IDs/names, PlanetScale main fingerprint, TLS/cache requirements and fail-closed behavior remain unchanged.
- Diff is limited to two files: one workflow secret mapping and its regression assertions.
- Independent read-only diagnostic confirmed HTTP 200 and exact expected names for all four retained Hyperdrive configs using the deployment token.