### PR TITLE
fix: stage waitlist candidate at zero traffic before probe

### DIFF
--- a/.github/workflows/deploy-public-waitlist.yml
+++ b/.github/workflows/deploy-public-waitlist.yml
@@ -133,6 +133,7 @@ jobs:
           set -euo pipefail
           npx wrangler versions upload \
             --config apps/lythaus-public-api/wrangler.jsonc \
+            --env="" \
             --tag "$RELEASE_SHA" \
             --message "Lythaus public waitlist candidate $RELEASE_SHA" \
             --secrets-file "$RUNNER_TEMP/waitlist-turnstile-secret.json" \
@@ -140,6 +141,40 @@ jobs:
           rm -f "$RUNNER_TEMP/waitlist-turnstile-secret.json"
           npx wrangler versions list --name "$PUBLIC_WORKER" --json > "$RUNNER_TEMP/waitlist-cutover/public-versions.json"
           node scripts/ci/resolve-latest-worker-version.mjs "$RUNNER_TEMP/waitlist-cutover/public-versions.json" "$RELEASE_SHA" PUBLIC
+
+      - name: Stage public Worker candidate at zero traffic
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          read -r -a rollback_specs <<< "$PUBLIC_ROLLBACK_SPECS"
+          if [ "${#rollback_specs[@]}" -ne 1 ]; then
+            echo 'Refusing zero-traffic staging: the predeployment state must contain exactly one traffic-serving version.' >&2
+            exit 1
+          fi
+          rollback_version="${rollback_specs[0]%%@*}"
+          npx wrangler versions deploy \
+            "${rollback_specs[0]}" \
+            "${PUBLIC_WORKER_VERSION_ID}@0" \
+            --name "$PUBLIC_WORKER" \
+            --env="" \
+            --yes \
+            --message "Stage reviewed Lythaus public waitlist $RELEASE_SHA at zero traffic"
+          echo 'PUBLIC_WORKER_DEPLOYED=true' >> "$GITHUB_ENV"
+          npx wrangler deployments status --name "$PUBLIC_WORKER" --json > "$RUNNER_TEMP/waitlist-cutover/public-staged.json"
+          jq -e \
+            --arg rollback "$rollback_version" \
+            --arg candidate "$PUBLIC_WORKER_VERSION_ID" \
+            '(.versions | length) == 2
+             and any(.versions[]; .version_id == $rollback and ((.percentage | tonumber) == 100))
+             and any(.versions[]; .version_id == $candidate and ((.percentage | tonumber) == 0))' \
+            "$RUNNER_TEMP/waitlist-cutover/public-staged.json" >/dev/null || {
+              echo 'Cloudflare did not report the exact 100/0 staging deployment.' >&2
+              exit 1
+            }
 
       - name: Probe candidate without production traffic
         env:
@@ -170,6 +205,7 @@ jobs:
           set -euo pipefail
           npx wrangler versions deploy "${PUBLIC_WORKER_VERSION_ID}@100" \
             --name "$PUBLIC_WORKER" \
+            --env="" \
             --yes \
             --message "Activate reviewed Lythaus public waitlist $RELEASE_SHA"
           echo 'PUBLIC_WORKER_DEPLOYED=true' >> "$GITHUB_ENV"
@@ -217,8 +253,10 @@ jobs:
         shell: bash
         run: |
           set +e
-          npx wrangler versions deploy $PUBLIC_ROLLBACK_SPECS \
+          read -r -a rollback_specs <<< "$PUBLIC_ROLLBACK_SPECS"
+          npx wrangler versions deploy "${rollback_specs[@]}" \
             --name "$PUBLIC_WORKER" \
+            --env="" \
             --yes \
             --message 'Restore exact pre-waitlist public Worker deployment'
 

--- a/scripts/ci/probe-public-waitlist-candidate.mjs
+++ b/scripts/ci/probe-public-waitlist-candidate.mjs
@@ -36,7 +36,7 @@ for (const path of ['/health', '/ready']) {
   if (!response.ok) throw new Error(`${path} returned HTTP ${response.status}`);
 }
 
-const routeProbe = await request('/api/waitlist', {
+const routeRequest = {
   method: 'POST',
   headers: {
     accept: 'application/json',
@@ -49,10 +49,41 @@ const routeProbe = await request('/api/waitlist', {
     consentVersion: 'waitlist-v1',
     source: 'lythaus.co',
   }),
-});
-const routeBody = await routeProbe.json().catch(() => null);
-if (routeProbe.status !== 400 || routeBody?.error !== 'turnstile_required') {
-  throw new Error('candidate /api/waitlist did not fail closed on a missing Turnstile token');
+};
+
+let routeProbe;
+let routeBody = null;
+let matchedCandidateContract = false;
+let attempts = 0;
+for (attempts = 1; attempts <= 6; attempts += 1) {
+  routeProbe = await request('/api/waitlist', routeRequest);
+  routeBody = await routeProbe.json().catch(() => null);
+  matchedCandidateContract = routeProbe.status === 400 && routeBody?.error === 'turnstile_required';
+  if (matchedCandidateContract) break;
+  if (attempts < 6) await new Promise((resolve) => setTimeout(resolve, 1_000));
+}
+
+const evidence = {
+  schemaVersion: 1,
+  releaseSha,
+  worker: workerName,
+  workerVersionId,
+  baseUrl: base.origin,
+  health: 'pass',
+  ready: 'pass',
+  waitlistRoute: matchedCandidateContract ? 'present_fail_closed' : 'candidate_contract_not_observed',
+  turnstileMissingTokenStatus: routeProbe?.status ?? null,
+  observedError: typeof routeBody?.error === 'string' ? routeBody.error : null,
+  attempts,
+  cacheControl: routeProbe?.headers.get('cache-control') ?? null,
+  corsOrigin: routeProbe?.headers.get('access-control-allow-origin') ?? null,
+  correlationIdPresent: Boolean(routeProbe?.headers.get('x-correlation-id')),
+  capturedAt: new Date().toISOString(),
+};
+if (evidencePath) fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+
+if (!matchedCandidateContract) {
+  throw new Error(`candidate /api/waitlist did not fail closed on a missing Turnstile token after ${attempts} attempts; observed HTTP ${routeProbe?.status ?? 'none'} error=${evidence.observedError ?? 'none'}`);
 }
 if (routeProbe.headers.get('cache-control') !== 'private, no-store') {
   throw new Error('candidate /api/waitlist error response must be private, no-store');
@@ -64,19 +95,4 @@ if (!routeProbe.headers.get('x-correlation-id')) {
   throw new Error('candidate /api/waitlist response is missing the correlation identifier');
 }
 
-const evidence = {
-  schemaVersion: 1,
-  releaseSha,
-  worker: workerName,
-  workerVersionId,
-  baseUrl: base.origin,
-  health: 'pass',
-  ready: 'pass',
-  waitlistRoute: 'present_fail_closed',
-  turnstileMissingTokenStatus: routeProbe.status,
-  cacheControl: routeProbe.headers.get('cache-control'),
-  corsOrigin: routeProbe.headers.get('access-control-allow-origin'),
-  capturedAt: new Date().toISOString(),
-};
-if (evidencePath) fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
-console.log(JSON.stringify({ status: 'pass', worker: workerName, workerVersionId, waitlistRoute: evidence.waitlistRoute }));
+console.log(JSON.stringify({ status: 'pass', worker: workerName, workerVersionId, waitlistRoute: evidence.waitlistRoute, attempts }));

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -77,7 +77,7 @@ test('protected cutover verifies database, preserves secrets, stages at zero tra
   const stageStep = cutover.slice(stage, candidateProbe);
   assert.match(stageStep, /PUBLIC_WORKER_DEPLOYED=true/);
   assert.match(stageStep, /\$\{PUBLIC_WORKER_VERSION_ID\}@0/);
-  assert.match(stageStep, /rollback_specs\[@\]/);
+  assert.match(stageStep, /rollback_specs\[0\]/);
 
   assert.match(hyperdriveProof, /manifest\.expectedMainOriginFingerprint/);
   assert.match(hyperdriveProof, /observedFingerprint === mainFingerprint/);

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -31,13 +31,18 @@ test('public materializer keeps full authenticated acceptance fail closed', () =
 test('candidate probe proves the route exists without writing a signup', () => {
   assert.match(probe, /candidate-probe@example\.invalid/);
   assert.match(probe, /turnstileToken: ''/);
-  assert.match(probe, /routeProbe\.status !== 400/);
+  assert.match(probe, /Cloudflare-Workers-Version-Overrides/);
+  assert.match(probe, /routeProbe\.status === 400/);
   assert.match(probe, /turnstile_required/);
+  assert.match(probe, /attempts <= 6/);
+  assert.match(probe, /candidate_contract_not_observed/);
+  assert.match(probe, /observedError/);
+  assert.match(probe, /fs\.writeFileSync\(evidencePath/);
   assert.match(probe, /private, no-store/);
   assert.match(probe, /access-control-allow-origin/);
 });
 
-test('protected cutover verifies database, preserves secrets, and has rollback', () => {
+test('protected cutover verifies database, preserves secrets, stages at zero traffic, and has rollback', () => {
   assert.match(cutover, /environment: production/);
   assert.match(cutover, /Require exact reviewed current main SHA/);
   assert.match(cutover, /PSCALE_ROLE_IDENTIFIERS: \$\{\{ secrets\.PSCALE_ROLE_IDENTIFIERS \}\}/);
@@ -46,6 +51,10 @@ test('protected cutover verifies database, preserves secrets, and has rollback',
   assert.match(cutover, /PII_ENCRYPTION_KEY_V1 PII_HMAC_KEY_V1/);
   assert.match(cutover, /waitlist-turnstile\.mjs ensure/);
   assert.match(cutover, /--secrets-file/);
+  assert.match(cutover, /--env=""/);
+  assert.match(cutover, /Stage public Worker candidate at zero traffic/);
+  assert.match(cutover, /\$\{PUBLIC_WORKER_VERSION_ID\}@0/);
+  assert.match(cutover, /exact 100\/0 staging deployment/);
   assert.match(cutover, /probe-public-waitlist-candidate\.mjs/);
   assert.match(cutover, /Restore exact pre-waitlist public Worker deployment/);
   assert.doesNotMatch(cutover, /PLANETSCALE_DEVELOPMENT_SCHEMA_READ_DATABASE_URL/);
@@ -59,6 +68,16 @@ test('protected cutover verifies database, preserves secrets, and has rollback',
   assert.match(proofStep, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
   assert.doesNotMatch(proofStep, /CLOUDFLARE_AUDIT_API_TOKEN/);
   assert.match(cutover.slice(proofEnd), /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);
+
+  const upload = cutover.indexOf('- name: Upload immutable public Worker candidate');
+  const stage = cutover.indexOf('- name: Stage public Worker candidate at zero traffic');
+  const candidateProbe = cutover.indexOf('- name: Probe candidate without production traffic');
+  const activate = cutover.indexOf('- name: Activate exact public Worker candidate');
+  assert.ok(upload >= 0 && stage > upload && candidateProbe > stage && activate > candidateProbe, 'candidate must be uploaded, staged at 0%, probed, then activated');
+  const stageStep = cutover.slice(stage, candidateProbe);
+  assert.match(stageStep, /PUBLIC_WORKER_DEPLOYED=true/);
+  assert.match(stageStep, /\$\{PUBLIC_WORKER_VERSION_ID\}@0/);
+  assert.match(stageStep, /rollback_specs\[@\]/);
 
   assert.match(hyperdriveProof, /manifest\.expectedMainOriginFingerprint/);
   assert.match(hyperdriveProof, /observedFingerprint === mainFingerprint/);


### PR DESCRIPTION
## Root cause
Run #9 uploaded the immutable Worker candidate but then tried to select it using `Cloudflare-Workers-Version-Overrides` before the candidate was part of the current deployment. Cloudflare only honors version overrides for versions in the active deployment, including versions staged at 0% traffic. The override was therefore ignored and the probe hit the existing live version.

## Change
- Explicitly target the top-level Wrangler environment with `--env=""` during upload/deploy operations.
- After upload, create an exact `previous@100 + candidate@0` deployment.
- Verify Cloudflare reports the exact 100/0 staging state before probing.
- Mark staging as rollback-relevant so any later failure restores the exact captured predeployment state.
- Keep the version-override probe against `api.lythaus.co`, now that the candidate is eligible for override selection.
- Retry the route probe briefly for Cloudflare propagation and persist sanitized observed status/error evidence before throwing.
- Add regression coverage for upload -> 0% stage -> probe -> 100% activation ordering.

## Safety
- Candidate receives 0% of normal traffic during the smoke test.
- No Turnstile or waitlist policy is weakened.
- No database or Hyperdrive policy changes.
- Predeployment state must contain exactly one traffic-serving version; otherwise the workflow fails closed rather than constructing a 3-version deployment.
- Any failure after 0% staging triggers the existing exact rollback.

Cloudflare reference: Workers version overrides only apply to versions in the current deployment; their documented smoke-test flow stages the new version at 0% and the existing version at 100% before sending the override header.