### PR TITLE
fix: harden waitlist live verification and rollback

### DIFF
--- a/.github/workflows/deploy-public-waitlist.yml
+++ b/.github/workflows/deploy-public-waitlist.yml
@@ -210,25 +210,25 @@ jobs:
             --message "Activate reviewed Lythaus public waitlist $RELEASE_SHA"
           echo 'PUBLIC_WORKER_DEPLOYED=true' >> "$GITHUB_ENV"
 
-      - name: Verify live route fails closed before browser token
+      - name: Verify live route fails closed after activation propagation
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PRODUCTION_LIVE_EVIDENCE_PATH: ${{ runner.temp }}/waitlist-cutover/public-live.json
         shell: bash
         run: |
           set -euo pipefail
-          body="$RUNNER_TEMP/waitlist-cutover/live-missing-token.json"
-          headers="$RUNNER_TEMP/waitlist-cutover/live-missing-token.headers"
-          status="$(curl --silent --show-error --max-time 20 \
-            --dump-header "$headers" \
-            --output "$body" \
-            --write-out '%{http_code}' \
-            --request POST 'https://api.lythaus.co/api/waitlist' \
-            --header 'content-type: application/json' \
-            --header 'origin: https://lythaus.co' \
-            --data '{"email":"candidate-probe@example.invalid","turnstileToken":"","consentVersion":"waitlist-v1","source":"lythaus.co"}')"
-          test "$status" = 400
-          jq -e '.error == "turnstile_required"' "$body" >/dev/null
-          grep -F -i 'cache-control: private, no-store' "$headers"
-          grep -F -i 'access-control-allow-origin: https://lythaus.co' "$headers"
-          rm -f "$body" "$headers"
+          npx wrangler deployments status --name "$PUBLIC_WORKER" --json > "$RUNNER_TEMP/waitlist-cutover/public-active.json"
+          jq -e \
+            --arg candidate "$PUBLIC_WORKER_VERSION_ID" \
+            '(.versions | length) == 1
+             and .versions[0].version_id == $candidate
+             and ((.versions[0].percentage | tonumber) == 100)' \
+            "$RUNNER_TEMP/waitlist-cutover/public-active.json" >/dev/null || {
+              echo 'Cloudflare control plane does not report the exact candidate at 100%.' >&2
+              exit 1
+            }
+          node scripts/ci/probe-live-public-waitlist.mjs
 
       - name: Write sanitized cutover evidence
         if: success()
@@ -254,16 +254,38 @@ jobs:
         run: |
           set +e
           read -r -a rollback_specs <<< "$PUBLIC_ROLLBACK_SPECS"
+          rollback_log="$RUNNER_TEMP/public-waitlist-rollback.log"
           npx wrangler versions deploy "${rollback_specs[@]}" \
             --name "$PUBLIC_WORKER" \
             --env="" \
             --yes \
-            --message 'Restore exact pre-waitlist public Worker deployment'
+            --message 'Restore exact pre-waitlist public Worker deployment' \
+            > "$rollback_log" 2>&1
+          rollback_status=$?
+          if [ "$rollback_status" -eq 0 ]; then
+            rm -f "$rollback_log"
+            exit 0
+          fi
+          if ! grep -Eq '10220' "$rollback_log"; then
+            echo 'Normal rollback failed without the approved Cloudflare secret-drift code 10220.' >&2
+            rm -f "$rollback_log"
+            exit "$rollback_status"
+          fi
+          rm -f "$rollback_log"
+
+          set -euo pipefail
+          current_path="$RUNNER_TEMP/waitlist-cutover/public-rollback-current.json"
+          npx wrangler deployments status --name "$PUBLIC_WORKER" --json > "$current_path"
+          PRODUCTION_WORKER_SCOPE="$PUBLIC_WORKER" \
+          EXPECTED_CANDIDATE_VERSION_ID="$PUBLIC_WORKER_VERSION_ID" \
+          ROLLBACK_SPECS="$PUBLIC_ROLLBACK_SPECS" \
+          CURRENT_DEPLOYMENT_PATH="$current_path" \
+          node scripts/ci/restore-worker-deployment.mjs
 
       - name: Remove temporary Turnstile secret material
         if: always()
         shell: bash
-        run: rm -f "$RUNNER_TEMP/waitlist-turnstile-secret.json"
+        run: rm -f "$RUNNER_TEMP/waitlist-turnstile-secret.json" "$RUNNER_TEMP/public-waitlist-rollback.log"
 
       - name: Upload sanitized waitlist cutover evidence
         if: always()

--- a/scripts/ci/probe-live-public-waitlist.mjs
+++ b/scripts/ci/probe-live-public-waitlist.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const baseUrl = process.env.PRODUCTION_PUBLIC_API_BASE_URL || 'https://api.lythaus.co';
+const evidencePath = process.env.PRODUCTION_LIVE_EVIDENCE_PATH ?? '';
+const base = new URL(baseUrl);
+
+if (base.protocol !== 'https:' || base.hostname !== 'api.lythaus.co' || base.pathname !== '/') {
+  throw new Error('PRODUCTION_PUBLIC_API_BASE_URL must be https://api.lythaus.co');
+}
+
+const attempts = [];
+let passed = false;
+
+for (let attempt = 1; attempt <= 6; attempt += 1) {
+  const response = await fetch(new URL('/api/waitlist', base), {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      origin: 'https://lythaus.co',
+    },
+    body: JSON.stringify({
+      email: 'candidate-probe@example.invalid',
+      turnstileToken: '',
+      consentVersion: 'waitlist-v1',
+      source: 'lythaus.co',
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const body = await response.json().catch(() => null);
+  const observed = {
+    attempt,
+    status: response.status,
+    error: typeof body?.error === 'string' ? body.error : null,
+    cacheControl: response.headers.get('cache-control'),
+    corsOrigin: response.headers.get('access-control-allow-origin'),
+    correlationIdPresent: Boolean(response.headers.get('x-correlation-id')),
+  };
+  attempts.push(observed);
+
+  passed = observed.status === 400
+    && observed.error === 'turnstile_required'
+    && observed.cacheControl === 'private, no-store'
+    && observed.corsOrigin === 'https://lythaus.co'
+    && observed.correlationIdPresent;
+
+  if (passed) break;
+  if (attempt < 6) await new Promise((resolve) => setTimeout(resolve, 2_000));
+}
+
+const evidence = {
+  schemaVersion: 1,
+  baseUrl: base.origin,
+  status: passed ? 'pass' : 'live_contract_not_observed',
+  attempts,
+  capturedAt: new Date().toISOString(),
+};
+if (evidencePath) fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+
+if (!passed) {
+  throw new Error('live /api/waitlist contract was not observed after activation propagation retries');
+}
+
+console.log(JSON.stringify({ status: 'pass', attempts: attempts.length, waitlistRoute: 'present_fail_closed' }));

--- a/scripts/ci/restore-worker-deployment.mjs
+++ b/scripts/ci/restore-worker-deployment.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
+const apiToken = process.env.CLOUDFLARE_API_TOKEN ?? '';
+const workerName = process.env.PRODUCTION_WORKER_SCOPE ?? '';
+const candidateVersionId = process.env.EXPECTED_CANDIDATE_VERSION_ID ?? '';
+const rollbackSpecs = process.env.ROLLBACK_SPECS ?? '';
+const currentDeploymentPath = process.env.CURRENT_DEPLOYMENT_PATH ?? '';
+
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+if (!/^[0-9a-f]{32}$/.test(accountId)) throw new Error('CLOUDFLARE_ACCOUNT_ID is invalid');
+if (!apiToken) throw new Error('CLOUDFLARE_API_TOKEN is required');
+if (workerName !== 'lythaus-public-api-development') throw new Error('forced restore requires the canonical public Worker');
+if (!uuid.test(candidateVersionId)) throw new Error('EXPECTED_CANDIDATE_VERSION_ID is invalid');
+if (!currentDeploymentPath || !fs.existsSync(currentDeploymentPath)) throw new Error('CURRENT_DEPLOYMENT_PATH is required');
+
+function parseRollbackSpecs(value) {
+  const specs = value.trim().split(/\s+/).filter(Boolean);
+  if (specs.length < 1 || specs.length > 2) throw new Error('ROLLBACK_SPECS must contain one or two versions');
+
+  const versions = specs.map((spec) => {
+    const match = spec.match(/^([0-9a-f-]{36})@([0-9]+(?:\.[0-9]+)?)$/i);
+    if (!match || !uuid.test(match[1])) throw new Error('ROLLBACK_SPECS contains an invalid version specification');
+    const percentage = Number(match[2]);
+    if (!Number.isFinite(percentage) || percentage < 0.01 || percentage > 100) {
+      throw new Error('ROLLBACK_SPECS contains an invalid traffic percentage');
+    }
+    return { version_id: match[1], percentage };
+  });
+
+  const ids = new Set(versions.map((version) => version.version_id));
+  if (ids.size !== versions.length) throw new Error('ROLLBACK_SPECS contains duplicate version IDs');
+  const total = versions.reduce((sum, version) => sum + version.percentage, 0);
+  if (Math.abs(total - 100) > 0.001) throw new Error(`rollback traffic totals ${total}, not 100`);
+  return versions;
+}
+
+function normalizeVersions(versions, { allowZero = false } = {}) {
+  if (!Array.isArray(versions) || versions.length < 1 || versions.length > 2) {
+    throw new Error('deployment state must contain one or two versions');
+  }
+  return versions.map((version) => {
+    const versionId = version?.version_id;
+    const percentage = Number(version?.percentage);
+    const minimum = allowZero ? 0 : 0.01;
+    if (!uuid.test(versionId ?? '') || !Number.isFinite(percentage) || percentage < minimum || percentage > 100) {
+      throw new Error('deployment state contains an invalid version');
+    }
+    return { version_id: versionId, percentage };
+  });
+}
+
+function sameDeployment(left, right) {
+  if (left.length !== right.length) return false;
+  const sortVersions = (versions) => [...versions].sort((a, b) => a.version_id.localeCompare(b.version_id));
+  const a = sortVersions(left);
+  const b = sortVersions(right);
+  return a.every((version, index) => version.version_id === b[index].version_id
+    && Math.abs(version.percentage - b[index].percentage) <= 0.001);
+}
+
+const rollbackVersions = parseRollbackSpecs(rollbackSpecs);
+const currentSource = JSON.parse(fs.readFileSync(currentDeploymentPath, 'utf8'));
+const currentVersions = normalizeVersions(currentSource?.versions, { allowZero: true });
+const rollbackIds = new Set(rollbackVersions.map((version) => version.version_id));
+const allowedCurrentIds = new Set([...rollbackIds, candidateVersionId]);
+
+if (sameDeployment(currentVersions, rollbackVersions)) {
+  console.log(JSON.stringify({ status: 'already_restored', worker: workerName, versions: rollbackVersions }));
+  process.exit(0);
+}
+
+if (!currentVersions.some((version) => version.version_id === candidateVersionId)) {
+  throw new Error('refusing forced restore: the expected candidate is not present in the current deployment');
+}
+if (currentVersions.some((version) => !allowedCurrentIds.has(version.version_id))) {
+  throw new Error('refusing forced restore: the current deployment contains an unexpected version');
+}
+
+const endpoint = new URL(`https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts/${encodeURIComponent(workerName)}/deployments`);
+endpoint.searchParams.set('force', 'true');
+
+const response = await fetch(endpoint, {
+  method: 'POST',
+  headers: {
+    authorization: `Bearer ${apiToken}`,
+    'content-type': 'application/json',
+  },
+  body: JSON.stringify({
+    strategy: 'percentage',
+    versions: rollbackVersions,
+    annotations: {
+      'workers/message': 'Restore exact pre-waitlist public Worker deployment',
+    },
+  }),
+  signal: AbortSignal.timeout(20_000),
+});
+const payload = await response.json().catch(() => null);
+if (!response.ok || payload?.success !== true) {
+  const codes = Array.isArray(payload?.errors)
+    ? payload.errors.map((error) => error?.code).filter((code) => code !== undefined)
+    : [];
+  throw new Error(`Cloudflare forced restore failed (HTTP ${response.status}; codes=${codes.join(',') || 'unknown'})`);
+}
+
+const restoredVersions = normalizeVersions(payload?.result?.versions);
+if (!sameDeployment(restoredVersions, rollbackVersions)) {
+  throw new Error('Cloudflare forced restore response did not match the captured predeployment state');
+}
+
+console.log(JSON.stringify({
+  status: 'restored',
+  worker: workerName,
+  deploymentId: payload.result?.id ?? null,
+  versions: restoredVersions,
+}));

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import test from 'node:test';
 
@@ -10,6 +11,13 @@ const restoreDeployment = fs.readFileSync('scripts/ci/restore-worker-deployment.
 const hyperdriveProof = fs.readFileSync('scripts/ci/verify-cloudflare-hyperdrive-targets.mjs', 'utf8');
 const cutover = fs.readFileSync('.github/workflows/deploy-public-waitlist.yml', 'utf8');
 const marketing = fs.readFileSync('.github/workflows/deploy-marketing-preview.yml', 'utf8');
+
+test('waitlist operational helpers parse under the pinned Node runtime', () => {
+  for (const path of ['scripts/ci/probe-live-public-waitlist.mjs', 'scripts/ci/restore-worker-deployment.mjs']) {
+    const result = spawnSync(process.execPath, ['--check', path], { encoding: 'utf8' });
+    assert.equal(result.status, 0, `${path} failed node --check: ${result.stderr}`);
+  }
+});
 
 test('Turnstile provisioning is exact, idempotent, and secret-safe', () => {
   assert.match(turnstile, /Lythaus Website Waitlist/);

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -5,6 +5,8 @@ import test from 'node:test';
 const turnstile = fs.readFileSync('scripts/cloudflare/waitlist-turnstile.mjs', 'utf8');
 const materializer = fs.readFileSync('scripts/ci/materialize-public-waitlist-deploy.mjs', 'utf8');
 const probe = fs.readFileSync('scripts/ci/probe-public-waitlist-candidate.mjs', 'utf8');
+const liveProbe = fs.readFileSync('scripts/ci/probe-live-public-waitlist.mjs', 'utf8');
+const restoreDeployment = fs.readFileSync('scripts/ci/restore-worker-deployment.mjs', 'utf8');
 const hyperdriveProof = fs.readFileSync('scripts/ci/verify-cloudflare-hyperdrive-targets.mjs', 'utf8');
 const cutover = fs.readFileSync('.github/workflows/deploy-public-waitlist.yml', 'utf8');
 const marketing = fs.readFileSync('.github/workflows/deploy-marketing-preview.yml', 'utf8');
@@ -42,7 +44,32 @@ test('candidate probe proves the route exists without writing a signup', () => {
   assert.match(probe, /access-control-allow-origin/);
 });
 
-test('protected cutover verifies database, preserves secrets, stages at zero traffic, and has rollback', () => {
+test('live probe tolerates bounded activation propagation without weakening the contract', () => {
+  assert.match(liveProbe, /candidate-probe@example\.invalid/);
+  assert.match(liveProbe, /attempt <= 6/);
+  assert.match(liveProbe, /setTimeout\(resolve, 2_000\)/);
+  assert.match(liveProbe, /status === 400/);
+  assert.match(liveProbe, /turnstile_required/);
+  assert.match(liveProbe, /private, no-store/);
+  assert.match(liveProbe, /https:\/\/lythaus\.co/);
+  assert.match(liveProbe, /correlationIdPresent/);
+  assert.match(liveProbe, /live_contract_not_observed/);
+  assert.match(liveProbe, /PRODUCTION_LIVE_EVIDENCE_PATH/);
+});
+
+test('forced restore is limited to captured state after explicit candidate validation', () => {
+  assert.match(restoreDeployment, /EXPECTED_CANDIDATE_VERSION_ID/);
+  assert.match(restoreDeployment, /ROLLBACK_SPECS/);
+  assert.match(restoreDeployment, /CURRENT_DEPLOYMENT_PATH/);
+  assert.match(restoreDeployment, /expected candidate is not present in the current deployment/);
+  assert.match(restoreDeployment, /current deployment contains an unexpected version/);
+  assert.match(restoreDeployment, /endpoint\.searchParams\.set\('force', 'true'\)/);
+  assert.match(restoreDeployment, /strategy: 'percentage'/);
+  assert.match(restoreDeployment, /sameDeployment\(restoredVersions, rollbackVersions\)/);
+  assert.doesNotMatch(restoreDeployment, /console\.log\([^\n]*apiToken/);
+});
+
+test('protected cutover verifies database, preserves secrets, stages at zero traffic, and has guarded rollback', () => {
   assert.match(cutover, /environment: production/);
   assert.match(cutover, /Require exact reviewed current main SHA/);
   assert.match(cutover, /PSCALE_ROLE_IDENTIFIERS: \$\{\{ secrets\.PSCALE_ROLE_IDENTIFIERS \}\}/);
@@ -56,7 +83,11 @@ test('protected cutover verifies database, preserves secrets, stages at zero tra
   assert.match(cutover, /\$\{PUBLIC_WORKER_VERSION_ID\}@0/);
   assert.match(cutover, /exact 100\/0 staging deployment/);
   assert.match(cutover, /probe-public-waitlist-candidate\.mjs/);
+  assert.match(cutover, /probe-live-public-waitlist\.mjs/);
+  assert.match(cutover, /Cloudflare control plane does not report the exact candidate at 100%/);
   assert.match(cutover, /Restore exact pre-waitlist public Worker deployment/);
+  assert.match(cutover, /approved Cloudflare secret-drift code 10220/);
+  assert.match(cutover, /restore-worker-deployment\.mjs/);
   assert.doesNotMatch(cutover, /PLANETSCALE_DEVELOPMENT_SCHEMA_READ_DATABASE_URL/);
   assert.doesNotMatch(cutover, /PLANETSCALE_API_TOKEN/);
   assert.doesNotMatch(cutover, /CLOUDFLARE_AUDIT_API_TOKEN/);
@@ -73,11 +104,18 @@ test('protected cutover verifies database, preserves secrets, stages at zero tra
   const stage = cutover.indexOf('- name: Stage public Worker candidate at zero traffic');
   const candidateProbe = cutover.indexOf('- name: Probe candidate without production traffic');
   const activate = cutover.indexOf('- name: Activate exact public Worker candidate');
-  assert.ok(upload >= 0 && stage > upload && candidateProbe > stage && activate > candidateProbe, 'candidate must be uploaded, staged at 0%, probed, then activated');
+  const live = cutover.indexOf('- name: Verify live route fails closed after activation propagation');
+  const rollback = cutover.indexOf('- name: Roll back public Worker on failure');
+  assert.ok(upload >= 0 && stage > upload && candidateProbe > stage && activate > candidateProbe && live > activate && rollback > live,
+    'candidate must be uploaded, staged at 0%, probed, activated, live-probed, then remain rollback-protected');
   const stageStep = cutover.slice(stage, candidateProbe);
   assert.match(stageStep, /PUBLIC_WORKER_DEPLOYED=true/);
   assert.match(stageStep, /\$\{PUBLIC_WORKER_VERSION_ID\}@0/);
   assert.match(stageStep, /rollback_specs\[0\]/);
+  const rollbackStep = cutover.slice(rollback, cutover.indexOf('- name: Remove temporary Turnstile secret material'));
+  assert.match(rollbackStep, /wrangler versions deploy/);
+  assert.match(rollbackStep, /grep -Eq '10220'/);
+  assert.match(rollbackStep, /EXPECTED_CANDIDATE_VERSION_ID="\$PUBLIC_WORKER_VERSION_ID"/);
 
   assert.match(hyperdriveProof, /manifest\.expectedMainOriginFingerprint/);
   assert.match(hyperdriveProof, /observedFingerprint === mainFingerprint/);


### PR DESCRIPTION
## Incident
Run #10 successfully staged and override-probed the candidate, reverified PlanetScale, and activated the exact candidate at 100%. The first un-overridden live request was issued roughly a quarter-second after activation and observed the prior edge state (`404 not_found`). A read-only follow-up diagnostic later proved the candidate remained live at 100%, `/health` and `/ready` were 200, and three consecutive live missing-token probes returned the required `400 turnstile_required` contract.

The automatic rollback then hit Cloudflare code `10220` because `TURNSTILE_SECRET_KEY` had changed since the captured predeployment version was active.

## Changes
- Replace the single immediate post-activation request with a bounded live propagation probe (up to 6 attempts, 2 seconds apart) that keeps the full fail-closed contract: HTTP 400, `turnstile_required`, `private, no-store`, approved CORS origin and correlation ID.
- Verify the Cloudflare control plane reports exactly the candidate at 100% before live probing.
- Persist sanitized live-probe evidence.
- Keep normal Wrangler rollback as the first choice.
- If and only if normal rollback fails with Cloudflare code `10220`, re-read current deployment state and invoke a guarded Deployments API restore with `force=true`.
- The forced restore refuses to run unless the current deployment still contains the expected candidate and no unexpected version, and restores only the exact captured predeployment version split.
- Add regression coverage for the propagation and guarded rollback paths.

## Safety
- No application, database, Hyperdrive, Turnstile policy, or moderation behavior changes.
- No secret values are logged.
- `force=true` is not unconditional and is not used for non-10220 failures.
- A delayed rollback cannot intentionally replace an unrelated newer deployment because current version IDs are validated first.

Cloudflare documents `force=true` on Create Deployment specifically for otherwise-blocked rollbacks when a secret has changed.