### PR TITLE
fix: validate marketing root route consistently

### DIFF
--- a/.github/workflows/deploy-marketing-preview.yml
+++ b/.github/workflows/deploy-marketing-preview.yml
@@ -118,8 +118,12 @@ jobs:
           mkdir -p preview-pages
           routes=(/ /about /ai-moderation /contact /features /guidelines /invite /pricing /privacy /terms)
           for route in "${routes[@]}"; do
-            name="${route//\//_}"
-            response="$(curl --location --silent --show-error --max-time 20 --output "preview-pages/${name:-root}.html" --write-out '%{http_code}|%{url_effective}' "${PREVIEW_URL}${route}")"
+            if [[ "$route" = "/" ]]; then
+              name="_root"
+            else
+              name="${route//\//_}"
+            fi
+            response="$(curl --location --silent --show-error --max-time 20 --output "preview-pages/${name}.html" --write-out '%{http_code}|%{url_effective}' "${PREVIEW_URL}${route}")"
             status="${response%%|*}"
             effective_url="${response#*|}"
             test "$status" = 200 || { echo "Unexpected status $status for $route"; exit 1; }

--- a/scripts/tests/public-waitlist-cutover.test.mjs
+++ b/scripts/tests/public-waitlist-cutover.test.mjs
@@ -139,10 +139,14 @@ test('protected cutover verifies database, preserves secrets, stages at zero tra
   assert.ok(typesCheck >= 0 && materialize >= 0 && typesCheck < materialize, 'Wrangler types must be checked before deployment-only config materialization');
 });
 
-test('production marketing resolves the public sitekey from Cloudflare', () => {
+test('production marketing resolves the public sitekey from Cloudflare and validates the root file consistently', () => {
   assert.match(marketing, /PUBLIC_API_BASE_URL: https:\/\/api\.lythaus\.co/);
   assert.match(marketing, /waitlist-turnstile\.mjs resolve/);
   assert.match(marketing, /challenges\.cloudflare\.com\/turnstile\/v0\/api\.js/);
   assert.match(marketing, /waitlist_signup/);
+  assert.match(marketing, /name="_root"/);
+  assert.match(marketing, /preview-pages\/\$\{name\}\.html/);
+  assert.match(marketing, /preview-pages\/_root\.html/);
+  assert.doesNotMatch(marketing, /\$\{name:-root\}/);
   assert.doesNotMatch(marketing, /vars\.PUBLIC_TURNSTILE_SITE_KEY/);
 });


### PR DESCRIPTION
## Incident
Production marketing run #10 successfully built and deployed the exact production artifact to Cloudflare Pages, then failed only in the post-deploy validator. The route loop wrote `/` to `preview-pages/_.html`, while the production Turnstile assertions later read `preview-pages/_root.html`.

## Fix
- Map `/` explicitly to `_root` before writing the fetched page.
- Keep all other route filenames unchanged.
- Add a regression assertion that the workflow writes `preview-pages/${name}.html`, sets `name="_root"` for `/`, and never uses the old `${name:-root}` fallback.

## Scope
Two files only. No marketing copy, public API, Worker, database, Turnstile configuration, Pages project, DNS or custom-domain changes.