### PR TITLE
ops: add protected waitlist runtime diagnostic

### DIFF
--- a/.github/workflows/diagnose-waitlist-runtime-89e00774-once.yml
+++ b/.github/workflows/diagnose-waitlist-runtime-89e00774-once.yml
@@ -1,0 +1,141 @@
+name: Diagnose waitlist runtime 89e00774 once
+
+on:
+  push:
+    branches:
+      - ops/diagnose-waitlist-runtime-89e00774
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: 89e0077495893ab581d7258239b2dd795613d87e
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - name: Compare public Hyperdrive origin user to canonical runtime role
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
+          const token = process.env.CLOUDFLARE_API_TOKEN ?? '';
+          const roles = JSON.parse(process.env.PSCALE_ROLE_IDENTIFIERS ?? '{}');
+          const expected = roles.lythaus_runtime ?? '';
+          if (!/^[a-f0-9]{32}$/.test(accountId)) throw new Error('Cloudflare account ID unavailable');
+          if (!token) throw new Error('Cloudflare API token unavailable');
+          if (!/^pscale_api_[a-z0-9]+$/.test(expected)) throw new Error('canonical runtime role identifier unavailable');
+          const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/hyperdrive/configs/3e59f07db51345aa896333ca861d1adf`, {
+            headers: { authorization: `Bearer ${token}`, accept: 'application/json' },
+            signal: AbortSignal.timeout(10_000),
+          });
+          const envelope = await response.json().catch(() => null);
+          if (!response.ok || envelope?.success !== true) {
+            const codes = Array.isArray(envelope?.errors) ? envelope.errors.map((e) => e?.code ?? null) : [];
+            throw new Error(`Hyperdrive GET failed status=${response.status} codes=${JSON.stringify(codes)}`);
+          }
+          const originUser = envelope?.result?.origin?.user;
+          const result = {
+            hyperdriveLookup: true,
+            configNameMatch: envelope?.result?.name === 'lythaus-db-app-dev',
+            originUserPresent: typeof originUser === 'string' && originUser.length > 0,
+            runtimeRoleMatch: originUser === expected,
+          };
+          console.log(JSON.stringify(result));
+          NODE
+
+      - name: Verify actual canonical runtime privileges read-only
+        shell: bash
+        env:
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import pg from 'pg';
+          const { Client } = pg;
+          const roles = JSON.parse(process.env.PSCALE_ROLE_IDENTIFIERS ?? '{}');
+          const runtime = roles.lythaus_runtime ?? '';
+          if (!/^pscale_api_[a-z0-9]+$/.test(runtime)) throw new Error('canonical runtime role identifier unavailable');
+          const raw = process.env.PLANETSCALE_SCHEMA_READ_DATABASE_URL ?? '';
+          if (!raw) throw new Error('schema-read credential unavailable');
+          const url = new URL(raw);
+          if (url.searchParams.get('sslrootcert') === 'system') url.searchParams.delete('sslrootcert');
+          const client = new Client({ connectionString: url.toString(), ssl: { rejectUnauthorized: true } });
+          await client.connect();
+          try {
+            await client.query('BEGIN READ ONLY');
+            const q = await client.query(`SELECT
+              has_schema_privilege($1, 'system', 'USAGE') AS system_usage,
+              has_table_privilege($1, 'system.rate_limit_windows', 'SELECT') AS rate_select,
+              has_table_privilege($1, 'system.rate_limit_windows', 'INSERT') AS rate_insert,
+              has_table_privilege($1, 'system.rate_limit_windows', 'UPDATE') AS rate_update,
+              has_schema_privilege($1, 'marketing', 'USAGE') AS marketing_usage,
+              has_column_privilege($1, 'marketing.waitlist_signups', 'id', 'INSERT') AS waitlist_id_insert,
+              has_column_privilege($1, 'marketing.waitlist_signups', 'email_lookup_hmac', 'INSERT') AS waitlist_hmac_insert,
+              has_column_privilege($1, 'marketing.waitlist_signups', 'email_ciphertext', 'INSERT') AS waitlist_cipher_insert,
+              has_column_privilege($1, 'marketing.waitlist_signups', 'encryption_key_version', 'INSERT') AS waitlist_key_insert,
+              has_column_privilege($1, 'marketing.waitlist_signups', 'status', 'INSERT') AS waitlist_status_insert,
+              has_column_privilege($1, 'marketing.waitlist_signups', 'source', 'INSERT') AS waitlist_source_insert,
+              has_column_privilege($1, 'marketing.waitlist_signups', 'consent_version', 'INSERT') AS waitlist_consent_insert,
+              has_table_privilege($1, 'marketing.waitlist_signups', 'SELECT') AS waitlist_table_select`, [runtime]);
+            console.log(JSON.stringify(q.rows[0] ?? {}));
+            await client.query('ROLLBACK');
+          } catch (error) {
+            await client.query('ROLLBACK').catch(() => undefined);
+            throw error;
+          } finally {
+            await client.end();
+          }
+          NODE
+
+      - name: Exercise live pre-Turnstile rate-limit path with synthetic request
+        shell: bash
+        run: |
+          set -euo pipefail
+          headers="$RUNNER_TEMP/waitlist-probe-headers.txt"
+          body="$RUNNER_TEMP/waitlist-probe-body.json"
+          status="$(curl --silent --show-error \
+            --output "$body" \
+            --dump-header "$headers" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --url 'https://api.lythaus.co/api/waitlist' \
+            --header 'Origin: https://lythaus.co' \
+            --header 'Content-Type: application/json' \
+            --data '{"email":"diagnostic-probe@example.invalid","turnstileToken":"diagnostic-invalid-turnstile-token","consentVersion":"waitlist-v1","source":"lythaus.co"}')"
+          error_code="$(jq -r '.error // "none"' "$body" 2>/dev/null || echo non_json)"
+          cache_control="$(awk 'BEGIN{IGNORECASE=1} /^cache-control:/ {sub(/^[^:]+:[[:space:]]*/, ""); gsub(/\r/, ""); print; exit}' "$headers")"
+          cors="$(awk 'BEGIN{IGNORECASE=1} /^access-control-allow-origin:/ {sub(/^[^:]+:[[:space:]]*/, ""); gsub(/\r/, ""); print; exit}' "$headers")"
+          rate_path='not_proven'
+          case "$error_code" in
+            turnstile_failed|turnstile_unavailable|rate_limit_exceeded) rate_path='passed' ;;
+            request_failed) rate_path='failed_before_turnstile' ;;
+            waitlist_unavailable) rate_path='blocked_before_rate_limit_or_required_secret' ;;
+          esac
+          jq -n \
+            --argjson httpStatus "$status" \
+            --arg error "$error_code" \
+            --arg ratePath "$rate_path" \
+            --arg cacheControl "$cache_control" \
+            --arg corsOrigin "$cors" \
+            '{httpStatus:$httpStatus,error:$error,rateLimitPath:$ratePath,cacheControl:$cacheControl,corsOrigin:$corsOrigin}'
+          test "$cache_control" = 'private, no-store'
+          test "$cors" = 'https://lythaus.co'
+          rm -f "$headers" "$body"

--- a/.github/workflows/diagnose-waitlist-runtime-89e00774-once.yml
+++ b/.github/workflows/diagnose-waitlist-runtime-89e00774-once.yml
@@ -1,12 +1,19 @@
-name: Diagnose waitlist runtime 89e00774 once
+name: Diagnose Lythaus waitlist runtime
 
 on:
-  push:
-    branches:
-      - ops/diagnose-waitlist-runtime-89e00774
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact current main SHA to diagnose
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+concurrency:
+  group: lythaus-waitlist-runtime-diagnostic
+  cancel-in-progress: false
 
 jobs:
   diagnose:
@@ -16,7 +23,22 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: 89e0077495893ab581d7258239b2dd795613d87e
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Require exact current main SHA
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full SHA' >&2; exit 1; }
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          test "$(git rev-parse origin/main)" = "$RELEASE_SHA" || {
+            echo 'Refusing diagnostic: release_sha is not current origin/main.' >&2
+            exit 1
+          }
 
       - uses: actions/setup-node@v7
         with:
@@ -24,6 +46,12 @@ jobs:
           cache: npm
 
       - run: npm ci --ignore-scripts
+
+      - name: Validate production Turnstile widget read-only
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: node scripts/cloudflare/waitlist-turnstile.mjs resolve
 
       - name: Compare public Hyperdrive origin user to canonical runtime role
         shell: bash
@@ -51,13 +79,12 @@ jobs:
             throw new Error(`Hyperdrive GET failed status=${response.status} codes=${JSON.stringify(codes)}`);
           }
           const originUser = envelope?.result?.origin?.user;
-          const result = {
+          console.log(JSON.stringify({
             hyperdriveLookup: true,
             configNameMatch: envelope?.result?.name === 'lythaus-db-app-dev',
             originUserPresent: typeof originUser === 'string' && originUser.length > 0,
             runtimeRoleMatch: originUser === expected,
-          };
-          console.log(JSON.stringify(result));
+          }));
           NODE
 
       - name: Verify actual canonical runtime privileges read-only


### PR DESCRIPTION
## Purpose
Add a one-use, protected production diagnostic to isolate the current public waitlist failure without deploying code, changing schema/grants, or submitting real PII.

## What it checks
- resolves the existing production Turnstile widget read-only and validates its managed-mode/domain contract
- compares the public Hyperdrive origin username to the canonical PlanetScale `lythaus_runtime` role identifier without printing either value
- verifies the canonical runtime role's exact rate-limit and waitlist INSERT privileges using the dedicated read-only schema credential
- sends one synthetic `.invalid` request with an invalid Turnstile token so the live Worker must exercise its pre-Turnstile rate-limit DML; records only HTTP/error classification, CORS, and cache-control

## Safety
- `workflow_dispatch` only
- requires an exact current `main` SHA
- uses the existing protected `production` environment and therefore still requires human approval
- no Worker upload/deployment/activation
- no Cloudflare configuration mutation
- no database DDL/grant mutation
- no real email address or valid Turnstile token
- only possible live DB mutation is the normal short-lived rate-limit window generated by the synthetic public request
- no secrets, database usernames, IP addresses, emails, tokens, ciphertext, or HMAC values are printed

The earlier temp-branch execution was rejected by the production environment branch rule before any steps ran; this PR preserves that protection rather than weakening it.