### PR TITLE
fix: restore runtime system-schema access

### DIFF
--- a/.github/workflows/diagnose-waitlist-runtime-89e00774-once.yml
+++ b/.github/workflows/diagnose-waitlist-runtime-89e00774-once.yml
@@ -53,11 +53,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: node scripts/cloudflare/waitlist-turnstile.mjs resolve
 
-      - name: Compare public Hyperdrive origin user to canonical runtime role
+      - name: Compare public Hyperdrive routed user to canonical runtime role
         shell: bash
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
           PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
         run: |
           set -euo pipefail
@@ -65,10 +66,20 @@ jobs:
           const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
           const token = process.env.CLOUDFLARE_API_TOKEN ?? '';
           const roles = JSON.parse(process.env.PSCALE_ROLE_IDENTIFIERS ?? '{}');
-          const expected = roles.lythaus_runtime ?? '';
+          const expectedBaseRole = roles.lythaus_runtime ?? '';
+          const metadataUrl = process.env.PLANETSCALE_SCHEMA_READ_DATABASE_URL ?? '';
           if (!/^[a-f0-9]{32}$/.test(accountId)) throw new Error('Cloudflare account ID unavailable');
           if (!token) throw new Error('Cloudflare API token unavailable');
-          if (!/^pscale_api_[a-z0-9]+$/.test(expected)) throw new Error('canonical runtime role identifier unavailable');
+          if (!/^pscale_api_[a-z0-9]+$/.test(expectedBaseRole)) throw new Error('canonical runtime role identifier unavailable');
+          if (!metadataUrl) throw new Error('PlanetScale main metadata URL unavailable');
+          const metadata = new URL(metadataUrl);
+          if (!metadata.hostname.endsWith('.psdb.cloud')) throw new Error('PlanetScale main metadata URL must target psdb.cloud');
+          const metadataUser = decodeURIComponent(metadata.username);
+          const routeSeparator = metadataUser.lastIndexOf('.');
+          if (routeSeparator <= 0 || routeSeparator === metadataUser.length - 1) throw new Error('PlanetScale routed username is unavailable');
+          const branchRoute = metadataUser.slice(routeSeparator + 1);
+          if (!/^[a-z0-9]+$/.test(branchRoute)) throw new Error('PlanetScale branch route has an unexpected format');
+          const expectedRoutedUser = `${expectedBaseRole}.${branchRoute}`;
           const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/hyperdrive/configs/3e59f07db51345aa896333ca861d1adf`, {
             headers: { authorization: `Bearer ${token}`, accept: 'application/json' },
             signal: AbortSignal.timeout(10_000),
@@ -79,11 +90,15 @@ jobs:
             throw new Error(`Hyperdrive GET failed status=${response.status} codes=${JSON.stringify(codes)}`);
           }
           const originUser = envelope?.result?.origin?.user;
+          const originUserPresent = typeof originUser === 'string' && originUser.length > 0;
+          const originSeparator = originUserPresent ? originUser.lastIndexOf('.') : -1;
           console.log(JSON.stringify({
             hyperdriveLookup: true,
             configNameMatch: envelope?.result?.name === 'lythaus-db-app-dev',
-            originUserPresent: typeof originUser === 'string' && originUser.length > 0,
-            runtimeRoleMatch: originUser === expected,
+            originUserPresent,
+            runtimeBaseRoleMatch: originSeparator > 0 && originUser.slice(0, originSeparator) === expectedBaseRole,
+            branchRouteMatch: originSeparator > 0 && originUser.slice(originSeparator + 1) === branchRoute,
+            runtimeRoutedRoleMatch: originUser === expectedRoutedUser,
           }));
           NODE
 

--- a/database/planetscale/grants/roles.sql
+++ b/database/planetscale/grants/roles.sql
@@ -17,7 +17,7 @@ GRANT CONNECT ON DATABASE postgres TO lythaus_runtime, lythaus_admin, lythaus_jo
 
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA identity, content, social, feed, moderation, privacy, trust, media, editorial, marketing, system TO lythaus_runtime, lythaus_admin, lythaus_jobs, lythaus_privacy;
 
-GRANT USAGE ON SCHEMA identity, content, social, feed, moderation, trust, media TO lythaus_runtime;
+GRANT USAGE ON SCHEMA identity, content, social, feed, moderation, trust, media, system TO lythaus_runtime;
 GRANT USAGE ON SCHEMA privacy TO lythaus_runtime;
 GRANT SELECT, INSERT, UPDATE ON identity.users, identity.handles, identity.email_credentials, identity.contact_emails, identity.auth_sessions, identity.refresh_token_families, identity.provider_links, identity.consent_records, identity.user_region_preferences, identity.email_verification_tokens, identity.password_reset_tokens, identity.account_events TO lythaus_runtime;
 GRANT SELECT, INSERT, UPDATE ON content.posts, content.comments, content.content_declarations, content.places, content.post_locations TO lythaus_runtime;

--- a/scripts/ci/verify-planetscale-production-schema.mjs
+++ b/scripts/ci/verify-planetscale-production-schema.mjs
@@ -128,6 +128,11 @@ async function verifyWaitlistPrivileges(client) {
     throw new Error('post-0013 privilege verification requires canonical PlanetScale role identifiers');
   }
   const result = await client.query(`SELECT
+    has_schema_privilege($1, 'system', 'USAGE') AS runtime_system_usage,
+    has_table_privilege($1, 'system.rate_limit_windows', 'SELECT') AS runtime_rate_select,
+    has_table_privilege($1, 'system.rate_limit_windows', 'INSERT') AS runtime_rate_insert,
+    has_table_privilege($1, 'system.rate_limit_windows', 'UPDATE') AS runtime_rate_update,
+    has_schema_privilege($1, 'marketing', 'USAGE') AS runtime_marketing_usage,
     has_column_privilege($1, 'marketing.waitlist_signups', 'email_lookup_hmac', 'INSERT') AS runtime_insert_hmac,
     has_table_privilege($1, 'marketing.waitlist_signups', 'SELECT') AS runtime_select,
     has_column_privilege($2, 'marketing.waitlist_signups', 'email_ciphertext', 'SELECT') AS admin_select_ciphertext,
@@ -139,11 +144,12 @@ async function verifyWaitlistPrivileges(client) {
     has_column_privilege($3, 'marketing.waitlist_signups', 'email_ciphertext', 'SELECT') AS privacy_select_ciphertext`,
   [runtime, admin, privacy]);
   const row = result.rows[0];
-  if (!row?.runtime_insert_hmac || row.runtime_select
+  if (!row?.runtime_system_usage || !row.runtime_rate_select || !row.runtime_rate_insert || !row.runtime_rate_update
+    || !row.runtime_marketing_usage || !row.runtime_insert_hmac || row.runtime_select
     || !row.admin_select_ciphertext || row.admin_select_hmac
     || !row.admin_update_status || row.admin_update_ciphertext
     || !row.privacy_delete || !row.privacy_select_purge || row.privacy_select_ciphertext) {
-    throw new Error('production waitlist least-privilege contract failed');
+    throw new Error('production waitlist/runtime least-privilege contract failed');
   }
 }
 

--- a/scripts/tests/planetscale-schema-verifier-views.test.mjs
+++ b/scripts/tests/planetscale-schema-verifier-views.test.mjs
@@ -27,3 +27,22 @@ test('production schema verification is sequential and emits safe relation drift
   assert.match(source, /extra=\$\{JSON\.stringify\(extra\)\}/);
   assert.match(source, /relations: relations\.rows/);
 });
+
+test('runtime rate-limit access requires system schema usage and is verified in production', async () => {
+  const grants = await fs.readFile('database/planetscale/grants/roles.sql', 'utf8');
+  const verifier = await fs.readFile('scripts/ci/verify-planetscale-production-schema.mjs', 'utf8');
+  const diagnostic = await fs.readFile('.github/workflows/diagnose-waitlist-runtime-89e00774-once.yml', 'utf8');
+
+  assert.match(grants, /GRANT USAGE ON SCHEMA identity, content, social, feed, moderation, trust, media, system TO lythaus_runtime;/);
+  assert.match(grants, /GRANT SELECT, INSERT, UPDATE ON system\.rate_limit_windows TO lythaus_runtime;/);
+
+  assert.match(verifier, /has_schema_privilege\(\$1, 'system', 'USAGE'\) AS runtime_system_usage/);
+  assert.match(verifier, /has_table_privilege\(\$1, 'system\.rate_limit_windows', 'SELECT'\) AS runtime_rate_select/);
+  assert.match(verifier, /has_table_privilege\(\$1, 'system\.rate_limit_windows', 'INSERT'\) AS runtime_rate_insert/);
+  assert.match(verifier, /has_table_privilege\(\$1, 'system\.rate_limit_windows', 'UPDATE'\) AS runtime_rate_update/);
+  assert.match(verifier, /!row\?\.runtime_system_usage/);
+
+  assert.match(diagnostic, /const expectedRoutedUser = `\$\{expectedBaseRole\}\.\$\{branchRoute\}`;/);
+  assert.match(diagnostic, /runtimeRoutedRoleMatch: originUser === expectedRoutedUser/);
+  assert.doesNotMatch(diagnostic, /runtimeRoleMatch: originUser === expected/);
+});


### PR DESCRIPTION
## Why
The protected waitlist runtime diagnostic proved the live request fails before Turnstile in the database-backed rate-limit path. The canonical runtime role has table privileges on `system.rate_limit_windows` but was missing `USAGE` on the `system` schema.

The same diagnostic also compared Cloudflare's routed PlanetScale username directly to the repository's base SQL role identifier. PlanetScale connection usernames include the branch-routing suffix, so that boolean could report a false mismatch.

## Changes
- grant `lythaus_runtime` `USAGE` on the `system` schema in the canonical grants template
- extend the production read-only verifier to require `system` schema usage plus SELECT/INSERT/UPDATE on `system.rate_limit_windows`
- correct the protected diagnostic to compare the full routed username using the branch suffix from the protected main metadata URL, without logging either username
- add regression coverage for the grant, production verifier, and corrected identity comparison

## Safety
- no migration payload/checksum changes
- no Worker/Turnstile/Hyperdrive mutation
- no credentials logged or stored
- existing reviewed Hyperdrive IDs/names remain unchanged
- after merge, the protected PlanetScale production migration workflow will run in its existing verified mode (no pending migrations) and reapply only canonical grants before final read-only verification