### PR TITLE
Fix waitlist runtime grants and Hyperdrive identity

### DIFF
--- a/.github/workflows/deploy-public-waitlist.yml
+++ b/.github/workflows/deploy-public-waitlist.yml
@@ -71,6 +71,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
           PSCALE_BRANCH_NAME: main
         run: |
           set -euo pipefail

--- a/.github/workflows/repair-waitlist-runtime-hyperdrive-once.yml
+++ b/.github/workflows/repair-waitlist-runtime-hyperdrive-once.yml
@@ -1,0 +1,235 @@
+name: Repair waitlist runtime Hyperdrive once
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact reviewed current main SHA to repair
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lythaus-waitlist-runtime-repair
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 20
+    env:
+      HYPERDRIVE_ID: 3e59f07db51345aa896333ca861d1adf
+      HYPERDRIVE_NAME: lythaus-db-app-dev
+      PRODUCTION_PUBLIC_API_BASE_URL: https://api.lythaus.co
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Require exact reviewed current main SHA
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full 40-character commit SHA' >&2; exit 1; }
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          test "$(git rev-parse origin/main)" = "$RELEASE_SHA" || {
+            echo 'Refusing production repair: release_sha is not current origin/main.' >&2
+            exit 1
+          }
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - name: Require repaired canonical runtime grants before credential rotation
+        env:
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import pg from 'pg';
+          const { Client } = pg;
+          const roles = JSON.parse(process.env.PSCALE_ROLE_IDENTIFIERS ?? '{}');
+          const runtime = roles.lythaus_runtime ?? '';
+          if (!/^pscale_api_[a-z0-9]+$/.test(runtime)) throw new Error('canonical runtime role identifier unavailable');
+          const raw = process.env.PLANETSCALE_SCHEMA_READ_DATABASE_URL ?? '';
+          if (!raw) throw new Error('schema-read credential unavailable');
+          const url = new URL(raw);
+          if (url.searchParams.get('sslmode') !== 'verify-full') throw new Error('schema-read credential must use sslmode=verify-full');
+          if (url.searchParams.get('sslrootcert') === 'system') url.searchParams.delete('sslrootcert');
+          const client = new Client({ connectionString: url.toString(), ssl: { rejectUnauthorized: true } });
+          await client.connect();
+          try {
+            await client.query('BEGIN READ ONLY');
+            const result = await client.query(`SELECT
+              has_schema_privilege($1, 'system', 'USAGE') AS system_usage,
+              has_table_privilege($1, 'system.rate_limit_windows', 'SELECT') AS rate_select,
+              has_table_privilege($1, 'system.rate_limit_windows', 'INSERT') AS rate_insert,
+              has_table_privilege($1, 'system.rate_limit_windows', 'UPDATE') AS rate_update`, [runtime]);
+            const row = result.rows[0] ?? {};
+            const ok = row.system_usage === true && row.rate_select === true && row.rate_insert === true && row.rate_update === true;
+            console.log(JSON.stringify({ runtimeRateLimitGrantsReady: ok }));
+            if (!ok) throw new Error('canonical runtime rate-limit grants are not repaired; run the reviewed production migration workflow first');
+            await client.query('ROLLBACK');
+          } catch (error) {
+            await client.query('ROLLBACK').catch(() => undefined);
+            throw error;
+          } finally {
+            await client.end();
+          }
+          NODE
+
+      - name: Reset canonical runtime credential and patch existing Hyperdrive in place
+        shell: bash
+        env:
+          PLANETSCALE_API_TOKEN: ${{ secrets.PLANETSCALE_API_TOKEN }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          test -n "${PLANETSCALE_API_TOKEN:-}" || { echo 'PLANETSCALE_API_TOKEN is unavailable.' >&2; exit 1; }
+          test -n "${CLOUDFLARE_API_TOKEN:-}" || { echo 'CLOUDFLARE_API_TOKEN is unavailable.' >&2; exit 1; }
+          [[ "${CLOUDFLARE_ACCOUNT_ID:-}" =~ ^[a-f0-9]{32}$ ]] || { echo 'CLOUDFLARE_ACCOUNT_ID is unavailable.' >&2; exit 1; }
+
+          expected="$(jq -r '.lythaus_runtime // empty' <<< "$PSCALE_ROLE_IDENTIFIERS")"
+          [[ "$expected" =~ ^pscale_api_[a-z0-9]+$ ]] || { echo 'Canonical runtime role identifier is unavailable.' >&2; exit 1; }
+
+          before="$RUNNER_TEMP/hyperdrive-before.json"
+          cf_code="$(curl --silent --show-error --output "$before" --write-out '%{http_code}' \
+            --url "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/hyperdrive/configs/$HYPERDRIVE_ID" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --header 'Accept: application/json')"
+          if [[ "$cf_code" != '200' ]] || ! jq -e '.success == true' "$before" >/dev/null; then
+            echo "Cloudflare Hyperdrive preflight failed with HTTP $cf_code." >&2
+            exit 1
+          fi
+          jq -e --arg name "$HYPERDRIVE_NAME" '
+            .result.name == $name
+            and .result.id == env.HYPERDRIVE_ID
+            and .result.caching.disabled == true
+            and .result.mtls.sslmode == "verify-full"
+            and (.result.origin.host | endswith(".psdb.cloud"))
+            and .result.origin.scheme == "postgres"
+          ' "$before" >/dev/null || { echo 'Existing Hyperdrive safety invariants do not match the reviewed configuration.' >&2; exit 1; }
+
+          current_matches="$(jq -r --arg expected "$expected" '.result.origin.user == $expected' "$before")"
+          if [[ "$current_matches" == 'true' ]]; then
+            echo 'Existing Hyperdrive already uses the canonical runtime role; credential rotation is not required.'
+            echo 'RUNTIME_ROTATION_PERFORMED=false' >> "$GITHUB_ENV"
+            rm -f "$before"
+            exit 0
+          fi
+
+          roles_file="$RUNNER_TEMP/planetscale-roles.json"
+          ps_code="$(curl --silent --show-error --output "$roles_file" --write-out '%{http_code}' \
+            --url 'https://api.planetscale.com/v1/organizations/lythaus/databases/lythaus-core/branches/main/roles?per_page=100' \
+            --header "Authorization: Bearer $PLANETSCALE_API_TOKEN" \
+            --header 'Accept: application/json')"
+          [[ "$ps_code" == '200' ]] || { echo "PlanetScale role lookup failed with HTTP $ps_code." >&2; exit 1; }
+
+          role_count="$(jq --arg expected "$expected" '[.data[] | select((.username == $expected or .base_username == $expected) and .deleted_at == null and .disabled_at == null and (.expired | not))] | length' "$roles_file")"
+          [[ "$role_count" == '1' ]] || { echo "Expected exactly one active canonical runtime API role; found $role_count." >&2; exit 1; }
+          role_id="$(jq -r --arg expected "$expected" '.data[] | select((.username == $expected or .base_username == $expected) and .deleted_at == null and .disabled_at == null and (.expired | not)) | .id' "$roles_file")"
+          test -n "$role_id" || { echo 'Canonical runtime API role ID could not be resolved.' >&2; exit 1; }
+
+          reset_file="$RUNNER_TEMP/planetscale-runtime-reset.json"
+          reset_code="$(curl --silent --show-error --output "$reset_file" --write-out '%{http_code}' \
+            --request POST \
+            --url "https://api.planetscale.com/v1/organizations/lythaus/databases/lythaus-core/branches/main/roles/$role_id/reset" \
+            --header "Authorization: Bearer $PLANETSCALE_API_TOKEN" \
+            --header 'Accept: application/json')"
+          [[ "$reset_code" == '200' ]] || { echo "PlanetScale runtime credential reset failed with HTTP $reset_code." >&2; exit 1; }
+          password="$(jq -r '.password // empty' "$reset_file")"
+          returned_matches="$(jq -r --arg expected "$expected" '(.username == $expected) or (.base_username == $expected)' "$reset_file")"
+          [[ "$returned_matches" == 'true' && -n "$password" ]] || { echo 'PlanetScale reset response did not match the canonical runtime role.' >&2; exit 1; }
+          echo "::add-mask::$password"
+
+          patch_body="$RUNNER_TEMP/hyperdrive-runtime-patch.json"
+          jq -n --arg user "$expected" --arg password "$password" '{origin:{user:$user,password:$password}}' > "$patch_body"
+          patched='false'
+          for attempt in 1 2 3; do
+            patch_response="$RUNNER_TEMP/hyperdrive-patch-response.json"
+            patch_code="$(curl --silent --show-error --output "$patch_response" --write-out '%{http_code}' \
+              --request PATCH \
+              --url "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/hyperdrive/configs/$HYPERDRIVE_ID" \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              --header 'Content-Type: application/json' \
+              --data-binary "@$patch_body")"
+            if [[ "$patch_code" == '200' ]] && jq -e --arg expected "$expected" '.success == true and .result.origin.user == $expected' "$patch_response" >/dev/null; then
+              patched='true'
+              break
+            fi
+            sleep $((attempt * 2))
+          done
+          rm -f "$before" "$roles_file" "$reset_file" "$patch_body" "$RUNNER_TEMP/hyperdrive-patch-response.json"
+          [[ "$patched" == 'true' ]] || { echo 'CRITICAL: PlanetScale credential was reset but Cloudflare Hyperdrive did not confirm the canonical runtime identity after three PATCH attempts.' >&2; exit 1; }
+          echo 'RUNTIME_ROTATION_PERFORMED=true' >> "$GITHUB_ENV"
+          echo 'Canonical runtime credential was rotated and the existing Hyperdrive was patched in place.'
+
+      - name: Prove repaired Hyperdrive target and runtime identity
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+          PSCALE_BRANCH_NAME: main
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/waitlist-runtime-repair"
+          node scripts/ci/verify-cloudflare-hyperdrive-targets.mjs > "$RUNNER_TEMP/waitlist-runtime-repair/hyperdrive.json"
+
+      - name: Prove live pre-Turnstile database path
+        shell: bash
+        run: |
+          set -euo pipefail
+          headers="$RUNNER_TEMP/waitlist-probe-headers.txt"
+          body="$RUNNER_TEMP/waitlist-probe-body.json"
+          status="$(curl --silent --show-error \
+            --output "$body" \
+            --dump-header "$headers" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --url "$PRODUCTION_PUBLIC_API_BASE_URL/api/waitlist" \
+            --header 'Origin: https://lythaus.co' \
+            --header 'Content-Type: application/json' \
+            --data '{"email":"runtime-repair-probe@example.invalid","turnstileToken":"diagnostic-invalid-turnstile-token","consentVersion":"waitlist-v1","source":"lythaus.co"}')"
+          error_code="$(jq -r '.error // "none"' "$body" 2>/dev/null || echo non_json)"
+          cache_control="$(awk 'BEGIN{IGNORECASE=1} /^cache-control:/ {sub(/^[^:]+:[[:space:]]*/, ""); gsub(/\r/, ""); print; exit}' "$headers")"
+          cors="$(awk 'BEGIN{IGNORECASE=1} /^access-control-allow-origin:/ {sub(/^[^:]+:[[:space:]]*/, ""); gsub(/\r/, ""); print; exit}' "$headers")"
+          rate_path='not_proven'
+          case "$error_code" in
+            turnstile_failed|turnstile_unavailable|rate_limit_exceeded) rate_path='passed' ;;
+            request_failed) rate_path='failed_before_turnstile' ;;
+            waitlist_unavailable) rate_path='blocked_before_rate_limit_or_required_secret' ;;
+          esac
+          test "$rate_path" = 'passed'
+          test "$cache_control" = 'private, no-store'
+          test "$cors" = 'https://lythaus.co'
+          jq -n \
+            --argjson httpStatus "$status" \
+            --arg error "$error_code" \
+            --arg ratePath "$rate_path" \
+            --arg rotationPerformed "${RUNTIME_ROTATION_PERFORMED:-unknown}" \
+            '{httpStatus:$httpStatus,error:$error,rateLimitPath:$ratePath,runtimeRotationPerformed:$rotationPerformed}' \
+            > "$RUNNER_TEMP/waitlist-runtime-repair/live-probe.json"
+          rm -f "$headers" "$body"
+
+      - name: Upload sanitized repair evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: waitlist-runtime-repair-${{ inputs.release_sha }}
+          path: ${{ runner.temp }}/waitlist-runtime-repair
+          if-no-files-found: warn

--- a/database/planetscale/grants/roles.sql
+++ b/database/planetscale/grants/roles.sql
@@ -17,7 +17,7 @@ GRANT CONNECT ON DATABASE postgres TO lythaus_runtime, lythaus_admin, lythaus_jo
 
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA identity, content, social, feed, moderation, privacy, trust, media, editorial, marketing, system TO lythaus_runtime, lythaus_admin, lythaus_jobs, lythaus_privacy;
 
-GRANT USAGE ON SCHEMA identity, content, social, feed, moderation, trust, media TO lythaus_runtime;
+GRANT USAGE ON SCHEMA identity, content, social, feed, moderation, trust, media, system TO lythaus_runtime;
 GRANT USAGE ON SCHEMA privacy TO lythaus_runtime;
 GRANT SELECT, INSERT, UPDATE ON identity.users, identity.handles, identity.email_credentials, identity.contact_emails, identity.auth_sessions, identity.refresh_token_families, identity.provider_links, identity.consent_records, identity.user_region_preferences, identity.email_verification_tokens, identity.password_reset_tokens, identity.account_events TO lythaus_runtime;
 GRANT SELECT, INSERT, UPDATE ON content.posts, content.comments, content.content_declarations, content.places, content.post_locations TO lythaus_runtime;

--- a/scripts/ci/apply-planetscale-production-migrations.mjs
+++ b/scripts/ci/apply-planetscale-production-migrations.mjs
@@ -127,6 +127,20 @@ async function verifyWaitlistPrivileges(client) {
   }
 }
 
+async function verifyRuntimeRateLimitPrivileges(client) {
+  const runtime = roleIdentifiers.lythaus_runtime;
+  const checks = await client.query(`SELECT
+    has_schema_privilege($1, 'system', 'USAGE') AS system_usage,
+    has_table_privilege($1, 'system.rate_limit_windows', 'SELECT') AS rate_limit_select,
+    has_table_privilege($1, 'system.rate_limit_windows', 'INSERT') AS rate_limit_insert,
+    has_table_privilege($1, 'system.rate_limit_windows', 'UPDATE') AS rate_limit_update`,
+  [runtime]);
+  const row = checks.rows[0];
+  if (!row?.system_usage || !row.rate_limit_select || !row.rate_limit_insert || !row.rate_limit_update) {
+    throw new Error('runtime rate-limit privilege verification failed');
+  }
+}
+
 async function applyGrants(client) {
   const template = fs.readFileSync(path.join(root, 'database', 'planetscale', 'grants', 'roles.sql'), 'utf8');
   const sql = template.replace(/\blythaus_(runtime|admin|jobs|privacy|migrations)\b/g, (label) => quoteRoleIdentifier(roleIdentifiers[label]));
@@ -195,6 +209,7 @@ try {
   if (!finalRegistry || !exactRegistryPrefix(finalRegistry, '0013_marketing_waitlist.sql')) throw new Error('production migration registry is incomplete after apply');
   await applyGrants(client);
   await verifyWaitlistPrivileges(client);
+  await verifyRuntimeRateLimitPrivileges(client);
   console.log(`Validated and applied PlanetScale production migrations on ${branch} (${mode}); no migration checksum was updated.`);
 } finally {
   await client.end();

--- a/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
+++ b/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
@@ -56,8 +56,11 @@ if (manifestOnly) {
 const apiToken = process.env.CLOUDFLARE_API_TOKEN ?? '';
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? manifest.accountId ?? '';
 const databaseUrl = process.env.PLANETSCALE_SCHEMA_READ_DATABASE_URL ?? '';
+const roleIdentifiers = JSON.parse(process.env.PSCALE_ROLE_IDENTIFIERS ?? '{}');
+const expectedRuntimeRole = roleIdentifiers.lythaus_runtime ?? '';
 if (!apiToken || !accountId || !databaseUrl) throw new Error('Cloudflare API credentials and the PlanetScale main metadata URL are required');
 if ((process.env.PSCALE_BRANCH_NAME ?? '') !== 'main') throw new Error('Hyperdrive target verification requires PSCALE_BRANCH_NAME=main');
+if (!/^pscale_api_[a-z0-9]+$/.test(expectedRuntimeRole)) throw new Error('canonical runtime role identifier is required');
 
 const mainOrigin = sourceOrigin(databaseUrl);
 if (mainOrigin.scheme !== 'postgres' || !mainOrigin.host.endsWith('.psdb.cloud')) throw new Error('PlanetScale main metadata URL must be a PostgreSQL psdb.cloud origin');
@@ -119,7 +122,8 @@ for (const entry of manifest.bindings) {
   const schemeValid = String(origin.scheme).toLowerCase() === 'postgres';
   const hostValid = String(origin.host ?? '').toLowerCase().endsWith('.psdb.cloud');
   const fingerprintMatches = observedFingerprint === mainFingerprint;
-  if (config.name !== entry.expectedConfigName || !cacheDisabled || !tlsVerified || !schemeValid || !hostValid || !fingerprintMatches) {
+  const runtimeRoleMatches = origin.user === expectedRuntimeRole;
+  if (config.name !== entry.expectedConfigName || !cacheDisabled || !tlsVerified || !schemeValid || !hostValid || !fingerprintMatches || !runtimeRoleMatches) {
     throw new Error(`Hyperdrive production target check failed for ${entry.worker}/${entry.binding}`);
   }
   results.push({
@@ -130,7 +134,8 @@ for (const entry of manifest.bindings) {
     databaseName: origin.database ?? null,
     originFingerprint: observedFingerprint,
     branch: 'main',
-    roleClass: 'runtime-probe-required',
+    roleClass: 'lythaus_runtime',
+    runtimeRoleMatches,
     cacheDisabled,
     tlsMode: config.mtls.sslmode,
     modifiedOn: config.modified_on ?? null,

--- a/scripts/tests/planetscale-production-migrations.test.mjs
+++ b/scripts/tests/planetscale-production-migrations.test.mjs
@@ -154,7 +154,35 @@ test('production runner preserves immutable registry history', async () => {
   assert.match(source, /recordFullyAppliedMigration/);
   assert.match(source, /assertCompleteMigrationPostconditions/);
   assert.match(source, /verifyWaitlistPrivileges/);
+  assert.match(source, /verifyRuntimeRateLimitPrivileges/);
+  assert.match(source, /has_schema_privilege\(\$1, 'system', 'USAGE'\)/);
+  assert.match(source, /has_table_privilege\(\$1, 'system\.rate_limit_windows', 'SELECT'\)/);
+  assert.match(source, /has_table_privilege\(\$1, 'system\.rate_limit_windows', 'INSERT'\)/);
+  assert.match(source, /has_table_privilege\(\$1, 'system\.rate_limit_windows', 'UPDATE'\)/);
   assert.match(source, /statement_timeout = '15min'/);
+});
+
+test('runtime grant template includes system schema access for rate limiting', async () => {
+  const grants = await (await import('node:fs/promises')).readFile('database/planetscale/grants/roles.sql', 'utf8');
+  assert.match(grants, /GRANT USAGE ON SCHEMA identity, content, social, feed, moderation, trust, media, system TO lythaus_runtime;/);
+  assert.match(grants, /GRANT SELECT, INSERT, UPDATE ON system\.rate_limit_windows TO lythaus_runtime;/);
+});
+
+test('production Hyperdrive gate requires the canonical runtime identity without exposing it', async () => {
+  const source = await (await import('node:fs/promises')).readFile('scripts/ci/verify-cloudflare-hyperdrive-targets.mjs', 'utf8');
+  assert.match(source, /PSCALE_ROLE_IDENTIFIERS/);
+  assert.match(source, /expectedRuntimeRole/);
+  assert.match(source, /origin\.user === expectedRuntimeRole/);
+  assert.match(source, /runtimeRoleMatches/);
+  assert.doesNotMatch(source, /originUser:/);
+
+  const workflow = await (await import('node:fs/promises')).readFile('.github/workflows/deploy-public-waitlist.yml', 'utf8');
+  const proofStart = workflow.indexOf('- name: Prove Hyperdrive targets PlanetScale main');
+  const nextStep = workflow.indexOf('- name: Verify production schema and waitlist grants read-only');
+  assert.ok(proofStart >= 0 && nextStep > proofStart, 'Hyperdrive proof step must remain explicit');
+  const proofStep = workflow.slice(proofStart, nextStep);
+  assert.match(proofStep, /PSCALE_ROLE_IDENTIFIERS: \$\{\{ secrets\.PSCALE_ROLE_IDENTIFIERS \}\}/);
+  assert.match(proofStep, /verify-cloudflare-hyperdrive-targets\.mjs/);
 });
 
 test('migration data preconditions reject unresolved open-appeal conflicts only', () => {


### PR DESCRIPTION
## Summary

Repairs the two defects isolated by the protected waitlist diagnostic without changing the Worker or Turnstile configuration.

- grant `lythaus_runtime` `USAGE` on the `system` schema
- verify `system` schema access plus `SELECT`/`INSERT`/`UPDATE` on `system.rate_limit_windows` after production grants are applied
- make the production Hyperdrive release gate require the canonical `lythaus_runtime` role identifier
- pass `PSCALE_ROLE_IDENTIFIERS` into the existing Hyperdrive verification step
- add regression assertions for the runtime grant and Hyperdrive identity gate
- add a one-use, `production`-gated credential repair workflow that preserves Hyperdrive ID `3e59f07db51345aa896333ca861d1adf` and performs no Worker deployment or Turnstile mutation

## Fault boundary

The protected diagnostic proved two independent defects:

1. canonical `lythaus_runtime` had table privileges on `system.rate_limit_windows` but no `USAGE` on schema `system`
2. the live public Hyperdrive origin user did not match the canonical runtime role

The synthetic invalid-Turnstile request returned `request_failed` before Turnstile, consistent with the pre-Turnstile rate-limit database path failing.

## Safe repair sequence after merge

1. Run the existing protected `PlanetScale production migrations` workflow for the exact merged current `main` SHA. This reapplies `roles.sql` and now fails unless the runtime rate-limit grants are actually present.
2. Run `Repair waitlist runtime Hyperdrive once` for the same exact current `main` SHA. It refuses to rotate credentials unless the grant repair is already proven, resets the existing canonical PlanetScale runtime credential, PATCHes the existing Hyperdrive in place, runs strict Hyperdrive identity verification, then exercises the live pre-Turnstile path using an `example.invalid` address and deliberately invalid Turnstile token.
3. Remove the one-use workflow after successful production evidence is captured.

No real signup is submitted. No Worker version is uploaded or deployed. No Turnstile widget is modified. Secrets and database usernames are not printed into evidence.