### PR TITLE
Orchestrate protected waitlist runtime repair

### DIFF
--- a/.github/workflows/orchestrate-waitlist-runtime-repair-dbfb78bc-once.yml
+++ b/.github/workflows/orchestrate-waitlist-runtime-repair-dbfb78bc-once.yml
@@ -1,0 +1,106 @@
+name: Orchestrate waitlist runtime repair once
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/orchestrate-waitlist-runtime-repair-dbfb78bc-once.yml
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: lythaus-waitlist-runtime-repair-orchestrator
+  cancel-in-progress: false
+
+jobs:
+  orchestrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+
+      - name: Require reviewed merge directly on expected main
+        shell: bash
+        env:
+          EXPECTED_BASE_SHA: dbfb78bcd8e7a75ff44548ca422009568774e832
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse origin/main)" = "$GITHUB_SHA" || {
+            echo 'Refusing repair orchestration: this run is not current origin/main.' >&2
+            exit 1
+          }
+          test "$(git rev-parse HEAD^1)" = "$EXPECTED_BASE_SHA" || {
+            echo 'Refusing repair orchestration: reviewed waitlist repair SHA is not the first parent.' >&2
+            exit 1
+          }
+
+      - name: Dispatch protected repairs in reviewed order
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          dispatch_and_wait() {
+            local workflow="$1"
+            local label="$2"
+            local run_id=''
+
+            git fetch --no-tags origin main
+            test "$(git rev-parse origin/main)" = "$GITHUB_SHA" || {
+              echo "Refusing $label: main advanced after orchestration began." >&2
+              exit 1
+            }
+
+            echo "Dispatching $label for exact main SHA $GITHUB_SHA"
+            gh workflow run "$workflow" --ref main -f "release_sha=$GITHUB_SHA"
+
+            for _ in $(seq 1 30); do
+              run_id="$(gh run list \
+                --workflow "$workflow" \
+                --event workflow_dispatch \
+                --branch main \
+                --limit 20 \
+                --json databaseId,headSha,createdAt \
+                --jq ".[] | select(.headSha == \"$GITHUB_SHA\") | .databaseId" \
+                | head -n1)"
+              if [[ -n "$run_id" ]]; then
+                break
+              fi
+              sleep 2
+            done
+
+            test -n "$run_id" || {
+              echo "Unable to resolve dispatched $label workflow run." >&2
+              exit 1
+            }
+
+            echo "$label run: https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id"
+
+            while true; do
+              status="$(gh run view "$run_id" --json status --jq '.status')"
+              conclusion="$(gh run view "$run_id" --json conclusion --jq '.conclusion // ""')"
+              echo "$label: status=$status conclusion=${conclusion:-pending}"
+              if [[ "$status" == 'completed' ]]; then
+                test "$conclusion" = 'success' || {
+                  echo "$label did not complete successfully; Hyperdrive repair will not continue." >&2
+                  exit 1
+                }
+                break
+              fi
+              sleep 15
+            done
+          }
+
+          dispatch_and_wait 'planetscale-production-migrations.yml' 'PlanetScale production grant repair'
+          dispatch_and_wait 'repair-waitlist-runtime-hyperdrive-once.yml' 'Waitlist runtime Hyperdrive repair'
+
+          echo 'Protected waitlist runtime repair sequence completed successfully.'


### PR DESCRIPTION
Adds a one-use exact-main orchestrator so the assistant can execute the already-reviewed production repair sequence without asking the founder to manually enter SHAs.

Safety properties:
- runs only when this exact one-use workflow is merged to main
- requires the reviewed PR #579 merge SHA `dbfb78bcd8e7a75ff44548ca422009568774e832` as first parent
- refuses to continue if `main` advances
- dispatches existing `PlanetScale production migrations` first with the exact merge SHA
- waits for that protected production run to succeed before dispatching `Repair waitlist runtime Hyperdrive once`
- preserves both existing `production` environment approval gates
- makes no direct provider mutation itself

After successful repair evidence, this one-use workflow should be removed.