### PR TITLE
Fix branch-qualified PlanetScale Hyperdrive recovery

### DIFF
--- a/.github/workflows/recover-waitlist-hyperdrive-branch-qualified-e437b2d5-once.yml
+++ b/.github/workflows/recover-waitlist-hyperdrive-branch-qualified-e437b2d5-once.yml
@@ -1,0 +1,361 @@
+name: Recover waitlist Hyperdrive branch-qualified once
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/recover-waitlist-hyperdrive-branch-qualified-e437b2d5-once.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lythaus-waitlist-hyperdrive-branch-qualified-recovery
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 20
+    env:
+      EXPECTED_BASE_SHA: e437b2d5d5788302433222278b4b702cdf7c247b
+      HYPERDRIVE_ID: 3e59f07db51345aa896333ca861d1adf
+      HYPERDRIVE_NAME: lythaus-db-app-dev
+      PRODUCTION_PUBLIC_API_BASE_URL: https://api.lythaus.co
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+
+      - name: Require recovery merged directly onto expected main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse origin/main)" = "$GITHUB_SHA" || {
+            echo 'Refusing recovery: this run is not current origin/main.' >&2
+            exit 1
+          }
+          test "$(git rev-parse HEAD^1)" = "$EXPECTED_BASE_SHA" || {
+            echo 'Refusing recovery: expected interrupted-recovery SHA is not the first parent.' >&2
+            exit 1
+          }
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - name: Re-prove canonical runtime grants
+        env:
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import pg from 'pg';
+          const { Client } = pg;
+          const roles = JSON.parse(process.env.PSCALE_ROLE_IDENTIFIERS ?? '{}');
+          const runtime = roles.lythaus_runtime ?? '';
+          if (!/^pscale_api_[a-z0-9]+$/.test(runtime)) throw new Error('canonical runtime role identifier unavailable');
+          const raw = process.env.PLANETSCALE_SCHEMA_READ_DATABASE_URL ?? '';
+          if (!raw) throw new Error('schema-read credential unavailable');
+          const url = new URL(raw);
+          if (url.searchParams.get('sslmode') !== 'verify-full') throw new Error('schema-read credential must use sslmode=verify-full');
+          if (url.searchParams.get('sslrootcert') === 'system') url.searchParams.delete('sslrootcert');
+          const client = new Client({ connectionString: url.toString(), ssl: { rejectUnauthorized: true } });
+          await client.connect();
+          try {
+            await client.query('BEGIN READ ONLY');
+            const result = await client.query(`SELECT
+              has_schema_privilege($1, 'system', 'USAGE') AS system_usage,
+              has_table_privilege($1, 'system.rate_limit_windows', 'SELECT') AS rate_select,
+              has_table_privilege($1, 'system.rate_limit_windows', 'INSERT') AS rate_insert,
+              has_table_privilege($1, 'system.rate_limit_windows', 'UPDATE') AS rate_update`, [runtime]);
+            const row = result.rows[0] ?? {};
+            const ok = row.system_usage === true && row.rate_select === true && row.rate_insert === true && row.rate_update === true;
+            console.log(JSON.stringify({ runtimeRateLimitGrantsReady: ok }));
+            if (!ok) throw new Error('canonical runtime rate-limit grants are not repaired');
+            await client.query('ROLLBACK');
+          } catch (error) {
+            await client.query('ROLLBACK').catch(() => undefined);
+            throw error;
+          } finally {
+            await client.end();
+          }
+          NODE
+
+      - name: Recover branch-qualified runtime credential into existing Hyperdrive
+        shell: bash
+        env:
+          PLANETSCALE_API_TOKEN: ${{ secrets.PLANETSCALE_API_TOKEN }}
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          test -n "${PLANETSCALE_API_TOKEN:-}" || { echo 'PLANETSCALE_API_TOKEN is unavailable.' >&2; exit 1; }
+          test -n "${PLANETSCALE_SCHEMA_READ_DATABASE_URL:-}" || { echo 'PLANETSCALE_SCHEMA_READ_DATABASE_URL is unavailable.' >&2; exit 1; }
+          test -n "${CLOUDFLARE_API_TOKEN:-}" || { echo 'CLOUDFLARE_API_TOKEN is unavailable.' >&2; exit 1; }
+          [[ "${CLOUDFLARE_ACCOUNT_ID:-}" =~ ^[a-f0-9]{32}$ ]] || { echo 'CLOUDFLARE_ACCOUNT_ID is unavailable.' >&2; exit 1; }
+
+          evidence="$RUNNER_TEMP/waitlist-hyperdrive-branch-qualified-recovery"
+          mkdir -p "$evidence"
+          expected_base="$(jq -r '.lythaus_runtime // empty' <<< "$PSCALE_ROLE_IDENTIFIERS")"
+          [[ "$expected_base" =~ ^pscale_api_[a-z0-9]+$ ]] || { echo 'Canonical runtime role identifier is unavailable.' >&2; exit 1; }
+
+          branch_id="$(node --input-type=module - <<'NODE'
+          const raw = process.env.PLANETSCALE_SCHEMA_READ_DATABASE_URL ?? '';
+          const url = new URL(raw);
+          const user = decodeURIComponent(url.username);
+          const at = user.lastIndexOf('.');
+          if (at <= 0 || at === user.length - 1) process.exit(2);
+          const branch = user.slice(at + 1);
+          if (!/^[a-z0-9]+$/.test(branch)) process.exit(3);
+          process.stdout.write(branch);
+          NODE
+          )" || { echo 'Could not derive PlanetScale main branch identifier from the authoritative connection URL.' >&2; exit 1; }
+          expected_connection_user="${expected_base}.${branch_id}"
+
+          before="$RUNNER_TEMP/hyperdrive-before.json"
+          noop_body="$RUNNER_TEMP/hyperdrive-noop.json"
+          noop_response="$RUNNER_TEMP/hyperdrive-noop-response.json"
+          roles_file="$RUNNER_TEMP/planetscale-roles.json"
+          reset_file="$RUNNER_TEMP/planetscale-runtime-reset.json"
+          patch_body="$RUNNER_TEMP/hyperdrive-runtime-patch.json"
+          patch_response="$RUNNER_TEMP/hyperdrive-patch-response.json"
+          put_body="$RUNNER_TEMP/hyperdrive-runtime-put.json"
+          put_response="$RUNNER_TEMP/hyperdrive-put-response.json"
+          after="$RUNNER_TEMP/hyperdrive-after.json"
+
+          cleanup_sensitive() {
+            rm -f "$noop_body" "$noop_response" "$roles_file" "$reset_file" "$patch_body" "$patch_response" "$put_body" "$put_response" "$before" "$after"
+          }
+          trap cleanup_sensitive EXIT
+
+          sanitize_cf() {
+            local file="$1"
+            local status="$2"
+            local label="$3"
+            jq -c --arg label "$label" --arg status "$status" '{
+              label:$label,
+              httpStatus:$status,
+              success:(.success // false),
+              errors:[.errors[]? | {code,message,source}],
+              messages:[.messages[]? | {code,message}]
+            }' "$file" 2>/dev/null || jq -n --arg label "$label" --arg status "$status" '{label:$label,httpStatus:$status,success:false,errors:[{message:"non-json Cloudflare response"}]}'
+          }
+
+          cf_code="$(curl --silent --show-error --output "$before" --write-out '%{http_code}' \
+            --url "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/hyperdrive/configs/$HYPERDRIVE_ID" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --header 'Accept: application/json')"
+          if [[ "$cf_code" != '200' ]] || ! jq -e '.success == true' "$before" >/dev/null; then
+            sanitize_cf "$before" "$cf_code" 'hyperdrive-get-preflight' | tee "$evidence/cloudflare-error.json" >&2
+            exit 1
+          fi
+          jq -e --arg name "$HYPERDRIVE_NAME" '
+            .result.name == $name
+            and .result.id == env.HYPERDRIVE_ID
+            and .result.caching.disabled == true
+            and .result.mtls.sslmode == "verify-full"
+            and (.result.mtls.ca_certificate_id | type == "string" and length > 0)
+            and (.result.origin.host | endswith(".psdb.cloud"))
+            and .result.origin.scheme == "postgres"
+          ' "$before" >/dev/null || { echo 'Existing Hyperdrive safety invariants do not match the reviewed configuration.' >&2; exit 1; }
+
+          jq -n --arg name "$HYPERDRIVE_NAME" '{name:$name}' > "$noop_body"
+          noop_code="$(curl --silent --show-error --output "$noop_response" --write-out '%{http_code}' \
+            --request PATCH \
+            --url "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/hyperdrive/configs/$HYPERDRIVE_ID" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --header 'Content-Type: application/json' \
+            --data-binary "@$noop_body")"
+          if [[ "$noop_code" != '200' ]] || ! jq -e '.success == true' "$noop_response" >/dev/null; then
+            sanitize_cf "$noop_response" "$noop_code" 'hyperdrive-write-preflight' | tee "$evidence/cloudflare-error.json" >&2
+            echo 'Refusing PlanetScale reset because Hyperdrive Write was not proven.' >&2
+            exit 1
+          fi
+          jq -n --arg status "$noop_code" '{hyperdriveWritePreflight:true,httpStatus:$status}' > "$evidence/cloudflare-write-preflight.json"
+
+          current_matches="$(jq -r --arg expected "$expected_connection_user" '.result.origin.user == $expected' "$before")"
+          if [[ "$current_matches" == 'true' ]]; then
+            probe_body="$RUNNER_TEMP/pre-rotation-probe.json"
+            probe_status="$(curl --silent --show-error --output "$probe_body" --write-out '%{http_code}' \
+              --request POST \
+              --url "$PRODUCTION_PUBLIC_API_BASE_URL/api/waitlist" \
+              --header 'Origin: https://lythaus.co' \
+              --header 'Content-Type: application/json' \
+              --data '{"email":"runtime-branch-qualified-precheck@example.invalid","turnstileToken":"diagnostic-invalid-turnstile-token","consentVersion":"waitlist-v1","source":"lythaus.co"}')"
+            probe_error="$(jq -r '.error // "none"' "$probe_body" 2>/dev/null || echo non_json)"
+            rm -f "$probe_body"
+            case "$probe_error" in
+              turnstile_failed|turnstile_unavailable|rate_limit_exceeded)
+                echo 'Existing branch-qualified runtime identity and live database path are already healthy; no further reset is required.'
+                jq -n --arg status "$probe_status" --arg error "$probe_error" '{recoveryAction:"no_rotation_required",httpStatus:$status,probeError:$error}' > "$evidence/recovery-action.json"
+                exit 0
+                ;;
+              request_failed)
+                ;;
+              *)
+                echo "Branch-qualified identity is present but live database health is inconclusive: HTTP $probe_status / $probe_error" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          ps_code="$(curl --silent --show-error --output "$roles_file" --write-out '%{http_code}' \
+            --url 'https://api.planetscale.com/v1/organizations/lythaus/databases/lythaus-core/branches/main/roles?per_page=100' \
+            --header "Authorization: Bearer $PLANETSCALE_API_TOKEN" \
+            --header 'Accept: application/json')"
+          [[ "$ps_code" == '200' ]] || { echo "PlanetScale role lookup failed with HTTP $ps_code." >&2; exit 1; }
+
+          role_count="$(jq --arg base "$expected_base" --arg connection "$expected_connection_user" '[.data[] | select((.base_username == $base or .username == $connection) and .deleted_at == null and .disabled_at == null and (.expired | not))] | length' "$roles_file")"
+          [[ "$role_count" == '1' ]] || { echo "Expected exactly one active canonical runtime API role; found $role_count." >&2; exit 1; }
+          role_id="$(jq -r --arg base "$expected_base" --arg connection "$expected_connection_user" '.data[] | select((.base_username == $base or .username == $connection) and .deleted_at == null and .disabled_at == null and (.expired | not)) | .id' "$roles_file")"
+          test -n "$role_id" || { echo 'Canonical runtime API role ID could not be resolved.' >&2; exit 1; }
+
+          reset_code="$(curl --silent --show-error --output "$reset_file" --write-out '%{http_code}' \
+            --request POST \
+            --url "https://api.planetscale.com/v1/organizations/lythaus/databases/lythaus-core/branches/main/roles/$role_id/reset" \
+            --header "Authorization: Bearer $PLANETSCALE_API_TOKEN" \
+            --header 'Accept: application/json')"
+          [[ "$reset_code" == '200' ]] || { echo "PlanetScale runtime credential reset failed with HTTP $reset_code." >&2; exit 1; }
+          password="$(jq -r '.password // empty' "$reset_file")"
+          returned_base="$(jq -r '.base_username // empty' "$reset_file")"
+          connection_user="$(jq -r '.username // empty' "$reset_file")"
+          [[ "$returned_base" == "$expected_base" && "$connection_user" == "$expected_connection_user" && -n "$password" ]] || {
+            echo 'PlanetScale reset response did not return the canonical branch-qualified runtime identity.' >&2
+            exit 1
+          }
+          echo "::add-mask::$password"
+          echo "::add-mask::$connection_user"
+
+          jq -n --arg user "$connection_user" --arg password "$password" '{origin:{user:$user,password:$password}}' > "$patch_body"
+          patch_code="$(curl --silent --show-error --output "$patch_response" --write-out '%{http_code}' \
+            --request PATCH \
+            --url "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/hyperdrive/configs/$HYPERDRIVE_ID" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --header 'Content-Type: application/json' \
+            --data-binary "@$patch_body")"
+
+          update_method='PATCH'
+          if [[ "$patch_code" != '200' ]] || ! jq -e --arg expected "$connection_user" '.success == true and .result.origin.user == $expected' "$patch_response" >/dev/null; then
+            sanitize_cf "$patch_response" "$patch_code" 'credential-patch' | tee "$evidence/cloudflare-error.json" >&2
+            echo 'Credential PATCH was not confirmed; using full Hyperdrive PUT with every reviewed connection/TLS field preserved.'
+            jq -n --arg user "$connection_user" --arg password "$password" --slurpfile cfg "$before" '
+              ($cfg[0].result) as $c |
+              {
+                name:$c.name,
+                origin:{
+                  database:$c.origin.database,
+                  host:$c.origin.host,
+                  password:$password,
+                  port:($c.origin.port // 5432),
+                  scheme:$c.origin.scheme,
+                  user:$user
+                },
+                caching:$c.caching,
+                mtls:$c.mtls,
+                origin_connection_limit:$c.origin_connection_limit
+              } | with_entries(select(.value != null))
+            ' > "$put_body"
+            put_code="$(curl --silent --show-error --output "$put_response" --write-out '%{http_code}' \
+              --request PUT \
+              --url "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/hyperdrive/configs/$HYPERDRIVE_ID" \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              --header 'Content-Type: application/json' \
+              --data-binary "@$put_body")"
+            if [[ "$put_code" != '200' ]] || ! jq -e --arg expected "$connection_user" '.success == true and .result.origin.user == $expected' "$put_response" >/dev/null; then
+              sanitize_cf "$put_response" "$put_code" 'credential-put-fallback' | tee "$evidence/cloudflare-error.json" >&2
+              echo 'CRITICAL: canonical PlanetScale password was reset, but Hyperdrive did not confirm the branch-qualified runtime identity.' >&2
+              exit 1
+            fi
+            update_method='PUT'
+          fi
+
+          after_code="$(curl --silent --show-error --output "$after" --write-out '%{http_code}' \
+            --url "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/hyperdrive/configs/$HYPERDRIVE_ID" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --header 'Accept: application/json')"
+          [[ "$after_code" == '200' ]] || { echo "Post-update Hyperdrive GET failed with HTTP $after_code." >&2; exit 1; }
+          if ! jq -e --arg expected "$connection_user" --arg name "$HYPERDRIVE_NAME" --slurpfile old "$before" '
+            .success == true
+            and .result.id == env.HYPERDRIVE_ID
+            and .result.name == $name
+            and .result.origin.user == $expected
+            and .result.caching.disabled == true
+            and .result.mtls.sslmode == "verify-full"
+            and .result.mtls.ca_certificate_id == $old[0].result.mtls.ca_certificate_id
+            and (.result.mtls.ca_certificate_id | type == "string" and length > 0)
+            and (.result.origin.host | endswith(".psdb.cloud"))
+            and .result.origin.scheme == "postgres"
+          ' "$after" >/dev/null; then
+            echo 'Post-update Hyperdrive invariant verification failed.' >&2
+            exit 1
+          fi
+
+          jq -n --arg method "$update_method" '{recoveryAction:"credential_rotated",hyperdriveUpdateMethod:$method,branchQualifiedRuntime:true,caCertificatePreserved:true}' > "$evidence/recovery-action.json"
+          cleanup_sensitive
+          trap - EXIT
+
+      - name: Prove repaired Hyperdrive target and runtime identity
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+          PSCALE_BRANCH_NAME: main
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/waitlist-hyperdrive-branch-qualified-recovery"
+          node scripts/ci/verify-cloudflare-hyperdrive-targets.mjs > "$RUNNER_TEMP/waitlist-hyperdrive-branch-qualified-recovery/hyperdrive.json"
+
+      - name: Prove live pre-Turnstile database path
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/waitlist-hyperdrive-branch-qualified-recovery"
+          mkdir -p "$evidence"
+          headers="$RUNNER_TEMP/waitlist-branch-qualified-headers.txt"
+          body="$RUNNER_TEMP/waitlist-branch-qualified-body.json"
+          status="$(curl --silent --show-error \
+            --output "$body" \
+            --dump-header "$headers" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --url "$PRODUCTION_PUBLIC_API_BASE_URL/api/waitlist" \
+            --header 'Origin: https://lythaus.co' \
+            --header 'Content-Type: application/json' \
+            --data '{"email":"runtime-branch-qualified-probe@example.invalid","turnstileToken":"diagnostic-invalid-turnstile-token","consentVersion":"waitlist-v1","source":"lythaus.co"}')"
+          error_code="$(jq -r '.error // "none"' "$body" 2>/dev/null || echo non_json)"
+          case "$error_code" in
+            turnstile_failed|turnstile_unavailable|rate_limit_exceeded)
+              rate_path='passed'
+              ;;
+            *)
+              rate_path='failed'
+              ;;
+          esac
+          cache_control="$(awk 'BEGIN{IGNORECASE=1} /^cache-control:/ {sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit}' "$headers")"
+          cors="$(awk 'BEGIN{IGNORECASE=1} /^access-control-allow-origin:/ {sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit}' "$headers")"
+          jq -n --arg status "$status" --arg error "$error_code" --arg rate "$rate_path" --arg cache "$cache_control" --arg cors "$cors" '{httpStatus:$status,error:$error,rateLimitPath:$rate,cacheControl:$cache,corsOrigin:$cors}' | tee "$evidence/live-probe.json"
+          rm -f "$headers" "$body"
+          [[ "$rate_path" == 'passed' ]] || { echo 'Live request still fails before Turnstile/database-rate-limit completion.' >&2; exit 1; }
+          [[ "$cors" == 'https://lythaus.co' ]] || { echo 'Live waitlist CORS origin is incorrect.' >&2; exit 1; }
+          [[ "$cache_control" == *'no-store'* ]] || { echo 'Live waitlist response is missing no-store cache control.' >&2; exit 1; }
+
+      - name: Upload sanitized recovery evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: waitlist-hyperdrive-branch-qualified-recovery-${{ github.sha }}
+          path: ${{ runner.temp }}/waitlist-hyperdrive-branch-qualified-recovery
+          if-no-files-found: warn
+          retention-days: 90

--- a/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
+++ b/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
@@ -23,14 +23,24 @@ function fingerprint(origin) {
   return crypto.createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
 }
 
-function sourceOrigin(databaseUrl) {
+function sourceMetadata(databaseUrl) {
   const url = new URL(databaseUrl);
   const scheme = url.protocol.replace(':', '').toLowerCase() === 'postgresql' ? 'postgres' : url.protocol.replace(':', '').toLowerCase();
+  const username = decodeURIComponent(url.username);
+  const separator = username.lastIndexOf('.');
+  if (separator <= 0 || separator === username.length - 1) {
+    throw new Error('PlanetScale main metadata URL must use a branch-qualified username');
+  }
+  const branchId = username.slice(separator + 1);
+  if (!/^[a-z0-9]+$/.test(branchId)) throw new Error('PlanetScale main metadata URL has an invalid branch identifier');
   return {
-    scheme,
-    host: url.hostname.toLowerCase(),
-    port: Number(url.port || 5432),
-    database: decodeURIComponent(url.pathname.replace(/^\/+/, '')),
+    origin: {
+      scheme,
+      host: url.hostname.toLowerCase(),
+      port: Number(url.port || 5432),
+      database: decodeURIComponent(url.pathname.replace(/^\/+/, '')),
+    },
+    branchId,
   };
 }
 
@@ -62,7 +72,9 @@ if (!apiToken || !accountId || !databaseUrl) throw new Error('Cloudflare API cre
 if ((process.env.PSCALE_BRANCH_NAME ?? '') !== 'main') throw new Error('Hyperdrive target verification requires PSCALE_BRANCH_NAME=main');
 if (!/^pscale_api_[a-z0-9]+$/.test(expectedRuntimeRole)) throw new Error('canonical runtime role identifier is required');
 
-const mainOrigin = sourceOrigin(databaseUrl);
+const mainSource = sourceMetadata(databaseUrl);
+const mainOrigin = mainSource.origin;
+const expectedRuntimeConnectionUser = `${expectedRuntimeRole}.${mainSource.branchId}`;
 if (mainOrigin.scheme !== 'postgres' || !mainOrigin.host.endsWith('.psdb.cloud')) throw new Error('PlanetScale main metadata URL must be a PostgreSQL psdb.cloud origin');
 const mainFingerprint = fingerprint(mainOrigin);
 if (mainFingerprint !== manifest.expectedMainOriginFingerprint) throw new Error('PlanetScale main origin fingerprint changed without a reviewed manifest update');
@@ -119,11 +131,13 @@ for (const entry of manifest.bindings) {
   const observedFingerprint = fingerprint(origin);
   const cacheDisabled = config.caching?.disabled === true;
   const tlsVerified = config.mtls?.sslmode === 'verify-full';
+  const caCertificatePresent = typeof config.mtls?.ca_certificate_id === 'string' && config.mtls.ca_certificate_id.length > 0;
   const schemeValid = String(origin.scheme).toLowerCase() === 'postgres';
   const hostValid = String(origin.host ?? '').toLowerCase().endsWith('.psdb.cloud');
   const fingerprintMatches = observedFingerprint === mainFingerprint;
-  const runtimeRoleMatches = origin.user === expectedRuntimeRole;
-  if (config.name !== entry.expectedConfigName || !cacheDisabled || !tlsVerified || !schemeValid || !hostValid || !fingerprintMatches || !runtimeRoleMatches) {
+  // Legacy exact-base comparison was: origin.user === expectedRuntimeRole. PlanetScale Postgres requires role.branch_id.
+  const runtimeRoleMatches = origin.user === expectedRuntimeConnectionUser;
+  if (config.name !== entry.expectedConfigName || !cacheDisabled || !tlsVerified || !caCertificatePresent || !schemeValid || !hostValid || !fingerprintMatches || !runtimeRoleMatches) {
     throw new Error(`Hyperdrive production target check failed for ${entry.worker}/${entry.binding}`);
   }
   results.push({
@@ -138,6 +152,7 @@ for (const entry of manifest.bindings) {
     runtimeRoleMatches,
     cacheDisabled,
     tlsMode: config.mtls.sslmode,
+    caCertificatePresent,
     modifiedOn: config.modified_on ?? null,
   });
 }


### PR DESCRIPTION
Emergency production repair for the waitlist Hyperdrive credential rotation.

Evidence from the last protected recovery showed two concrete defects after Hyperdrive:Edit was granted:
- Cloudflare rejected the credential PATCH because PlanetScale Postgres requires the connection user in `{role}.{branch_id}` form; the workflow incorrectly sent the SQL-visible base role identifier.
- The full Hyperdrive PUT fallback reconstructed `mtls` with only `sslmode`, dropping the existing `ca_certificate_id`, so Cloudflare correctly rejected verify-full TLS.

This PR:
- derives the authoritative PlanetScale main branch ID from `PLANETSCALE_SCHEMA_READ_DATABASE_URL` without logging it
- updates the permanent Hyperdrive verifier to require the canonical `lythaus_runtime` role qualified with that branch ID
- requires the existing verify-full CA certificate ID to be present
- adds a new one-use protected production recovery workflow
- performs a harmless same-name Hyperdrive PATCH before any new PlanetScale reset to prove Hyperdrive Write
- selects the canonical PlanetScale API role by `base_username`, resets it once only if the live branch-qualified identity is not already healthy, and uses the reset response `username` as the Hyperdrive connection user
- validates `base_username` against the canonical SQL role and the returned connection username against the authoritative branch ID
- patches the same Hyperdrive ID in place; if PATCH fails, full PUT preserves the complete existing `mtls` object including `ca_certificate_id`
- verifies the CA ID remains unchanged, then runs the permanent target verifier and a live invalid-Turnstile probe requiring the database/rate-limit path to pass
- creates no new Hyperdrive, does not redeploy the Worker, and does not modify Turnstile.

The one-use workflow runs only if merged directly onto current main `e437b2d5d5788302433222278b4b702cdf7c247b` and still requires the protected `production` environment approval.