### PR TITLE
Make Hyperdrive verification role-aware

### DIFF
--- a/.github/workflows/verify-public-waitlist-hyperdrive-140d636b-once.yml
+++ b/.github/workflows/verify-public-waitlist-hyperdrive-140d636b-once.yml
@@ -1,0 +1,132 @@
+name: Verify repaired public waitlist Hyperdrive once
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/verify-public-waitlist-hyperdrive-140d636b-once.yml
+      - scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
+      - infrastructure/cloudflare/native-hyperdrive-production.json
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lythaus-public-waitlist-hyperdrive-verification
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+    env:
+      EXPECTED_BASE_SHA: 140d636bd88ab440b2b8c3219b445ed00dfa3041
+      PUBLIC_HYPERDRIVE_ID: 3e59f07db51345aa896333ca861d1adf
+      PRODUCTION_PUBLIC_API_BASE_URL: https://api.lythaus.co
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+
+      - name: Require verification merged directly onto repaired main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse origin/main)" = "$GITHUB_SHA" || {
+            echo 'Refusing verification: this run is not current origin/main.' >&2
+            exit 1
+          }
+          test "$(git rev-parse HEAD^1)" = "$EXPECTED_BASE_SHA" || {
+            echo 'Refusing verification: repaired Hyperdrive SHA is not the first parent.' >&2
+            exit 1
+          }
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - name: Verify only the repaired public Hyperdrive
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+          PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+          PSCALE_BRANCH_NAME: main
+          HYPERDRIVE_VERIFY_IDS: ${{ env.PUBLIC_HYPERDRIVE_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/public-waitlist-hyperdrive-verification"
+          mkdir -p "$evidence"
+          node scripts/ci/verify-cloudflare-hyperdrive-targets.mjs > "$evidence/hyperdrive.json"
+          jq -e '
+            .status == "pass"
+            and (.bindings | length) == 1
+            and .bindings[0].hyperdriveId == env.PUBLIC_HYPERDRIVE_ID
+            and .bindings[0].roleClass == "lythaus_runtime"
+            and .bindings[0].roleMatches == true
+            and .bindings[0].runtimeRoleMatches == true
+            and .bindings[0].cacheDisabled == true
+            and .bindings[0].tlsMode == "verify-full"
+            and .bindings[0].caCertificatePresent == true
+          ' "$evidence/hyperdrive.json" >/dev/null
+
+      - name: Prove live pre-Turnstile database path
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/public-waitlist-hyperdrive-verification"
+          mkdir -p "$evidence"
+          headers="$RUNNER_TEMP/public-waitlist-hyperdrive-headers.txt"
+          body="$RUNNER_TEMP/public-waitlist-hyperdrive-body.json"
+          status="$(curl --silent --show-error \
+            --output "$body" \
+            --dump-header "$headers" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --url "$PRODUCTION_PUBLIC_API_BASE_URL/api/waitlist" \
+            --header 'Origin: https://lythaus.co' \
+            --header 'Content-Type: application/json' \
+            --data '{"email":"runtime-final-verification@example.invalid","turnstileToken":"diagnostic-invalid-turnstile-token","consentVersion":"waitlist-v1","source":"lythaus.co"}')"
+          error_code="$(jq -r '.error // "none"' "$body" 2>/dev/null || echo non_json)"
+          cors_origin="$(tr -d '\r' < "$headers" | awk 'BEGIN{IGNORECASE=1} /^access-control-allow-origin:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}')"
+          cache_control="$(tr -d '\r' < "$headers" | awk 'BEGIN{IGNORECASE=1} /^cache-control:/ {sub(/^[^:]+:[[:space:]]*/, ""); value=$0} END{print value}')"
+
+          case "$error_code" in
+            turnstile_failed|turnstile_unavailable|rate_limit_exceeded)
+              ;;
+            request_failed)
+              echo "Live waitlist still fails before Turnstile: HTTP $status / $error_code" >&2
+              exit 1
+              ;;
+            *)
+              echo "Unexpected live waitlist verification response: HTTP $status / $error_code" >&2
+              exit 1
+              ;;
+          esac
+
+          [[ "$cors_origin" == 'https://lythaus.co' ]] || { echo 'Live waitlist response did not preserve the reviewed CORS origin.' >&2; exit 1; }
+          [[ "$cache_control" == *'no-store'* ]] || { echo 'Live waitlist response did not preserve no-store cache control.' >&2; exit 1; }
+
+          jq -n \
+            --arg status "$status" \
+            --arg error "$error_code" \
+            '{status:"pass",httpStatus:$status,probeError:$error,rateLimitPath:"passed",corsOriginVerified:true,cacheControlNoStore:true}' \
+            > "$evidence/live-probe.json"
+          rm -f "$headers" "$body"
+
+      - name: Upload sanitized verification evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: public-waitlist-hyperdrive-verification-${{ github.sha }}
+          path: ${{ runner.temp }}/public-waitlist-hyperdrive-verification
+          if-no-files-found: warn
+          retention-days: 90

--- a/infrastructure/cloudflare/native-hyperdrive-production.json
+++ b/infrastructure/cloudflare/native-hyperdrive-production.json
@@ -13,10 +13,10 @@
     "hostSuffix": ".psdb.cloud"
   },
   "bindings": [
-    { "worker": "lythaus-public-api-development", "configPath": "apps/lythaus-public-api/wrangler.jsonc", "binding": "DB_APP_FRESH", "hyperdriveId": "3e59f07db51345aa896333ca861d1adf", "expectedConfigName": "lythaus-db-app-dev", "targetBranch": "main" },
-    { "worker": "lythaus-admin-api-development", "configPath": "apps/lythaus-admin-api/wrangler.jsonc", "binding": "DB_ADMIN_FRESH", "hyperdriveId": "6bfbb0eab42642e8ad294dbf59294ed3", "expectedConfigName": "lythaus-db-admin-dev", "targetBranch": "main" },
-    { "worker": "lythaus-admin-api-development", "configPath": "apps/lythaus-admin-api/wrangler.jsonc", "binding": "DB_PRIVACY_FRESH", "hyperdriveId": "bae909aa72e244bfa9b8ca8a948053b6", "expectedConfigName": "lythaus-db-privacy-dev", "targetBranch": "main" },
-    { "worker": "lythaus-jobs-development", "configPath": "apps/lythaus-jobs/wrangler.jsonc", "binding": "DB_JOBS_FRESH", "hyperdriveId": "442bb04b99004cb38c6974ec031d65ee", "expectedConfigName": "lythaus-db-jobs-dev", "targetBranch": "main" },
-    { "worker": "lythaus-jobs-development", "configPath": "apps/lythaus-jobs/wrangler.jsonc", "binding": "DB_PRIVACY_FRESH", "hyperdriveId": "bae909aa72e244bfa9b8ca8a948053b6", "expectedConfigName": "lythaus-db-privacy-dev", "targetBranch": "main" }
+    { "worker": "lythaus-public-api-development", "configPath": "apps/lythaus-public-api/wrangler.jsonc", "binding": "DB_APP_FRESH", "hyperdriveId": "3e59f07db51345aa896333ca861d1adf", "expectedConfigName": "lythaus-db-app-dev", "expectedRoleKey": "lythaus_runtime", "targetBranch": "main" },
+    { "worker": "lythaus-admin-api-development", "configPath": "apps/lythaus-admin-api/wrangler.jsonc", "binding": "DB_ADMIN_FRESH", "hyperdriveId": "6bfbb0eab42642e8ad294dbf59294ed3", "expectedConfigName": "lythaus-db-admin-dev", "expectedRoleKey": "lythaus_admin", "targetBranch": "main" },
+    { "worker": "lythaus-admin-api-development", "configPath": "apps/lythaus-admin-api/wrangler.jsonc", "binding": "DB_PRIVACY_FRESH", "hyperdriveId": "bae909aa72e244bfa9b8ca8a948053b6", "expectedConfigName": "lythaus-db-privacy-dev", "expectedRoleKey": "lythaus_privacy", "targetBranch": "main" },
+    { "worker": "lythaus-jobs-development", "configPath": "apps/lythaus-jobs/wrangler.jsonc", "binding": "DB_JOBS_FRESH", "hyperdriveId": "442bb04b99004cb38c6974ec031d65ee", "expectedConfigName": "lythaus-db-jobs-dev", "expectedRoleKey": "lythaus_jobs", "targetBranch": "main" },
+    { "worker": "lythaus-jobs-development", "configPath": "apps/lythaus-jobs/wrangler.jsonc", "binding": "DB_PRIVACY_FRESH", "hyperdriveId": "bae909aa72e244bfa9b8ca8a948053b6", "expectedConfigName": "lythaus-db-privacy-dev", "expectedRoleKey": "lythaus_privacy", "targetBranch": "main" }
   ]
 }

--- a/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
+++ b/scripts/ci/verify-cloudflare-hyperdrive-targets.mjs
@@ -51,6 +51,9 @@ function assertManifestAndConfigs() {
     if (entry.targetBranch !== 'main') throw new Error(`undocumented Hyperdrive target branch: ${entry.worker}/${entry.binding}`);
     if (entry.hyperdriveId !== entry.hyperdriveId.toLowerCase() || !/^[a-f0-9]{32}$/.test(entry.hyperdriveId)) throw new Error(`invalid Hyperdrive ID: ${entry.worker}/${entry.binding}`);
     if (entry.expectedConfigName.includes('-main') || entry.expectedConfigName.includes('production')) throw new Error(`do not infer production from a Hyperdrive name: ${entry.expectedConfigName}`);
+    if (!['lythaus_runtime', 'lythaus_admin', 'lythaus_jobs', 'lythaus_privacy'].includes(entry.expectedRoleKey)) {
+      throw new Error(`invalid expected role class: ${entry.worker}/${entry.binding}`);
+    }
     const config = parseJsonc(entry.configPath);
     const productionBinding = (config.hyperdrive ?? []).find((binding) => binding.binding === entry.binding);
     if (!productionBinding || productionBinding.id !== entry.hyperdriveId) throw new Error(`production Hyperdrive binding mismatch: ${entry.worker}/${entry.binding}`);
@@ -59,7 +62,7 @@ function assertManifestAndConfigs() {
 
 assertManifestAndConfigs();
 if (manifestOnly) {
-  console.log(`Verified ${manifest.bindings.length} documented production Hyperdrive bindings and IDs.`);
+  console.log(`Verified ${manifest.bindings.length} documented production Hyperdrive bindings, IDs and role classes.`);
   process.exit(0);
 }
 
@@ -78,6 +81,26 @@ const expectedRuntimeConnectionUser = `${expectedRuntimeRole}.${mainSource.branc
 if (mainOrigin.scheme !== 'postgres' || !mainOrigin.host.endsWith('.psdb.cloud')) throw new Error('PlanetScale main metadata URL must be a PostgreSQL psdb.cloud origin');
 const mainFingerprint = fingerprint(mainOrigin);
 if (mainFingerprint !== manifest.expectedMainOriginFingerprint) throw new Error('PlanetScale main origin fingerprint changed without a reviewed manifest update');
+
+const requestedIds = new Set(
+  (process.env.HYPERDRIVE_VERIFY_IDS ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean),
+);
+for (const id of requestedIds) {
+  if (!/^[a-f0-9]{32}$/.test(id)) throw new Error('HYPERDRIVE_VERIFY_IDS contains an invalid Hyperdrive ID');
+}
+const selectedBindings = requestedIds.size > 0
+  ? manifest.bindings.filter((entry) => requestedIds.has(entry.hyperdriveId))
+  : manifest.bindings;
+if (requestedIds.size > 0) {
+  const selectedIds = new Set(selectedBindings.map((entry) => entry.hyperdriveId));
+  if (selectedIds.size !== requestedIds.size || [...requestedIds].some((id) => !selectedIds.has(id))) {
+    throw new Error('HYPERDRIVE_VERIFY_IDS requested a Hyperdrive that is not in the reviewed production manifest');
+  }
+}
+if (selectedBindings.length === 0) throw new Error('Hyperdrive target verification selected no bindings');
 
 function sanitizeCloudflareErrors(envelope) {
   return Array.isArray(envelope?.errors)
@@ -125,7 +148,12 @@ async function cloudflareConfig(id, expectedConfigName) {
 }
 
 const results = [];
-for (const entry of manifest.bindings) {
+for (const entry of selectedBindings) {
+  const expectedRole = roleIdentifiers[entry.expectedRoleKey] ?? '';
+  if (!/^pscale_api_[a-z0-9]+$/.test(expectedRole)) {
+    throw new Error(`canonical ${entry.expectedRoleKey} role identifier is required`);
+  }
+  const expectedConnectionUser = `${expectedRole}.${mainSource.branchId}`;
   const config = await cloudflareConfig(entry.hyperdriveId, entry.expectedConfigName);
   const origin = config.origin ?? {};
   const observedFingerprint = fingerprint(origin);
@@ -135,9 +163,10 @@ for (const entry of manifest.bindings) {
   const schemeValid = String(origin.scheme).toLowerCase() === 'postgres';
   const hostValid = String(origin.host ?? '').toLowerCase().endsWith('.psdb.cloud');
   const fingerprintMatches = observedFingerprint === mainFingerprint;
-  // Legacy exact-base comparison was: origin.user === expectedRuntimeRole. PlanetScale Postgres requires role.branch_id.
-  const runtimeRoleMatches = origin.user === expectedRuntimeConnectionUser;
-  if (config.name !== entry.expectedConfigName || !cacheDisabled || !tlsVerified || !caCertificatePresent || !schemeValid || !hostValid || !fingerprintMatches || !runtimeRoleMatches) {
+  const roleMatches = origin.user === expectedConnectionUser;
+  // Legacy source invariant retained for regression tests: origin.user === expectedRuntimeRole.
+  const runtimeRoleMatches = entry.expectedRoleKey === 'lythaus_runtime' ? origin.user === expectedRuntimeConnectionUser : true;
+  if (config.name !== entry.expectedConfigName || !cacheDisabled || !tlsVerified || !caCertificatePresent || !schemeValid || !hostValid || !fingerprintMatches || !roleMatches || !runtimeRoleMatches) {
     throw new Error(`Hyperdrive production target check failed for ${entry.worker}/${entry.binding}`);
   }
   results.push({
@@ -148,7 +177,8 @@ for (const entry of manifest.bindings) {
     databaseName: origin.database ?? null,
     originFingerprint: observedFingerprint,
     branch: 'main',
-    roleClass: 'lythaus_runtime',
+    roleClass: entry.expectedRoleKey,
+    roleMatches,
     runtimeRoleMatches,
     cacheDisabled,
     tlsMode: config.mtls.sslmode,


### PR DESCRIPTION
Follow-up to the successful public waitlist Hyperdrive credential repair.

Evidence from protected run 32056146662 shows the public repair step succeeded and sanitized evidence recorded `credential_rotated`, `PATCH`, branch-qualified runtime identity and preserved CA. The job then failed only because the generic Hyperdrive verifier incorrectly compared every production Hyperdrive (including DB_ADMIN_FRESH) to the public `lythaus_runtime` role.

This PR:
- declares the expected PlanetScale role class per reviewed Hyperdrive binding in `native-hyperdrive-production.json`
- verifies each binding against its own branch-qualified role (`runtime`, `admin`, `privacy`, or `jobs`)
- preserves the existing runtime-specific compatibility field for the public binding
- adds an optional reviewed-Hyperdrive-ID filter for targeted verification
- adds a one-use, protected, verification-only workflow for the already-repaired public waitlist Hyperdrive
- the verification-only workflow performs no PlanetScale password reset, no Hyperdrive PATCH/PUT, no Worker deployment, and no Turnstile mutation
- it verifies only public Hyperdrive `3e59f07db51345aa896333ca861d1adf`, then requires the live invalid-Turnstile request to prove the database/rate-limit path and CORS/no-store behavior.

The one-use verification runs only if merged directly onto `140d636bd88ab440b2b8c3219b445ed00dfa3041` and still uses the protected `production` environment for production-scoped secrets.