### PR TITLE
Refresh lythaus.co with human-first public-interest pitch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
       - run: npm ci --ignore-scripts --prefix apps/control-panel
       - run: npm ci --ignore-scripts --prefix apps/marketing-site
       - run: npm --prefix apps/control-panel test
+      - run: node --test apps/marketing-site/tests/*.test.mjs
       - run: npm --prefix apps/control-panel run build
       - run: npm --prefix apps/marketing-site run build
 

--- a/.github/workflows/deploy-marketing-human-first-refresh-once.yml
+++ b/.github/workflows/deploy-marketing-human-first-refresh-once.yml
@@ -1,0 +1,137 @@
+name: Deploy human-first marketing refresh once
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/deploy-marketing-human-first-refresh-once.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lythaus-marketing-production
+  cancel-in-progress: false
+
+jobs:
+  deploy-and-verify:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 20
+    env:
+      EXPECTED_BASE_SHA: ce949bf961b8342613839931dfaad2db3dc7f22c
+      PAGES_PROJECT: lythaus-marketing
+      PUBLIC_API_BASE_URL: https://api.lythaus.co
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+
+      - name: Require merge directly onto reviewed current main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse origin/main)" = "$GITHUB_SHA" || {
+            echo 'Refusing deployment: this run is not current origin/main.' >&2
+            exit 1
+          }
+          test "$(git rev-parse HEAD^1)" = "$EXPECTED_BASE_SHA" || {
+            echo 'Refusing deployment: expected reviewed main SHA is not the first parent.' >&2
+            exit 1
+          }
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/marketing-site/package-lock.json
+
+      - name: Resolve production Turnstile sitekey
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: node scripts/cloudflare/waitlist-turnstile.mjs resolve
+
+      - name: Build exact current-main marketing artifact
+        working-directory: apps/marketing-site
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const url = new URL(process.env.PUBLIC_API_BASE_URL); if (url.protocol !== 'https:' || url.hostname !== 'api.lythaus.co' || url.pathname !== '/') throw new Error('PUBLIC_API_BASE_URL must be https://api.lythaus.co');"
+          node -e "if (!/^[A-Za-z0-9_-]{20,}$/.test(process.env.PUBLIC_TURNSTILE_SITE_KEY ?? '')) throw new Error('PUBLIC_TURNSTILE_SITE_KEY is invalid');"
+          npm ci
+          npm run build
+          node ../../scripts/cloudflare/validate-marketing-output.mjs dist
+          grep -F 'challenges.cloudflare.com/turnstile/v0/api.js' dist/index.html
+          grep -F 'waitlist_signup' dist/index.html
+          grep -F 'The human internet is worth protecting.' dist/index.html
+          grep -F 'Built for humans first.' dist/index.html
+          grep -F 'Lythaus is a human-first, public-interest platform built for genuine human interaction.' dist/index.html
+          grep -F 'Algorithms for relevance, not addiction.' dist/index.html
+          grep -F 'Reputation is earned.' dist/index.html
+          grep -F 'Member content is not sold or repurposed to train generative models.' dist/index.html
+          if grep -R -n -i 'TURNSTILE_SECRET\|PII_ENCRYPTION_KEY\|PII_HMAC_KEY' dist; then
+            echo 'Sensitive binding name leaked into the marketing artifact.' >&2
+            exit 1
+          fi
+
+      - name: Deploy exact current main SHA to Cloudflare Pages production
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CLOUDFLARE_API_TOKEN" && test -n "$CLOUDFLARE_ACCOUNT_ID"
+          npx --yes wrangler@4.110.0 pages deploy apps/marketing-site/dist \
+            --project-name "$PAGES_PROJECT" \
+            --branch main \
+            --commit-hash "$GITHUB_SHA" \
+            --commit-dirty=false | tee "$RUNNER_TEMP/wrangler-marketing-output.txt"
+          preview_url="$(grep -Eo 'https://[a-z0-9-]+\.lythaus-marketing\.pages\.dev' "$RUNNER_TEMP/wrangler-marketing-output.txt" | head -n 1)"
+          test -n "$preview_url"
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+          rm -f "$RUNNER_TEMP/wrangler-marketing-output.txt"
+
+      - name: Verify custom domains serve deployed production artifact
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/marketing-human-first"
+          for host in https://lythaus.co https://www.lythaus.co; do
+            body="$(mktemp)"
+            headers="$(mktemp)"
+            status="$(curl --location --silent --show-error --max-time 30 --retry 6 --retry-delay 3 --dump-header "$headers" --output "$body" --write-out '%{http_code}' "$host/")"
+            test "$status" = 200
+            grep -F 'The human internet is worth protecting.' "$body"
+            grep -F 'Built for humans first.' "$body"
+            grep -F 'Algorithms for relevance, not addiction.' "$body"
+            grep -F 'Reputation is earned.' "$body"
+            grep -F 'challenges.cloudflare.com/turnstile/v0/api.js' "$body"
+            grep -F 'waitlist_signup' "$body"
+            grep -F -i 'X-Content-Type-Options: nosniff' "$headers"
+            grep -F -i 'X-Frame-Options: DENY' "$headers"
+            rm -f "$body" "$headers"
+          done
+          jq -n \
+            --arg commitSha "$GITHUB_SHA" \
+            --arg project "$PAGES_PROJECT" \
+            --arg previewUrl "$PREVIEW_URL" \
+            --arg verifiedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{schemaVersion:1,status:"pass",commitSha:$commitSha,project:$project,branch:"main",previewUrl:$previewUrl,customDomains:["lythaus.co","www.lythaus.co"],turnstileClientPresent:true,waitlistClientPresent:true,verifiedAt:$verifiedAt}' \
+            > "$RUNNER_TEMP/marketing-human-first/deployment.json"
+
+      - name: Upload sanitized deployment evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: marketing-human-first-${{ github.sha }}
+          path: ${{ runner.temp }}/marketing-human-first
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/deploy-marketing-shell.yml
+++ b/.github/workflows/deploy-marketing-shell.yml
@@ -64,9 +64,12 @@ jobs:
             echo 'Turnstile client must not be present while waitlist activation is deferred.' >&2
             exit 1
           fi
-          grep -F 'The internet is changing.' dist/index.html
-          grep -F 'Trust should not disappear with it.' dist/index.html
-          grep -F 'Human authenticity will become more valuable' dist/index.html
+          grep -F 'The human internet is worth protecting.' dist/index.html
+          grep -F 'Built for humans first.' dist/index.html
+          grep -F 'Lythaus is a human-first, public-interest platform built for genuine human interaction.' dist/index.html
+          grep -F 'Algorithms for relevance, not addiction.' dist/index.html
+          grep -F 'Reputation is earned.' dist/index.html
+          grep -F 'Member content is not sold or repurposed to train generative models.' dist/index.html
           if grep -R -n -i 'TURNSTILE_SECRET\|PII_ENCRYPTION_KEY\|PII_HMAC_KEY' dist; then
             echo 'Sensitive binding name leaked into the marketing artifact.' >&2
             exit 1
@@ -96,9 +99,10 @@ jobs:
             headers="$(mktemp)"
             status="$(curl --location --silent --show-error --max-time 30 --retry 6 --retry-delay 3 --dump-header "$headers" --output "$body" --write-out '%{http_code}' "$host/")"
             test "$status" = 200
-            grep -F 'The internet is changing.' "$body"
-            grep -F 'Trust should not disappear with it.' "$body"
-            grep -F 'Human authenticity will become more valuable' "$body"
+            grep -F 'The human internet is worth protecting.' "$body"
+            grep -F 'Built for humans first.' "$body"
+            grep -F 'Algorithms for relevance, not addiction.' "$body"
+            grep -F 'Reputation is earned.' "$body"
             grep -F -i 'X-Content-Type-Options: nosniff' "$headers"
             grep -F -i 'X-Frame-Options: DENY' "$headers"
             rm -f "$body" "$headers"

--- a/apps/marketing-site/src/layouts/BaseLayout.astro
+++ b/apps/marketing-site/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ import '../styles/global.css';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
-    <meta name="theme-color" content={homePage ? '#1c1c1a' : '#090a0b'} />
+    <meta name="theme-color" content={homePage ? '#070706' : '#090a0b'} />
     <title>{pageTitle}</title>
     <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" sizes="any" />
@@ -49,9 +49,11 @@ import '../styles/global.css';
       <nav class="site-nav" aria-label="Main navigation">
         {homePage ? (
           <>
-            <a href="#vision">Vision</a>
+            <a href="#problem">Problem</a>
+            <a href="#lythaus">Lythaus</a>
+            <a href="#experience">Experience</a>
+            <a href="#discovery">Discovery</a>
             <a href="#principles">Principles</a>
-            <a href="#audience">Who it is for</a>
           </>
         ) : (
           <>

--- a/apps/marketing-site/src/pages/index.astro
+++ b/apps/marketing-site/src/pages/index.astro
@@ -1,120 +1,217 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import '../styles/home-pitch.css';
 
 const publicApiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL ?? 'https://api.lythaus.co';
 const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY ?? '';
 ---
 <BaseLayout
-  title="Lythaus | A more trustworthy social platform"
-  description="Lythaus is building a social platform for human contribution, credible discussion and clearer context online. Join the private beta waitlist."
+  title="Lythaus | Human-first public-interest platform"
+  description="Lythaus is a human-first, public-interest platform built for genuine human interaction, transparent Discovery and accountable human contribution."
   canonicalPath="/"
   absoluteTitle={true}
   homePage={true}
 >
-  <section class="home-hero" aria-labelledby="hero-title">
-    <div class="home-hero-copy">
-      <p class="home-eyebrow"><span class="home-status-dot" aria-hidden="true"></span>A different kind of social platform</p>
-      <h1 id="hero-title">The internet is changing.<br />Trust should not disappear with it.</h1>
-      <p class="home-hero-body">Lythaus is building a social platform for people who value human contribution, credible discussion and clearer context online.</p>
-      <div class="home-actions">
-        <a class="button primary" href="#waitlist">Join the waitlist</a>
-        <a class="home-secondary-link" href="#vision">Why Lythaus</a>
+  <section class="pitch-intro" id="top" aria-labelledby="pitch-wordmark">
+    <div class="pitch-intro-inner">
+      <h1 class="pitch-wordmark" id="pitch-wordmark" aria-label="Lythaus">
+        <span class="pitch-letter" style="--letter-index: 0" aria-hidden="true">L</span>
+        <span class="pitch-letter" style="--letter-index: 1" aria-hidden="true">Y</span>
+        <span class="pitch-letter" style="--letter-index: 2" aria-hidden="true">T</span>
+        <span class="pitch-letter" style="--letter-index: 3" aria-hidden="true">H</span>
+        <span class="pitch-letter" style="--letter-index: 4" aria-hidden="true">A</span>
+        <span class="pitch-letter" style="--letter-index: 5" aria-hidden="true">U</span>
+        <span class="pitch-letter" style="--letter-index: 6" aria-hidden="true">S</span>
+      </h1>
+      <p class="pitch-intro-statement">The human internet is worth protecting.</p>
+    </div>
+    <a class="pitch-scroll-cue" href="#problem" aria-label="Continue to the problem section"><span></span></a>
+  </section>
+
+  <section class="pitch-section pitch-problem" id="problem" aria-labelledby="problem-title" data-pitch-reveal>
+    <div class="pitch-section-meta">01 / The Problem</div>
+    <div class="pitch-problem-grid">
+      <div class="pitch-copy-column">
+        <h2 id="problem-title">The internet has changed.</h2>
+        <p class="pitch-lede">Content can now be generated at extraordinary scale due to AI.</p>
+        <p>At the same time, existing social media platforms increasingly reward volume, virality and engagement, creating an environment where these can thrive.</p>
       </div>
-      <p class="home-hero-note">Private beta. Early members will help shape the platform.</p>
-    </div>
-    <aside class="home-hero-rail" aria-label="Lythaus private beta">
-      <span>LYT / 2026</span>
-      <p>A social platform designed around trust, contribution and clearer context.</p>
-    </aside>
-  </section>
-
-  <section class="home-problem home-section" id="vision" aria-labelledby="problem-title">
-    <p class="home-section-index">01 / The problem</p>
-    <div class="home-section-copy">
-      <h2 id="problem-title">We are entering an internet where content is abundant. Certainty is not.</h2>
-      <p>Synthetic content, automated accounts, engagement farming and increasingly opaque feeds are changing the character of online conversation. The question is no longer only what we see. It is whether we understand what stands behind it.</p>
+      <div>
+        <ul class="pitch-signal-list" aria-label="Problems affecting modern social platforms">
+          <li>AI-generated slop.</li>
+          <li>Bot accounts manipulating feeds.</li>
+          <li>Ragebait headlines.</li>
+          <li>Engagement farming.</li>
+          <li>Manufactured attention.</li>
+        </ul>
+        <p class="pitch-result">The result is more noise, greater manipulation and growing uncertainty about what or who is real.</p>
+      </div>
     </div>
   </section>
 
-  <section class="home-thesis home-section" id="principles" aria-labelledby="thesis-title">
-    <div class="home-section-heading">
-      <p class="home-kicker">The Lythaus thesis</p>
-      <h2 id="thesis-title">Social media should become more trustworthy, not more artificial.</h2>
-      <p>We are designing Lythaus around a small number of principles that are deliberately different from the incentives shaping many existing platforms.</p>
+  <section class="pitch-section pitch-human-first" id="human-first" aria-labelledby="human-first-title" data-pitch-reveal>
+    <div class="pitch-section-meta">02 / Built for Humans First</div>
+    <h2 id="human-first-title">Built for humans first.</h2>
+    <div class="pitch-four-lines" aria-label="Lythaus priorities">
+      <span>Human interaction.</span>
+      <span>Public-interest information.</span>
+      <span>Accountable contribution.</span>
+      <span>Clearer context.</span>
     </div>
-    <div class="home-principle-list">
-      <article class="home-principle-row">
-        <span>01</span>
-        <h3>Human contribution should matter</h3>
-        <p>In a world where content can be produced at extraordinary scale, genuine human perspective becomes more valuable. Lythaus is being built to recognise that distinction.</p>
-      </article>
-      <article class="home-principle-row">
-        <span>02</span>
-        <h3>Transparency should be normal</h3>
-        <p>AI is part of the future. Deception does not have to be. Lythaus is pro technology and pro transparency. People should have clearer context about the content they consume.</p>
-      </article>
-      <article class="home-principle-row">
-        <span>03</span>
-        <h3>Quality should beat manipulation</h3>
-        <p>The loudest post should not automatically become the most important post. We want thoughtful contribution, credibility and public value to matter more than outrage or engagement tricks.</p>
-      </article>
-      <article class="home-principle-row">
-        <span>04</span>
-        <h3>Trust has to be earned</h3>
-        <p>Credibility should come from contribution and accountability, not status, follower count or the ability to pay for attention.</p>
-      </article>
+    <p class="pitch-welcome">Welcome to Lythaus.</p>
+  </section>
+
+  <section class="pitch-section pitch-platform" id="lythaus" aria-labelledby="lythaus-title" data-pitch-reveal>
+    <div class="pitch-section-meta">03 / What Lythaus Is</div>
+    <div class="pitch-platform-grid">
+      <div>
+        <h2 id="lythaus-title">Lythaus is a human-first, public-interest platform built for genuine human interaction.</h2>
+        <p class="pitch-lede">Follow people and topics. Share your perspective. Discuss what matters. Discover public-interest information from other humans.</p>
+      </div>
+      <div class="pitch-platform-detail">
+        <h3>Lythaus is different.</h3>
+        <p>Lythaus Authenticity AI actively detects and blocks AI-generated public content, while behavioural signals help identify bot activity, coordinated abuse and manipulation.</p>
+        <p>Our Discovery feed uses simple, transparent algorithms based on interests you choose, your optional general location, previous searches and other signals you control.</p>
+      </div>
+    </div>
+    <div class="pitch-manifesto-line">
+      <strong>Algorithms for relevance, not addiction.</strong>
+      <span>Human contribution, reputation and public-interest value have more influence over what you see than whatever simply generates the most clicks, outrage or time on screen.</span>
     </div>
   </section>
 
-  <section class="home-positioning home-section" aria-labelledby="positioning-title">
-    <p class="home-kicker" id="positioning-title">What Lythaus stands for</p>
-    <div class="home-positioning-grid">
-      <article class="home-positioning-panel home-positioning-positive">
-        <p class="home-panel-label">We are building for</p>
-        <h2>Human authenticity.<br />Better information.<br />Accountable discussion.</h2>
-        <p>A platform designed around trust and signal rather than volume for its own sake.</p>
-      </article>
-      <article class="home-positioning-panel">
-        <p class="home-panel-label">We are not building for</p>
-        <h2>AI spam.<br />Ragebait.<br />Manufactured attention.</h2>
-        <p>Lythaus is not another social feed with a different logo. The product is being designed around a different set of incentives.</p>
-      </article>
+  <section class="pitch-section pitch-experience" id="experience" aria-labelledby="experience-title" data-pitch-reveal>
+    <div class="pitch-section-meta">04 / Experience Lythaus</div>
+    <div class="pitch-experience-grid">
+      <div class="pitch-copy-column">
+        <h2 id="experience-title">Explore the app yourself.</h2>
+        <p class="pitch-lede">Enter a live, read-only version of Lythaus and experience the platform directly.</p>
+        <p>Browse Discovery. Scroll posts. Open discussions. Visit profiles. Explore public-interest topics. Inspect authenticity labels and see how reputation works.</p>
+        <p class="pitch-quiet">Participation remains restricted to registered members.</p>
+      </div>
+      <div class="pitch-preview-shell" aria-label="Guest Preview">
+        <div class="pitch-preview-topbar">
+          <span>Guest Preview</span>
+          <span>Read only</span>
+        </div>
+        <div class="pitch-preview-body">
+          <div class="pitch-preview-nav" aria-hidden="true">
+            <span class="active">Discovery</span>
+            <span>Topics</span>
+            <span>News Board</span>
+          </div>
+          <article class="pitch-preview-post">
+            <div class="pitch-preview-post-head">
+              <span class="pitch-avatar" aria-hidden="true"></span>
+              <div>
+                <strong>Public-interest discussion</strong>
+                <small>Human-authored</small>
+              </div>
+            </div>
+            <p>See the product, the context around each contribution and how reputation is surfaced without taking part as a guest.</p>
+          </article>
+          <article class="pitch-preview-post secondary" aria-hidden="true">
+            <div class="pitch-preview-lines"><span></span><span></span><span></span></div>
+          </article>
+        </div>
+        <div class="pitch-preview-footer">
+          <div>
+            <strong>You've explored Lythaus.</strong>
+            <span>Want to be part of it?</span>
+          </div>
+          <a class="button primary" href="#waitlist">Join the private beta</a>
+        </div>
+      </div>
     </div>
   </section>
 
-  <section class="home-audience home-section" id="audience" aria-labelledby="audience-title">
-    <div class="home-section-heading">
-      <p class="home-kicker">Who Lythaus is for</p>
-      <h2 id="audience-title">People who want more signal from the internet.</h2>
+  <section class="pitch-section pitch-discovery" id="discovery" aria-labelledby="discovery-title" data-pitch-reveal>
+    <div class="pitch-section-meta">07 / A Different Kind of Feed</div>
+    <div class="pitch-discovery-grid">
+      <div>
+        <h2 id="discovery-title">Algorithms for relevance, not addiction.</h2>
+        <p class="pitch-lede">Personalisation itself is not the problem.</p>
+        <p>The question is what it is optimised for.</p>
+      </div>
+      <div>
+        <p class="pitch-small-heading">Lythaus Discovery can consider</p>
+        <ul class="pitch-clean-list">
+          <li>Your chosen interests</li>
+          <li>General location, optional, or a region of your choice</li>
+          <li>Previous searches</li>
+          <li>Topics you follow</li>
+          <li>Your feed preferences</li>
+          <li>Reputation and contribution signals</li>
+        </ul>
+      </div>
     </div>
-    <div class="home-audience-list">
-      <article>
-        <span>Audience 01</span>
-        <h3>People who follow the world closely</h3>
-        <p>For people interested in news, technology, science, business, policy, culture and the conversations that shape them.</p>
-      </article>
-      <article>
-        <span>Audience 02</span>
-        <h3>Journalists, researchers and analysts</h3>
-        <p>For people whose work depends on credibility, sourcing, context and the ability to have serious public conversations.</p>
-      </article>
-      <article>
-        <span>Audience 03</span>
-        <h3>People tired of low quality feeds</h3>
-        <p>For anyone who feels that more content has not necessarily produced a better internet.</p>
-      </article>
+    <div class="pitch-control-line">
+      <strong>Your interests. Your controls. Your feed.</strong>
+      <span>Members can see and manage the information shaping Discovery.</span>
+    </div>
+    <div class="pitch-no-profile">
+      <h3>No hidden behavioural profile built simply to keep you scrolling.</h3>
+      <p>Personalisation is designed to be transparent, editable and under the member's control.</p>
     </div>
   </section>
 
-  <section class="home-statement home-section" aria-label="A founding principle of Lythaus">
-    <p>Human authenticity will become more valuable as synthetic content becomes easier to create.</p>
-    <span>A founding principle of Lythaus</span>
+  <section class="pitch-section pitch-reputation" id="reputation" aria-labelledby="reputation-title" data-pitch-reveal>
+    <div class="pitch-section-meta">08 / Reputation</div>
+    <p class="pitch-pretitle">Attention is easy to manufacture.</p>
+    <h2 id="reputation-title">Reputation is earned.</h2>
+    <div class="pitch-reputation-grid">
+      <div>
+        <p>Lythaus reputation is designed around contribution and accountability rather than:</p>
+        <ul class="pitch-reputation-rejects">
+          <li>Follower count.</li>
+          <li>Posting volume.</li>
+          <li>Virality.</li>
+          <li>Paid visibility.</li>
+          <li>Engagement manipulation.</li>
+        </ul>
+      </div>
+      <div class="pitch-reputation-copy">
+        <p>Qualifying human-authored contributions can build authorship reputation.</p>
+        <p>Deliberate mislabelling, manipulation, evasion and coordinated abuse can reduce standing.</p>
+        <strong>Who contributes should matter. How they contribute should matter more.</strong>
+      </div>
+    </div>
   </section>
 
-  <section class="home-waitlist home-section" id="waitlist" aria-labelledby="waitlist-title">
+  <section class="pitch-section pitch-ai" id="ai" aria-labelledby="ai-title" data-pitch-reveal>
+    <div class="pitch-section-meta">11 / Lythaus and AI</div>
+    <div class="pitch-ai-grid">
+      <div>
+        <h2 id="ai-title">Lythaus is not anti-AI.</h2>
+        <p class="pitch-lede">AI helped us design and build Lythaus, and it will remain an important part of our lives.</p>
+      </div>
+      <div class="pitch-ai-copy">
+        <p>The distinction is not whether AI should exist, but how and where it should participate.</p>
+        <p>Lythaus prioritises human authorship and human accountability in public-interest discussion.</p>
+        <p class="pitch-emphasis">Technology should assist human participation, not impersonate or quietly replace it.</p>
+        <p class="pitch-data-promise">Member content is not sold or repurposed to train generative models.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="pitch-section pitch-principles" id="principles" aria-labelledby="principles-title" data-pitch-reveal>
+    <div class="pitch-section-meta">12 / Principles</div>
+    <h2 id="principles-title" class="sr-only">Lythaus principles</h2>
+    <ol class="pitch-principle-list">
+      <li>Human interaction should remain human.</li>
+      <li>Technology should assist people, not impersonate them.</li>
+      <li>Reputation is earned. Trust is gained.</li>
+      <li>Public-interest conversation deserves better incentives.</li>
+      <li>People should understand why they see what they see.</li>
+      <li>Algorithms should serve relevance, not addiction.</li>
+      <li>The human internet is worth protecting.</li>
+    </ol>
+  </section>
+
+  <section class="home-waitlist pitch-waitlist" id="waitlist" aria-labelledby="waitlist-title" data-pitch-reveal>
     <div class="home-waitlist-copy">
       <p class="home-eyebrow"><span class="home-status-dot" aria-hidden="true"></span>Lythaus private beta</p>
-      <h2 id="waitlist-title">Help shape a more trustworthy social platform.</h2>
+      <h2 id="waitlist-title">The human internet is worth protecting.</h2>
       <p>Join the Lythaus waitlist for early access, product updates and an opportunity to help shape what comes next.</p>
     </div>
     <form class="home-waitlist-form" data-waitlist data-api-base-url={publicApiBaseUrl} data-turnstile-site-key={turnstileSiteKey} novalidate>
@@ -132,6 +229,22 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY ?? '';
       <p class="home-form-status" id="waitlist-status" data-waitlist-status aria-live="polite" role="status"></p>
     </form>
   </section>
+
+  <script>
+    const revealTargets = document.querySelectorAll('[data-pitch-reveal]');
+    if ('IntersectionObserver' in window && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      const revealObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          entry.target.classList.add('is-visible');
+          revealObserver.unobserve(entry.target);
+        }
+      }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
+      revealTargets.forEach((target) => revealObserver.observe(target));
+    } else {
+      revealTargets.forEach((target) => target.classList.add('is-visible'));
+    }
+  </script>
 
   {turnstileSiteKey && <script is:inline src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>}
   <script>

--- a/apps/marketing-site/src/styles/home-pitch.css
+++ b/apps/marketing-site/src/styles/home-pitch.css
@@ -1,0 +1,1000 @@
+.home-page {
+  --pitch-bg: #070706;
+  --pitch-surface: #0d0d0b;
+  --pitch-surface-raised: #12120f;
+  --pitch-text: #f2eee3;
+  --pitch-text-soft: #c9c3b7;
+  --pitch-muted: #918b80;
+  --pitch-quiet: #686359;
+  --pitch-line: rgba(242, 238, 227, 0.11);
+  --pitch-line-strong: rgba(242, 238, 227, 0.22);
+  --pitch-warm: #f2c98d;
+  --pitch-max: 1280px;
+  color: var(--pitch-text);
+  background: var(--pitch-bg);
+}
+
+.home-page .page {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+}
+
+.home-page .site-header {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  z-index: 80;
+  width: min(calc(100% - 72px), var(--pitch-max));
+  min-height: 78px;
+  transform: translateX(-50%);
+  opacity: 0;
+  border-color: transparent;
+  background: rgba(7, 7, 6, 0.72);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
+  animation: pitchHeaderReveal 520ms ease 4.55s forwards;
+}
+
+.home-page .site-header::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1px;
+  background: var(--pitch-line);
+}
+
+.home-page .brand,
+.home-page .site-nav,
+.home-page .site-footer {
+  color: var(--pitch-text);
+}
+
+.home-page .site-nav {
+  color: var(--pitch-muted);
+}
+
+.home-page .site-nav a:hover {
+  color: var(--pitch-text);
+}
+
+.home-page .header-cta,
+.home-page .button.primary {
+  color: #1e1810;
+  background: var(--pitch-warm);
+  border-color: var(--pitch-warm);
+}
+
+.home-page .header-cta:hover,
+.home-page .button.primary:hover {
+  color: #17120c;
+  background: #f6d7aa;
+  border-color: #f6d7aa;
+}
+
+.home-page .header-cta,
+.home-page .button {
+  border-radius: 3px;
+}
+
+.home-page .site-footer {
+  width: min(calc(100% - 72px), var(--pitch-max));
+  border-color: var(--pitch-line);
+  color: var(--pitch-muted);
+}
+
+.pitch-intro,
+.pitch-section,
+.pitch-waitlist {
+  width: min(calc(100% - 72px), var(--pitch-max));
+  margin-inline: auto;
+}
+
+.pitch-intro {
+  position: relative;
+  min-height: 100svh;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.pitch-intro::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 47%, rgba(242, 201, 141, 0.035), transparent 34%);
+}
+
+.pitch-intro-inner {
+  display: grid;
+  justify-items: center;
+  gap: clamp(34px, 5vh, 58px);
+  text-align: center;
+  transform: translateY(-1.5vh);
+}
+
+.pitch-wordmark {
+  display: flex;
+  justify-content: center;
+  gap: clamp(7px, 1.3vw, 20px);
+  margin: 0;
+  color: var(--pitch-text);
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(68px, 12vw, 164px);
+  font-weight: 500;
+  line-height: 0.88;
+  letter-spacing: -0.05em;
+}
+
+.pitch-letter {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  min-width: 0.58em;
+  opacity: 0;
+  transform: scale(0.82);
+  filter: blur(13px) brightness(7);
+  color: #fffaf0;
+  text-shadow:
+    0 0 16px rgba(255, 250, 238, 0.96),
+    0 0 44px rgba(242, 201, 141, 0.72),
+    0 0 90px rgba(242, 201, 141, 0.26);
+  animation: pitchLetterResolve 940ms cubic-bezier(0.2, 0.72, 0.2, 1) forwards;
+  animation-delay: calc(720ms + (var(--letter-index) * 390ms));
+}
+
+.pitch-letter::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0.13em;
+  height: 0.13em;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(0.15);
+  opacity: 0;
+  background: #fffdf6;
+  box-shadow:
+    0 0 9px rgba(255, 253, 246, 1),
+    0 0 24px rgba(255, 247, 222, 0.88),
+    0 0 58px rgba(242, 201, 141, 0.56);
+  animation: pitchLightPoint 760ms ease-out forwards;
+  animation-delay: calc(610ms + (var(--letter-index) * 390ms));
+}
+
+.pitch-intro-statement {
+  max-width: 820px;
+  margin: 0;
+  opacity: 0;
+  transform: translateY(10px);
+  color: var(--pitch-text);
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(25px, 3.7vw, 48px);
+  font-weight: 500;
+  line-height: 1.18;
+  letter-spacing: -0.035em;
+  animation: pitchCopyReveal 700ms ease 3.82s forwards;
+}
+
+.pitch-scroll-cue {
+  position: absolute;
+  left: 50%;
+  bottom: 34px;
+  width: 28px;
+  height: 44px;
+  transform: translateX(-50%);
+  opacity: 0;
+  animation: pitchCueReveal 500ms ease 4.5s forwards;
+}
+
+.pitch-scroll-cue::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 1px;
+  height: 38px;
+  transform: translateX(-50%);
+  background: linear-gradient(to bottom, transparent, rgba(242, 238, 227, 0.58), transparent);
+}
+
+.pitch-scroll-cue span {
+  position: absolute;
+  left: 50%;
+  top: 6px;
+  width: 3px;
+  height: 7px;
+  border-radius: 999px;
+  transform: translateX(-50%);
+  background: var(--pitch-text);
+  animation: pitchCueMove 1.8s ease-in-out 4.7s infinite;
+}
+
+.pitch-section {
+  position: relative;
+  padding: clamp(110px, 14vw, 190px) 0;
+  border-top: 1px solid var(--pitch-line);
+}
+
+.pitch-section[data-pitch-reveal],
+.pitch-waitlist[data-pitch-reveal] {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 760ms ease, transform 760ms cubic-bezier(0.2, 0.72, 0.2, 1);
+}
+
+.pitch-section[data-pitch-reveal].is-visible,
+.pitch-waitlist[data-pitch-reveal].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.pitch-section-meta {
+  margin-bottom: clamp(46px, 6vw, 78px);
+  color: var(--pitch-warm);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.pitch-section h2,
+.pitch-waitlist h2 {
+  margin: 0;
+  color: var(--pitch-text);
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(46px, 6.5vw, 88px);
+  font-weight: 500;
+  line-height: 1.01;
+  letter-spacing: -0.06em;
+  text-wrap: balance;
+}
+
+.pitch-section h3 {
+  margin: 0;
+  color: var(--pitch-text);
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(25px, 3vw, 38px);
+  font-weight: 500;
+  line-height: 1.12;
+  letter-spacing: -0.04em;
+}
+
+.pitch-section p,
+.pitch-waitlist p {
+  color: var(--pitch-text-soft);
+  font-size: 17px;
+  line-height: 1.72;
+}
+
+.pitch-lede {
+  max-width: 760px;
+  color: var(--pitch-text) !important;
+  font-size: clamp(20px, 2vw, 26px) !important;
+  line-height: 1.5 !important;
+}
+
+.pitch-quiet {
+  color: var(--pitch-muted) !important;
+}
+
+.pitch-problem-grid,
+.pitch-platform-grid,
+.pitch-experience-grid,
+.pitch-discovery-grid,
+.pitch-reputation-grid,
+.pitch-ai-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: clamp(58px, 9vw, 150px);
+  align-items: start;
+}
+
+.pitch-copy-column > p:last-child {
+  margin-bottom: 0;
+}
+
+.pitch-signal-list,
+.pitch-clean-list,
+.pitch-reputation-rejects,
+.pitch-principle-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pitch-signal-list {
+  border-top: 1px solid var(--pitch-line-strong);
+}
+
+.pitch-signal-list li {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--pitch-line);
+  color: var(--pitch-text);
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(24px, 3.4vw, 43px);
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.pitch-result {
+  max-width: 780px;
+  margin: clamp(46px, 6vw, 76px) 0 0;
+  color: var(--pitch-text) !important;
+  font-size: clamp(24px, 3.6vw, 45px) !important;
+  line-height: 1.2 !important;
+  letter-spacing: -0.035em;
+}
+
+.pitch-human-first {
+  min-height: min(900px, 90svh);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.pitch-human-first h2 {
+  max-width: 980px;
+  font-size: clamp(62px, 9vw, 126px);
+}
+
+.pitch-four-lines {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 54px;
+  margin-top: clamp(60px, 8vw, 100px);
+  border-top: 1px solid var(--pitch-line-strong);
+}
+
+.pitch-four-lines span {
+  padding: 24px 0;
+  border-bottom: 1px solid var(--pitch-line);
+  color: var(--pitch-text-soft);
+  font-size: clamp(20px, 2.5vw, 31px);
+}
+
+.pitch-welcome {
+  margin: clamp(70px, 9vw, 118px) 0 0 !important;
+  color: var(--pitch-warm) !important;
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(30px, 4.6vw, 64px) !important;
+  font-weight: 500;
+  letter-spacing: -0.04em;
+}
+
+.pitch-platform-grid h2 {
+  font-size: clamp(43px, 5.4vw, 76px);
+}
+
+.pitch-platform-detail {
+  padding-top: 10px;
+}
+
+.pitch-platform-detail p {
+  margin: 22px 0 0;
+}
+
+.pitch-manifesto-line,
+.pitch-control-line {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: clamp(40px, 8vw, 120px);
+  margin-top: clamp(84px, 10vw, 140px);
+  padding: 30px 0;
+  border-top: 1px solid var(--pitch-line-strong);
+  border-bottom: 1px solid var(--pitch-line);
+}
+
+.pitch-manifesto-line strong,
+.pitch-control-line strong {
+  color: var(--pitch-text);
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(24px, 3vw, 40px);
+  font-weight: 500;
+  line-height: 1.18;
+  letter-spacing: -0.035em;
+}
+
+.pitch-manifesto-line span,
+.pitch-control-line span {
+  align-self: center;
+  color: var(--pitch-text-soft);
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.pitch-preview-shell {
+  overflow: hidden;
+  min-width: 0;
+  border: 1px solid var(--pitch-line-strong);
+  border-radius: 12px;
+  background: #0a0a08;
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.28);
+}
+
+.pitch-preview-topbar,
+.pitch-preview-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 22px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--pitch-line);
+  color: var(--pitch-muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pitch-preview-topbar span:first-child {
+  color: var(--pitch-warm);
+}
+
+.pitch-preview-body {
+  padding: 20px;
+}
+
+.pitch-preview-nav {
+  display: flex;
+  gap: 22px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--pitch-line);
+  color: var(--pitch-muted);
+  font-size: 13px;
+}
+
+.pitch-preview-nav .active {
+  color: var(--pitch-text);
+}
+
+.pitch-preview-post {
+  margin-top: 20px;
+  padding: 22px;
+  border: 1px solid var(--pitch-line);
+  border-radius: 8px;
+  background: var(--pitch-surface);
+}
+
+.pitch-preview-post-head {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.pitch-avatar {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #d8c09d, #706554);
+}
+
+.pitch-preview-post-head div {
+  display: grid;
+  gap: 3px;
+}
+
+.pitch-preview-post-head strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pitch-preview-post-head small {
+  width: fit-content;
+  padding: 3px 6px;
+  border: 1px solid rgba(242, 201, 141, 0.28);
+  border-radius: 999px;
+  color: var(--pitch-warm);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pitch-preview-post p {
+  margin: 18px 0 0;
+  color: var(--pitch-text-soft);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.pitch-preview-post.secondary {
+  min-height: 106px;
+  opacity: 0.52;
+}
+
+.pitch-preview-lines {
+  display: grid;
+  gap: 11px;
+}
+
+.pitch-preview-lines span {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(242, 238, 227, 0.09);
+}
+
+.pitch-preview-lines span:nth-child(1) { width: 86%; }
+.pitch-preview-lines span:nth-child(2) { width: 71%; }
+.pitch-preview-lines span:nth-child(3) { width: 48%; }
+
+.pitch-preview-footer {
+  border-top: 1px solid var(--pitch-line);
+  border-bottom: 0;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.pitch-preview-footer div {
+  display: grid;
+  gap: 3px;
+}
+
+.pitch-preview-footer strong {
+  color: var(--pitch-text);
+  font-size: 13px;
+}
+
+.pitch-preview-footer span {
+  color: var(--pitch-muted);
+  font-size: 12px;
+}
+
+.pitch-preview-footer .button {
+  min-height: 42px;
+  padding: 0 15px;
+  font-size: 12px;
+}
+
+.pitch-small-heading {
+  margin: 0 0 18px !important;
+  color: var(--pitch-muted) !important;
+  font-size: 12px !important;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.pitch-clean-list {
+  border-top: 1px solid var(--pitch-line-strong);
+}
+
+.pitch-clean-list li {
+  padding: 17px 0;
+  border-bottom: 1px solid var(--pitch-line);
+  color: var(--pitch-text-soft);
+  font-size: 17px;
+}
+
+.pitch-no-profile {
+  max-width: 900px;
+  margin-top: clamp(76px, 10vw, 130px);
+}
+
+.pitch-no-profile p {
+  max-width: 690px;
+  margin: 20px 0 0;
+}
+
+.pitch-pretitle {
+  margin: 0 0 18px !important;
+  color: var(--pitch-muted) !important;
+  font-size: clamp(18px, 2vw, 24px) !important;
+}
+
+.pitch-reputation h2 {
+  font-size: clamp(64px, 10vw, 136px);
+}
+
+.pitch-reputation-grid {
+  margin-top: clamp(70px, 9vw, 118px);
+}
+
+.pitch-reputation-rejects {
+  margin-top: 26px;
+  border-top: 1px solid var(--pitch-line-strong);
+}
+
+.pitch-reputation-rejects li {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--pitch-line);
+  color: var(--pitch-muted);
+  font-size: 18px;
+}
+
+.pitch-reputation-copy {
+  display: grid;
+  gap: 12px;
+}
+
+.pitch-reputation-copy p {
+  margin: 0;
+}
+
+.pitch-reputation-copy strong,
+.pitch-emphasis,
+.pitch-data-promise {
+  color: var(--pitch-text) !important;
+}
+
+.pitch-reputation-copy strong {
+  margin-top: 28px;
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(24px, 3vw, 38px);
+  font-weight: 500;
+  line-height: 1.25;
+  letter-spacing: -0.035em;
+}
+
+.pitch-ai-copy p:first-child {
+  margin-top: 0;
+}
+
+.pitch-emphasis {
+  margin-top: 36px !important;
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(22px, 2.6vw, 34px) !important;
+  font-weight: 500;
+  line-height: 1.35 !important;
+  letter-spacing: -0.03em;
+}
+
+.pitch-data-promise {
+  margin-top: 40px !important;
+  padding-top: 24px;
+  border-top: 1px solid var(--pitch-line-strong);
+  font-weight: 600;
+}
+
+.pitch-principles {
+  padding-bottom: clamp(120px, 16vw, 220px);
+}
+
+.pitch-principle-list {
+  counter-reset: principle;
+  border-top: 1px solid var(--pitch-line-strong);
+}
+
+.pitch-principle-list li {
+  counter-increment: principle;
+  position: relative;
+  padding: clamp(24px, 3.6vw, 44px) 0 clamp(24px, 3.6vw, 44px) 78px;
+  border-bottom: 1px solid var(--pitch-line);
+  color: var(--pitch-text);
+  font-family: "Manrope", sans-serif;
+  font-size: clamp(28px, 4.3vw, 62px);
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: -0.045em;
+}
+
+.pitch-principle-list li::before {
+  content: counter(principle, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: clamp(33px, 4.2vw, 52px);
+  color: var(--pitch-warm);
+  font-family: "DM Sans", sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+}
+
+.pitch-waitlist {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(380px, 0.75fr);
+  gap: clamp(50px, 10vw, 140px);
+  align-items: center;
+  min-width: 0;
+  margin-bottom: 110px;
+  padding: clamp(42px, 7vw, 86px) 0;
+  border-top: 1px solid var(--pitch-line-strong);
+  border-bottom: 1px solid var(--pitch-line);
+  background: transparent;
+}
+
+.pitch-waitlist .home-waitlist-copy,
+.pitch-waitlist .home-waitlist-form {
+  min-width: 0;
+}
+
+.pitch-waitlist .home-waitlist-copy h2 {
+  margin-top: 24px;
+  font-size: clamp(42px, 5.2vw, 72px);
+}
+
+.pitch-waitlist .home-waitlist-copy > p:last-child {
+  max-width: 620px;
+  color: var(--pitch-text-soft);
+}
+
+.pitch-waitlist .home-waitlist-form {
+  display: grid;
+  gap: 14px;
+}
+
+.pitch-waitlist .home-waitlist-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.pitch-waitlist input {
+  width: 100%;
+  min-width: 0;
+  height: 52px;
+  padding: 0 16px;
+  color: var(--pitch-text);
+  background: #0a0a08;
+  border: 1px solid var(--pitch-line-strong);
+  border-radius: 3px;
+  outline: none;
+}
+
+.pitch-waitlist input:focus {
+  border-color: rgba(242, 201, 141, 0.72);
+  box-shadow: 0 0 0 3px rgba(242, 201, 141, 0.08);
+}
+
+.pitch-waitlist .home-consent-note,
+.pitch-waitlist .home-form-status,
+.pitch-waitlist .home-waitlist-success p {
+  color: var(--pitch-muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.pitch-waitlist .home-consent-note a {
+  color: var(--pitch-text-soft);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.pitch-waitlist .home-waitlist-success {
+  padding: 18px 0 0;
+  border-top: 1px solid var(--pitch-line);
+}
+
+.pitch-waitlist .home-waitlist-success h3 {
+  margin: 0;
+  color: var(--pitch-text);
+  font-size: 20px;
+}
+
+@keyframes pitchLetterResolve {
+  0% {
+    opacity: 0;
+    transform: scale(0.82);
+    filter: blur(13px) brightness(7);
+  }
+  16% {
+    opacity: 1;
+    transform: scale(0.92);
+    filter: blur(8px) brightness(5.8);
+  }
+  45% {
+    opacity: 1;
+    transform: scale(1.015);
+    filter: blur(2.2px) brightness(2.25);
+  }
+  72% {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0.4px) brightness(1.12);
+    text-shadow: 0 0 11px rgba(242, 201, 141, 0.16);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+    filter: none;
+    color: var(--pitch-text);
+    text-shadow: none;
+  }
+}
+
+@keyframes pitchLightPoint {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.15);
+  }
+  18% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(0.8);
+  }
+  42% {
+    opacity: 0.95;
+    transform: translate(-50%, -50%) scale(1.4);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.45);
+  }
+}
+
+@keyframes pitchCopyReveal {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pitchCueReveal {
+  to { opacity: 1; }
+}
+
+@keyframes pitchCueMove {
+  0% { transform: translate(-50%, 0); opacity: 0; }
+  20% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { transform: translate(-50%, 23px); opacity: 0; }
+}
+
+@keyframes pitchHeaderReveal {
+  to { opacity: 1; }
+}
+
+@media (max-width: 900px) {
+  .home-page .site-header,
+  .pitch-intro,
+  .pitch-section,
+  .pitch-waitlist,
+  .home-page .site-footer {
+    width: min(calc(100% - 40px), var(--pitch-max));
+  }
+
+  .pitch-problem-grid,
+  .pitch-platform-grid,
+  .pitch-experience-grid,
+  .pitch-discovery-grid,
+  .pitch-reputation-grid,
+  .pitch-ai-grid,
+  .pitch-manifesto-line,
+  .pitch-control-line {
+    grid-template-columns: 1fr;
+    gap: 46px;
+  }
+
+  .pitch-four-lines {
+    grid-template-columns: 1fr;
+  }
+
+  .pitch-preview-shell {
+    max-width: 680px;
+  }
+
+  .pitch-waitlist {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 700px) {
+  .home-page .site-header,
+  .pitch-intro,
+  .pitch-section,
+  .pitch-waitlist,
+  .home-page .site-footer {
+    width: min(calc(100% - 28px), var(--pitch-max));
+  }
+
+  .home-page .site-header {
+    min-height: 68px;
+  }
+
+  .pitch-wordmark {
+    gap: 2px;
+    font-size: clamp(52px, 18vw, 88px);
+    letter-spacing: -0.075em;
+  }
+
+  .pitch-letter {
+    min-width: 0.55em;
+  }
+
+  .pitch-intro-inner {
+    gap: 34px;
+  }
+
+  .pitch-intro-statement {
+    max-width: 330px;
+    font-size: 27px;
+  }
+
+  .pitch-section {
+    padding: 94px 0;
+  }
+
+  .pitch-section-meta {
+    margin-bottom: 42px;
+  }
+
+  .pitch-section h2 {
+    font-size: clamp(42px, 13vw, 62px);
+  }
+
+  .pitch-human-first h2,
+  .pitch-reputation h2 {
+    font-size: clamp(54px, 16vw, 78px);
+  }
+
+  .pitch-signal-list li {
+    font-size: clamp(25px, 8vw, 34px);
+  }
+
+  .pitch-result {
+    font-size: 28px !important;
+  }
+
+  .pitch-four-lines {
+    margin-top: 50px;
+  }
+
+  .pitch-manifesto-line,
+  .pitch-control-line {
+    margin-top: 64px;
+    padding: 24px 0;
+  }
+
+  .pitch-preview-topbar,
+  .pitch-preview-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .pitch-preview-footer .button {
+    width: 100%;
+  }
+
+  .pitch-principle-list li {
+    padding-left: 46px;
+    font-size: clamp(27px, 8.3vw, 42px);
+  }
+
+  .pitch-principle-list li::before {
+    top: 31px;
+  }
+
+  .pitch-waitlist {
+    margin-bottom: 72px;
+    padding: 76px 0;
+  }
+
+  .pitch-waitlist .home-waitlist-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .pitch-waitlist .home-waitlist-fields .button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-page .site-header,
+  .pitch-letter,
+  .pitch-letter::before,
+  .pitch-intro-statement,
+  .pitch-scroll-cue,
+  .pitch-scroll-cue span,
+  .pitch-section[data-pitch-reveal],
+  .pitch-waitlist[data-pitch-reveal] {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .home-page .site-header,
+  .pitch-letter,
+  .pitch-intro-statement,
+  .pitch-scroll-cue,
+  .pitch-section[data-pitch-reveal],
+  .pitch-waitlist[data-pitch-reveal] {
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+
+  .pitch-letter::before {
+    display: none;
+  }
+}

--- a/apps/marketing-site/tests/homepage-waitlist.test.mjs
+++ b/apps/marketing-site/tests/homepage-waitlist.test.mjs
@@ -8,6 +8,7 @@ const homepage = fs.readFileSync(path.join(root, 'src/pages/index.astro'), 'utf8
 const layout = fs.readFileSync(path.join(root, 'src/layouts/BaseLayout.astro'), 'utf8');
 const privacy = fs.readFileSync(path.join(root, 'src/pages/privacy/index.astro'), 'utf8');
 const styles = fs.readFileSync(path.join(root, 'src/styles/global.css'), 'utf8');
+const homePitchStyles = fs.readFileSync(path.join(root, 'src/styles/home-pitch.css'), 'utf8');
 const headers = fs.readFileSync(path.join(root, 'public/_headers'), 'utf8');
 
 test('homepage uses the approved waitlist submission and accessible states', () => {
@@ -32,14 +33,29 @@ test('homepage uses the approved waitlist submission and accessible states', () 
   assert.doesNotMatch(homepage, /You are on the list\. We will be in touch when a place opens\./);
 });
 
-test('homepage public copy stays restrained and launch safe', () => {
+test('homepage public copy matches the human-first pitch and stays launch safe', () => {
   const publicSource = `${homepage}\n${layout}`;
   const visibleCopy = publicSource.replace(/<script[\s\S]*?<\/script>/giu, '');
   assert.doesNotMatch(visibleCopy, /\u2014/u);
   assert.doesNotMatch(visibleCopy, /lime|neon green|purple gradient|PlanetScale|Hyperdrive|Cloudflare|C2PA|stylometric|confidence score|policy engine|appeal threshold|moderation weight/i);
-  assert.match(homepage, /The internet is changing\.<br \/>Trust should not disappear with it\./);
+  assert.match(homepage, /The human internet is worth protecting\./);
+  assert.match(homepage, /Built for humans first\./);
+  assert.match(homepage, /Lythaus is a human-first, public-interest platform built for genuine human interaction\./);
+  assert.match(homepage, /Algorithms for relevance, not addiction\./);
+  assert.match(homepage, /Reputation is earned\./);
+  assert.match(homepage, /Member content is not sold or repurposed to train generative models\./);
   assert.match(homepage, /Join the waitlist/);
   assert.match(styles, /--accent: #f2c98d/i);
+});
+
+test('homepage opening resolves the Lythaus letters from light without a lighthouse beam', () => {
+  assert.match(homepage, /class="pitch-wordmark"/);
+  assert.match(homepage, /--letter-index: 0/);
+  assert.match(homepage, /--letter-index: 6/);
+  assert.match(homePitchStyles, /@keyframes pitchLetterResolve/);
+  assert.match(homePitchStyles, /@keyframes pitchLightPoint/);
+  assert.doesNotMatch(homePitchStyles, /lighthouse|beam/i);
+  assert.match(homePitchStyles, /prefers-reduced-motion/);
 });
 
 test('shared layout declares the Lythaus favicon assets', () => {
@@ -56,10 +72,10 @@ test('Turnstile CSP is narrowly allowlisted', () => {
 });
 
 test('homepage layout remains bounded at desktop and 390 pixel widths', () => {
-  assert.match(styles, /\.home-waitlist \{[\s\S]*grid-template-columns: minmax\(0, 0\.9fr\) minmax\(380px, 0\.75fr\)/);
-  assert.match(styles, /\.home-waitlist \{[\s\S]*min-width: 0/);
-  assert.match(styles, /@media \(max-width: 700px\) \{[\s\S]*?\.home-waitlist-fields \{[\s\S]*?grid-template-columns: 1fr/);
-  assert.match(styles, /@media \(max-width: 700px\) \{[\s\S]*?\.home-waitlist-fields \.button \{[\s\S]*?width: 100%/);
+  assert.match(homePitchStyles, /\.pitch-waitlist \{[\s\S]*grid-template-columns: minmax\(0, 0\.9fr\) minmax\(380px, 0\.75fr\)/);
+  assert.match(homePitchStyles, /\.pitch-waitlist \{[\s\S]*min-width: 0/);
+  assert.match(homePitchStyles, /@media \(max-width: 700px\) \{[\s\S]*?\.pitch-waitlist \.home-waitlist-fields \{[\s\S]*?grid-template-columns: 1fr/);
+  assert.match(homePitchStyles, /@media \(max-width: 700px\) \{[\s\S]*?\.pitch-waitlist \.home-waitlist-fields \.button \{[\s\S]*?width: 100%/);
 });
 
 test('Privacy Policy states the approved waitlist retention policy', () => {


### PR DESCRIPTION
## Summary
- replace the legacy trust-first landing copy with the approved human-first, public-interest pitch
- add the letter-by-letter warm-light Lythaus opening with reduced-motion support
- restructure the homepage as a scrolling editorial pitch deck with stronger hierarchy and less card-heavy UI
- preserve waitlist, Turnstile, privacy/legal and public API wiring
- align home navigation with Problem, Lythaus, Experience, Discovery and Principles
- update marketing tests and production validation strings
- add a one-time exact-main deployment workflow for the existing `lythaus-marketing` Cloudflare Pages project

## Product integrity
- PlanetScale production schema was inspected read-only; no migration is required
- the guest experience section is visually prepared without inventing an unverified external guest-app URL
- no Azure references or runtime changes

## Production validation
The one-time deployment workflow will build the exact merged main SHA, resolve the production Turnstile site key, deploy through Wrangler to Cloudflare Pages, and verify `lythaus.co` plus `www.lythaus.co` for the new copy and required security headers.