### PR TITLE
fix: harden provider evidence and production contract audits

### DIFF
--- a/.github/workflows/cloudflare-domain-audit.yml
+++ b/.github/workflows/cloudflare-domain-audit.yml
@@ -22,10 +22,10 @@ jobs:
   inventory:
     name: Sanitized Cloudflare inventory
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
-      CLOUDFLARE_AUDIT_API_TOKEN: ${{ secrets.CLOUDFLARE_AUDIT_API_TOKEN }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_AUDIT_API_TOKEN: ${{ secrets.CLOUDFLARE_AUDIT_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_ZONE_ID: 7bc572c8b7cd3c00be9c655176c29382
       CLOUDFLARE_AUDIT_OUTPUT: .artifacts/provider-inventory/cloudflare.json
@@ -37,7 +37,7 @@ jobs:
           node-version: '22'
       - name: Capture read-only account inventory
         run: node scripts/cloudflare/audit-account.mjs
-      - name: Reject active legacy-named Cloudflare resources after cutover
+      - name: Validate inventory shape
         shell: bash
         run: |
           set -euo pipefail
@@ -50,9 +50,9 @@ jobs:
         run: |
           set -euo pipefail
           report='.artifacts/provider-inventory/cloudflare.json'
-          mkdir -p .artifacts/provider-inventory
           counts="$(jq -c '{pages:(.resources.pages|length),workers:(.resources.workers|length),hyperdrives:(.resources.hyperdrives|length),r2:(.resources.r2|length),queues:(.resources.queues|length),workflows:(.resources.workflows|length),kv:(.resources.kv|length),access:(.resources.access|length),turnstile:(.resources.turnstile|length),dns:(.resources.dns|length),routes:(.resources.routes|length)}' "$report")"
-          endpoint_failures="$(jq -c '[.endpointState | to_entries[] | select(.value.ok != true) | .key]' "$report")"
+          endpoint_failures="$(jq -c '.failedEndpoints' "$report")"
+          admin_settings_ok="$(jq -r '.adminWorkerSettings.state.ok' "$report")"
           legacy_names="$(jq -c '[.legacyNamedResources[] | {type,name}]' "$report")"
           {
             echo 'Sanitized read-only Cloudflare inventory evidence.'
@@ -61,7 +61,9 @@ jobs:
             echo "Run URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             echo "Main SHA: ${GITHUB_SHA}"
             echo "Captured at: $(jq -r '.capturedAt' "$report")"
+            echo "Inventory complete: $(jq -r '.complete' "$report")"
             echo "Endpoint failures: ${endpoint_failures}"
+            echo "Admin Worker settings readable: ${admin_settings_ok}"
             echo "Resource counts: ${counts}"
             echo "Legacy-named resources: ${legacy_names}"
             echo
@@ -72,6 +74,19 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "Cloudflare inventory evidence ${GITHUB_SHA:0:12} run ${GITHUB_RUN_ID}" \
             --body-file .artifacts/provider-inventory/cloudflare-issue.md
+      - name: Require complete provider evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          report='.artifacts/provider-inventory/cloudflare.json'
+          jq -e '.complete == true' "$report" >/dev/null || {
+            echo 'Cloudflare inventory is incomplete; provider state remains UNKNOWN/BLOCKED.' >&2
+            exit 1
+          }
+          jq -e '.adminWorkerSettings.state.ok == true' "$report" >/dev/null || {
+            echo 'Cloudflare admin Worker settings are unreadable; admin cutover evidence remains UNKNOWN/BLOCKED.' >&2
+            exit 1
+          }
       - name: Upload sanitized provider evidence
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/native-workers-validation.yml
+++ b/.github/workflows/native-workers-validation.yml
@@ -17,7 +17,9 @@ on:
       - 'scripts/ci/materialize-public-waitlist-deploy.mjs'
       - 'scripts/ci/probe-public-waitlist-candidate.mjs'
       - 'scripts/ci/resolve-latest-worker-version.mjs'
+      - 'scripts/cloudflare/audit-account.mjs'
       - 'scripts/cloudflare/waitlist-turnstile.mjs'
+      - 'scripts/planetscale/audit-production-contract.mjs'
       - 'scripts/validate-production-gates.mjs'
       - 'infrastructure/cloudflare/production-gates.json'
       - 'scripts/validate-planetscale-extensions.mjs'
@@ -32,6 +34,7 @@ on:
       - 'scripts/tests/budget-contract.test.mjs'
       - 'scripts/tests/db-identity-contract.test.mjs'
       - 'scripts/tests/native-architecture-invariants.test.js'
+      - 'scripts/tests/provider-audit-contract.test.mjs'
       - 'scripts/tests/production-gates.test.mjs'
       - 'scripts/tests/product-integrity-runtime-invariants.test.mjs'
       - 'scripts/tests/planetscale-production-migrations.test.mjs'
@@ -42,6 +45,8 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/native-workers-validation.yml'
+      - '.github/workflows/cloudflare-domain-audit.yml'
+      - '.github/workflows/planetscale-account-audit.yml'
       - '.github/workflows/planetscale-production-migrations.yml'
       - '.github/workflows/deploy-public-waitlist.yml'
       - '.github/workflows/deploy-marketing.yml'
@@ -59,7 +64,9 @@ on:
       - 'scripts/ci/materialize-public-waitlist-deploy.mjs'
       - 'scripts/ci/probe-public-waitlist-candidate.mjs'
       - 'scripts/ci/resolve-latest-worker-version.mjs'
+      - 'scripts/cloudflare/audit-account.mjs'
       - 'scripts/cloudflare/waitlist-turnstile.mjs'
+      - 'scripts/planetscale/audit-production-contract.mjs'
       - 'scripts/validate-production-gates.mjs'
       - 'infrastructure/cloudflare/production-gates.json'
       - 'scripts/validate-planetscale-extensions.mjs'
@@ -73,6 +80,7 @@ on:
       - 'scripts/tests/budget-contract.test.mjs'
       - 'scripts/tests/db-identity-contract.test.mjs'
       - 'scripts/tests/native-architecture-invariants.test.js'
+      - 'scripts/tests/provider-audit-contract.test.mjs'
       - 'scripts/tests/production-gates.test.mjs'
       - 'scripts/tests/product-integrity-runtime-invariants.test.mjs'
       - 'scripts/tests/planetscale-production-migrations.test.mjs'
@@ -83,6 +91,8 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/native-workers-validation.yml'
+      - '.github/workflows/cloudflare-domain-audit.yml'
+      - '.github/workflows/planetscale-account-audit.yml'
       - '.github/workflows/planetscale-production-migrations.yml'
       - '.github/workflows/deploy-public-waitlist.yml'
       - '.github/workflows/deploy-marketing.yml'
@@ -111,6 +121,7 @@ jobs:
       - run: npm run test:planetscale-production-migrations
       - run: npm run validate:planetscale-extensions
       - run: npm run test:native-architecture
+      - run: node --test scripts/tests/provider-audit-contract.test.mjs
       - run: node --test scripts/tests/production-gates.test.mjs
       - run: npm run test:product-integrity-runtime
       - run: node --test scripts/tests/public-waitlist-cutover.test.mjs

--- a/.github/workflows/planetscale-account-audit.yml
+++ b/.github/workflows/planetscale-account-audit.yml
@@ -52,9 +52,13 @@ jobs:
           jq -e '.assertions.mainExists == true' .artifacts/provider-inventory/planetscale.json >/dev/null
           jq -e '.assertions.exactlyOneProductionMain == true' .artifacts/provider-inventory/planetscale.json >/dev/null
       - name: Verify live production contract read-only
+        id: production_contract
+        continue-on-error: true
         run: node scripts/planetscale/audit-production-contract.mjs
       - name: Persist sanitized audit locator and summary
         shell: bash
+        env:
+          CONTRACT_OUTCOME: ${{ steps.production_contract.outcome }}
         run: |
           set -euo pipefail
           report='.artifacts/provider-inventory/planetscale.json'
@@ -62,7 +66,11 @@ jobs:
           branches="$(jq -c '[.branches[] | {name,production,ready,schemaReady,parentBranch,region:(.region.slug // null)}]' "$report")"
           assertions="$(jq -c '.assertions' "$report")"
           database_summary="$(jq -c '{name:.database.name,kind:.database.kind,region:.database.region,branchesCount:.database.branchesCount,openSchemaRecommendationsCount:.database.openSchemaRecommendationsCount,schemaLastUpdatedAt:.database.schemaLastUpdatedAt}' "$report")"
-          contract_summary="$(jq -c '{postgresVersion,verifierPassed,post0013Required,extensions,migrationLedger,visibleGrantMetadata,verifierOutput}' "$contract")"
+          if [[ -f "$contract" ]]; then
+            contract_summary="$(jq -c '{postgresVersion,verifierPassed,post0013Required,extensions,migrationLedger,visibleGrantMetadata,verifierOutput}' "$contract")"
+          else
+            contract_summary='{"state":"UNKNOWN/BLOCKED","reason":"production contract verifier did not emit a sanitized contract artifact"}'
+          fi
           {
             echo 'Sanitized read-only PlanetScale inventory evidence.'
             echo
@@ -73,21 +81,31 @@ jobs:
             echo "Database: ${database_summary}"
             echo "Branches: ${branches}"
             echo "Assertions: ${assertions}"
+            echo "Production contract outcome: ${CONTRACT_OUTCOME}"
             echo "Production contract: ${contract_summary}"
             echo
-            echo 'The complete sanitized inventory and production-contract audit are stored in the Actions artifact named below. No provider mutation or DDL is performed by this workflow.'
+            echo 'The sanitized evidence produced by this run is stored in the Actions artifact named below. No provider mutation or DDL is performed by this workflow.'
             echo "Artifact: planetscale-account-audit-${GITHUB_SHA}"
           } > .artifacts/provider-inventory/planetscale-issue.md
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "PlanetScale inventory evidence ${GITHUB_SHA:0:12} run ${GITHUB_RUN_ID}" \
             --body-file .artifacts/provider-inventory/planetscale-issue.md
+      - name: Require complete production contract evidence
+        shell: bash
+        env:
+          CONTRACT_OUTCOME: ${{ steps.production_contract.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "$CONTRACT_OUTCOME" != 'success' ]]; then
+            echo 'PlanetScale production contract evidence is incomplete; provider contract remains UNKNOWN/BLOCKED.' >&2
+            exit 1
+          fi
+          jq -e '.verifierPassed == true and .post0013Required == true' .artifacts/provider-inventory/planetscale-production-contract.json >/dev/null
       - name: Upload sanitized provider evidence
         if: always()
         uses: actions/upload-artifact@v6
         with:
           name: planetscale-account-audit-${{ github.sha }}
           if-no-files-found: error
-          path: |
-            .artifacts/provider-inventory/planetscale.json
-            .artifacts/provider-inventory/planetscale-production-contract.json
+          path: .artifacts/provider-inventory/planetscale*.json

--- a/.github/workflows/planetscale-account-audit.yml
+++ b/.github/workflows/planetscale-account-audit.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
     paths:
       - 'scripts/planetscale/audit-account.mjs'
+      - 'scripts/planetscale/audit-production-contract.mjs'
+      - 'scripts/ci/verify-planetscale-production-schema.mjs'
       - '.github/workflows/planetscale-account-audit.yml'
       - 'database/planetscale/**'
       - 'infrastructure/lythaus-resource-registry.json'
@@ -22,18 +24,25 @@ jobs:
   inventory:
     name: Sanitized PlanetScale inventory
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       PLANETSCALE_API_TOKEN: ${{ secrets.PLANETSCALE_API_TOKEN }}
       PLANETSCALE_ORGANIZATION: lythaus
       PLANETSCALE_DATABASE: lythaus-core
       PLANETSCALE_AUDIT_OUTPUT: .artifacts/provider-inventory/planetscale.json
+      PLANETSCALE_SCHEMA_READ_DATABASE_URL: ${{ secrets.PLANETSCALE_SCHEMA_READ_DATABASE_URL }}
+      PSCALE_ROLE_IDENTIFIERS: ${{ secrets.PSCALE_ROLE_IDENTIFIERS }}
+      EXPECTED_DATABASE_SCHEMA_FINGERPRINT: ${{ vars.PRODUCT_INTEGRITY_DATABASE_SCHEMA_FINGERPRINT }}
+      EXPECTED_DATABASE_RELATION_COUNT: ${{ vars.PRODUCT_INTEGRITY_DATABASE_RELATION_COUNT }}
+      PLANETSCALE_CONTRACT_AUDIT_OUTPUT: .artifacts/provider-inventory/planetscale-production-contract.json
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
+          cache: npm
+      - run: npm ci --ignore-scripts
       - name: Capture read-only database and branch inventory
         run: node scripts/planetscale/audit-account.mjs
       - name: Enforce canonical production branch
@@ -42,14 +51,18 @@ jobs:
           set -euo pipefail
           jq -e '.assertions.mainExists == true' .artifacts/provider-inventory/planetscale.json >/dev/null
           jq -e '.assertions.exactlyOneProductionMain == true' .artifacts/provider-inventory/planetscale.json >/dev/null
+      - name: Verify live production contract read-only
+        run: node scripts/planetscale/audit-production-contract.mjs
       - name: Persist sanitized audit locator and summary
         shell: bash
         run: |
           set -euo pipefail
           report='.artifacts/provider-inventory/planetscale.json'
+          contract='.artifacts/provider-inventory/planetscale-production-contract.json'
           branches="$(jq -c '[.branches[] | {name,production,ready,schemaReady,parentBranch,region:(.region.slug // null)}]' "$report")"
           assertions="$(jq -c '.assertions' "$report")"
           database_summary="$(jq -c '{name:.database.name,kind:.database.kind,region:.database.region,branchesCount:.database.branchesCount,openSchemaRecommendationsCount:.database.openSchemaRecommendationsCount,schemaLastUpdatedAt:.database.schemaLastUpdatedAt}' "$report")"
+          contract_summary="$(jq -c '{postgresVersion,verifierPassed,post0013Required,extensions,migrationLedger,visibleGrantMetadata,verifierOutput}' "$contract")"
           {
             echo 'Sanitized read-only PlanetScale inventory evidence.'
             echo
@@ -60,8 +73,9 @@ jobs:
             echo "Database: ${database_summary}"
             echo "Branches: ${branches}"
             echo "Assertions: ${assertions}"
+            echo "Production contract: ${contract_summary}"
             echo
-            echo 'The complete sanitized inventory is stored in the Actions artifact named below. No provider mutation or DDL is performed by this workflow.'
+            echo 'The complete sanitized inventory and production-contract audit are stored in the Actions artifact named below. No provider mutation or DDL is performed by this workflow.'
             echo "Artifact: planetscale-account-audit-${GITHUB_SHA}"
           } > .artifacts/provider-inventory/planetscale-issue.md
           gh issue create \
@@ -74,4 +88,6 @@ jobs:
         with:
           name: planetscale-account-audit-${{ github.sha }}
           if-no-files-found: error
-          path: .artifacts/provider-inventory/planetscale.json
+          path: |
+            .artifacts/provider-inventory/planetscale.json
+            .artifacts/provider-inventory/planetscale-production-contract.json

--- a/scripts/cloudflare/audit-account.mjs
+++ b/scripts/cloudflare/audit-account.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
 const zoneId = process.env.CLOUDFLARE_ZONE_ID ?? '7bc572c8b7cd3c00be9c655176c29382';
-const token = process.env.CLOUDFLARE_AUDIT_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN || '';
+const token = process.env.CLOUDFLARE_API_TOKEN || process.env.CLOUDFLARE_AUDIT_API_TOKEN || '';
 const outputPath = process.env.CLOUDFLARE_AUDIT_OUTPUT ?? '.artifacts/provider-inventory/cloudflare.json';
 
 if (!/^[0-9a-f]{32}$/i.test(accountId)) throw new Error('CLOUDFLARE_ACCOUNT_ID is required');
@@ -11,19 +11,33 @@ if (!/^[0-9a-f]{32}$/i.test(zoneId)) throw new Error('CLOUDFLARE_ZONE_ID is requ
 if (!token) throw new Error('Cloudflare audit token is required');
 
 const headers = { Authorization: `Bearer ${token}`, 'content-type': 'application/json' };
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
-async function request(url) {
-  const response = await fetch(url, { headers });
-  let payload;
-  try { payload = await response.json(); } catch { payload = {}; }
-  return {
-    status: response.status,
-    ok: response.ok && payload?.success !== false,
-    result: payload?.result,
-    errors: Array.isArray(payload?.errors)
-      ? payload.errors.map(({ code, message }) => ({ code, message: String(message ?? '').slice(0, 240) }))
-      : [],
-  };
+async function request(url, { attempts = 5 } = {}) {
+  let last = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await fetch(url, { headers });
+    let payload;
+    try { payload = await response.json(); } catch { payload = {}; }
+    last = {
+      status: response.status,
+      ok: response.ok && payload?.success !== false,
+      result: payload?.result,
+      errors: Array.isArray(payload?.errors)
+        ? payload.errors.map(({ code, message }) => ({ code, message: String(message ?? '').slice(0, 240) }))
+        : [],
+    };
+    if (last.ok) return last;
+
+    const retryable = response.status === 429 || response.status >= 500;
+    if (!retryable || attempt === attempts) return last;
+
+    const retryAfter = Number.parseInt(response.headers.get('retry-after') ?? '', 10);
+    const boundedRetryAfterMs = Number.isFinite(retryAfter) ? Math.min(Math.max(retryAfter, 1), 15) * 1000 : 0;
+    const exponentialMs = Math.min(1000 * (2 ** (attempt - 1)), 8000);
+    await sleep(Math.max(boundedRetryAfterMs, exponentialMs));
+  }
+  return last;
 }
 
 function arrayResult(response) {
@@ -51,8 +65,11 @@ const endpoints = {
   routes: `${zoneBase}/workers/routes?per_page=100`,
 };
 
-const entries = await Promise.all(Object.entries(endpoints).map(async ([name, url]) => [name, await request(url)]));
-const responses = Object.fromEntries(entries);
+const responses = {};
+for (const [name, url] of Object.entries(endpoints)) {
+  responses[name] = await request(url);
+  await sleep(300);
+}
 
 const adminSettings = await request(`${accountBase}/workers/scripts/lythaus-admin-api-development/settings`);
 const adminBindings = adminSettings.ok && Array.isArray(adminSettings.result?.bindings) ? adminSettings.result.bindings : [];
@@ -104,12 +121,17 @@ const legacyNamedResources = [
   ...workflows.filter(({ name }) => legacyPattern.test(name ?? '')).map(({ name }) => ({ type: 'workflow', name })),
 ];
 
+const endpointStates = Object.fromEntries(Object.entries(responses).map(([name, response]) => [name, endpointState(response)]));
+const failedEndpoints = Object.entries(endpointStates).filter(([, state]) => !state.ok).map(([name]) => name);
+
 const report = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   capturedAt: new Date().toISOString(),
   accountId,
   zoneId,
-  endpointState: Object.fromEntries(Object.entries(responses).map(([name, response]) => [name, endpointState(response)])),
+  complete: failedEndpoints.length === 0,
+  failedEndpoints,
+  endpointState: endpointStates,
   adminWorkerSettings: { state: endpointState(adminSettings), access: publicAccessValues },
   resources: { pages, workers, hyperdrives, r2, queues, workflows, kv, access, turnstile, dns, routes },
   legacyNamedResources,
@@ -117,4 +139,4 @@ const report = {
 
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
-console.log(`Wrote sanitized Cloudflare inventory to ${outputPath}; legacy-named resources=${legacyNamedResources.length}.`);
+console.log(`Wrote sanitized Cloudflare inventory to ${outputPath}; complete=${report.complete}; failed=${failedEndpoints.length}; legacy-named resources=${legacyNamedResources.length}.`);

--- a/scripts/planetscale/audit-production-contract.mjs
+++ b/scripts/planetscale/audit-production-contract.mjs
@@ -1,0 +1,83 @@
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import pg from 'pg';
+
+const { Client } = pg;
+const databaseUrl = process.env.PLANETSCALE_SCHEMA_READ_DATABASE_URL ?? '';
+const outputPath = process.env.PLANETSCALE_CONTRACT_AUDIT_OUTPUT ?? '.artifacts/provider-inventory/planetscale-production-contract.json';
+
+if (!databaseUrl) throw new Error('PLANETSCALE_SCHEMA_READ_DATABASE_URL is required');
+const connection = new URL(databaseUrl);
+if (connection.searchParams.get('sslmode') !== 'verify-full') throw new Error('PlanetScale contract audit requires sslmode=verify-full');
+if (connection.searchParams.get('sslrootcert') === 'system') connection.searchParams.delete('sslrootcert');
+
+const verifier = spawnSync(process.execPath, ['scripts/ci/verify-planetscale-production-schema.mjs'], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    PLANETSCALE_SCHEMA_READ_DATABASE_URL: connection.toString(),
+    PSCALE_BRANCH_NAME: 'main',
+    REQUIRE_PRODUCT_INTEGRITY_MIGRATION: 'true',
+  },
+  encoding: 'utf8',
+});
+if (verifier.status !== 0) {
+  process.stderr.write(verifier.stdout ?? '');
+  process.stderr.write(verifier.stderr ?? '');
+  throw new Error(`production schema verifier failed with exit code ${verifier.status}`);
+}
+
+const client = new Client({ connectionString: connection.toString(), ssl: { rejectUnauthorized: true } });
+await client.connect();
+let report;
+try {
+  await client.query('BEGIN READ ONLY');
+  const versionResult = await client.query('SHOW server_version');
+  const extensionsResult = await client.query('SELECT extname, extversion FROM pg_extension ORDER BY extname');
+  const migrationsResult = await client.query('SELECT version, checksum FROM system.schema_migrations ORDER BY version');
+  const grantsResult = await client.query(`SELECT privilege_type, COUNT(*)::int AS grant_count
+    FROM information_schema.role_table_grants
+    WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+    GROUP BY privilege_type
+    ORDER BY privilege_type`);
+  const roleCountResult = await client.query(`SELECT COUNT(DISTINCT grantee)::int AS role_count
+    FROM information_schema.role_table_grants
+    WHERE table_schema NOT IN ('pg_catalog', 'information_schema')`);
+  await client.query('ROLLBACK');
+
+  const migrationsPayload = migrationsResult.rows.map(({ version, checksum }) => `${version}:${checksum}`).join('\n');
+  report = {
+    schemaVersion: 1,
+    capturedAt: new Date().toISOString(),
+    branch: 'main',
+    verifierPassed: true,
+    post0013Required: true,
+    postgresVersion: versionResult.rows[0]?.server_version ?? null,
+    extensions: extensionsResult.rows,
+    migrationLedger: {
+      count: migrationsResult.rowCount ?? migrationsResult.rows.length,
+      first: migrationsResult.rows[0]?.version ?? null,
+      last: migrationsResult.rows.at(-1)?.version ?? null,
+      ledgerSha256: createHash('sha256').update(migrationsPayload).digest('hex'),
+    },
+    visibleGrantMetadata: {
+      distinctGrantees: roleCountResult.rows[0]?.role_count ?? 0,
+      byPrivilege: grantsResult.rows.map(({ privilege_type, grant_count }) => ({ privilege: privilege_type, count: grant_count })),
+      note: 'Specific runtime/admin/privacy least-privilege assertions are enforced by verify-planetscale-production-schema.mjs.',
+    },
+    verifierOutput: String(verifier.stdout ?? '')
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('Observed post-0013 catalog SHA-256:') || line.startsWith('Approved migration-set SHA-256:') || line.startsWith('Verified read-only PlanetScale migration registry')),
+  };
+} catch (error) {
+  await client.query('ROLLBACK').catch(() => undefined);
+  throw error;
+} finally {
+  await client.end();
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+console.log(`Wrote sanitized PlanetScale production contract audit to ${outputPath}.`);

--- a/scripts/tests/provider-audit-contract.test.mjs
+++ b/scripts/tests/provider-audit-contract.test.mjs
@@ -36,7 +36,10 @@ test('PlanetScale contract audit is read-only and delegates exact post-0013 veri
   assert.match(planetscaleContractAudit, /FROM pg_extension/);
   assert.match(planetscaleContractAudit, /FROM system\.schema_migrations/);
   assert.match(planetscaleContractAudit, /information_schema\.role_table_grants/);
-  assert.doesNotMatch(planetscaleContractAudit, /\b(?:INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b/i);
+  assert.doesNotMatch(
+    planetscaleContractAudit,
+    /client\.query\(\s*['"`]\s*(?:INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b/i,
+  );
 });
 
 test('PlanetScale account audit supplies verifier evidence without mutation or DDL', () => {

--- a/scripts/tests/provider-audit-contract.test.mjs
+++ b/scripts/tests/provider-audit-contract.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '../..');
+const read = (path) => readFileSync(resolve(root, path), 'utf8');
+
+const cloudflareAudit = read('scripts/cloudflare/audit-account.mjs');
+const cloudflareWorkflow = read('.github/workflows/cloudflare-domain-audit.yml');
+const planetscaleContractAudit = read('scripts/planetscale/audit-production-contract.mjs');
+const planetscaleWorkflow = read('.github/workflows/planetscale-account-audit.yml');
+
+test('Cloudflare inventory prefers canonical deployment token and throttles account reads', () => {
+  assert.match(cloudflareAudit, /CLOUDFLARE_API_TOKEN \|\| process\.env\.CLOUDFLARE_AUDIT_API_TOKEN/);
+  assert.match(cloudflareAudit, /response\.status === 429/);
+  assert.match(cloudflareAudit, /for \(const \[name, url\] of Object\.entries\(endpoints\)\)/);
+  assert.match(cloudflareAudit, /await sleep\(300\)/);
+  assert.doesNotMatch(cloudflareAudit, /Promise\.all\(Object\.entries\(endpoints\)/);
+});
+
+test('Cloudflare inventory cannot pass as empty when provider evidence is incomplete', () => {
+  assert.match(cloudflareAudit, /complete: failedEndpoints\.length === 0/);
+  assert.match(cloudflareAudit, /failedEndpoints/);
+  assert.match(cloudflareWorkflow, /Require complete provider evidence/);
+  assert.match(cloudflareWorkflow, /\.complete == true/);
+  assert.match(cloudflareWorkflow, /adminWorkerSettings\.state\.ok == true/);
+  assert.match(cloudflareWorkflow, /provider state remains UNKNOWN\/BLOCKED/);
+});
+
+test('PlanetScale contract audit is read-only and delegates exact post-0013 verification', () => {
+  assert.match(planetscaleContractAudit, /verify-planetscale-production-schema\.mjs/);
+  assert.match(planetscaleContractAudit, /REQUIRE_PRODUCT_INTEGRITY_MIGRATION: 'true'/);
+  assert.match(planetscaleContractAudit, /BEGIN READ ONLY/);
+  assert.match(planetscaleContractAudit, /SHOW server_version/);
+  assert.match(planetscaleContractAudit, /FROM pg_extension/);
+  assert.match(planetscaleContractAudit, /FROM system\.schema_migrations/);
+  assert.match(planetscaleContractAudit, /information_schema\.role_table_grants/);
+  assert.doesNotMatch(planetscaleContractAudit, /\b(?:INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b/i);
+});
+
+test('PlanetScale account audit supplies verifier evidence without mutation or DDL', () => {
+  assert.match(planetscaleWorkflow, /PLANETSCALE_SCHEMA_READ_DATABASE_URL/);
+  assert.match(planetscaleWorkflow, /PSCALE_ROLE_IDENTIFIERS/);
+  assert.match(planetscaleWorkflow, /PRODUCT_INTEGRITY_DATABASE_SCHEMA_FINGERPRINT/);
+  assert.match(planetscaleWorkflow, /PRODUCT_INTEGRITY_DATABASE_RELATION_COUNT/);
+  assert.match(planetscaleWorkflow, /audit-production-contract\.mjs/);
+  assert.match(planetscaleWorkflow, /No provider mutation or DDL is performed/);
+  assert.doesNotMatch(planetscaleWorkflow, /--request\s+(?:POST|PUT|PATCH|DELETE)/i);
+});


### PR DESCRIPTION
## Controlled consolidation provider-evidence hardening

This PR addresses evidence gaps discovered after the read-only post-merge audits.

### Cloudflare
- prefer the canonical `CLOUDFLARE_API_TOKEN`, falling back to the audit token only if the canonical token is unavailable;
- audit endpoints sequentially with bounded 429/5xx retry/backoff instead of a parallel burst;
- distinguish incomplete evidence from a genuinely empty account;
- persist sanitized evidence first, then fail the workflow if any required endpoint or the admin Worker settings cannot be read;
- preserve `UNKNOWN/BLOCKED` semantics for incomplete provider evidence.

### PlanetScale
- keep the account/branch inventory read-only;
- additionally run the existing exact post-0013 production verifier under the dedicated schema-read credential;
- record PostgreSQL version, extensions, migration-ledger digest, visible grant metadata, and verifier/catalog evidence in the sanitized artifact;
- no schema mutation or DDL.

### Regression coverage
- provider-audit safety contract tests are included in `native-workers-validation`.

No Cloudflare or PlanetScale resource mutation is performed or authorized by this PR.