### PR TITLE
fix: align production release governance with solo-founder protection

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -109,7 +109,8 @@ jobs:
             .required_status_checks != null
             and ((.required_status_checks.contexts | length) > 0)
             and .required_pull_request_reviews != null
-            and (.required_pull_request_reviews.required_approving_review_count >= 1)
+            and (.required_pull_request_reviews.required_approving_review_count == 0)
+            and ((.required_pull_request_reviews.require_last_push_approval // false) == false)
             and (.enforce_admins.enabled == true)
             and (.required_linear_history.enabled == true)
             and (.allow_force_pushes.enabled == false)

--- a/scripts/tests/production-release-governance.test.mjs
+++ b/scripts/tests/production-release-governance.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync('.github/workflows/production-release.yml', 'utf8');
+
+const satisfiesGovernance = (protection) => (
+  protection.required_status_checks !== null
+  && protection.required_status_checks.contexts.length > 0
+  && protection.required_pull_request_reviews !== null
+  && protection.required_pull_request_reviews.required_approving_review_count === 0
+  && (protection.required_pull_request_reviews.require_last_push_approval ?? false) === false
+  && protection.enforce_admins.enabled === true
+  && protection.required_linear_history.enabled === true
+  && protection.allow_force_pushes.enabled === false
+  && protection.allow_deletions.enabled === false
+  && protection.required_conversation_resolution.enabled === true
+);
+
+test('production release models solo-founder branch protection', () => {
+  assert.match(workflow, /\.required_status_checks != null/);
+  assert.match(workflow, /\(\(\.required_status_checks\.contexts \| length\) > 0\)/);
+  assert.match(workflow, /\.required_pull_request_reviews != null/);
+  assert.match(workflow, /\.required_pull_request_reviews\.required_approving_review_count == 0/);
+  assert.match(workflow, /\(\(\.required_pull_request_reviews\.require_last_push_approval \/\/ false\) == false\)/);
+  assert.doesNotMatch(workflow, /required_approving_review_count\s*>=\s*1/);
+});
+
+test('zero approvals pass while approval or last-push requirements fail', () => {
+  const base = {
+    required_status_checks: { contexts: ['Repository hygiene'] },
+    required_pull_request_reviews: {
+      required_approving_review_count: 0,
+      require_last_push_approval: false,
+    },
+    enforce_admins: { enabled: true },
+    required_linear_history: { enabled: true },
+    allow_force_pushes: { enabled: false },
+    allow_deletions: { enabled: false },
+    required_conversation_resolution: { enabled: true },
+  };
+
+  assert.equal(satisfiesGovernance(base), true);
+  assert.equal(
+    satisfiesGovernance({
+      ...base,
+      required_pull_request_reviews: {
+        ...base.required_pull_request_reviews,
+        required_approving_review_count: 1,
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    satisfiesGovernance({
+      ...base,
+      required_pull_request_reviews: {
+        ...base.required_pull_request_reviews,
+        require_last_push_approval: true,
+      },
+    }),
+    false,
+  );
+});
+
+test('governance retains required checks and destructive-action protections', () => {
+  const requiredExpressions = [
+    /\.enforce_admins\.enabled == true/,
+    /\.required_linear_history\.enabled == true/,
+    /\.allow_force_pushes\.enabled == false/,
+    /\.allow_deletions\.enabled == false/,
+    /\.required_conversation_resolution\.enabled == true/,
+  ];
+
+  for (const expression of requiredExpressions) assert.match(workflow, expression);
+});


### PR DESCRIPTION
Summary: model the protected main branch's intentional zero-approval solo-founder policy; explicitly require last-push approval to remain disabled; retain required checks, conversation resolution, linear history, admin enforcement, and no force/deletion protections; add regression tests. Validation: production release contract, workflow action pins, focused Node tests, actionlint 1.7.7, git diff --check.