### PR TITLE
fix: use supported Pages deployment page size

### DIFF
--- a/scripts/cloudflare/execute-lythaus-pages-cutover.mjs
+++ b/scripts/cloudflare/execute-lythaus-pages-cutover.mjs
@@ -129,7 +129,7 @@ async function getProject(name) {
 }
 
 async function listDeployments(name) {
-  const result = await request('GET', `${accountBase}/pages/projects/${encodeURIComponent(name)}/deployments?per_page=100`);
+  const result = await request('GET', `${accountBase}/pages/projects/${encodeURIComponent(name)}/deployments?per_page=25`);
   assertSuccess(`Pages deployments ${name} lookup`, result);
   return Array.isArray(result.result) ? result.result : [];
 }


### PR DESCRIPTION
## Summary\n- use the Cloudflare-supported Pages deployment page size in the permanent cutover inventory\n- addresses sanitized provider error HTTP 400 / code 8000024 from the first exact-SHA cutover attempt\n\n## Validation\n- node --check and cutover contract tests\n- actionlint\n- immutable Action pin validation\n- repository hygiene and retired-reference validation\n\nThe first cutover attempt stopped before mutation; the provider state remains unchanged.