### PR TITLE
fix: rotate and validate Lythaus Access credentials

### DIFF
--- a/.github/workflows/cloudflare-rotate-lythaus-access-credentials.yml
+++ b/.github/workflows/cloudflare-rotate-lythaus-access-credentials.yml
@@ -1,0 +1,56 @@
+name: Rotate Lythaus Access credentials
+
+on:
+  workflow_dispatch:
+    inputs:
+      rotate:
+        description: Create, validate, install, and revoke the Lythaus control-panel service token
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: lythaus-access-credential-rotation
+  cancel-in-progress: false
+
+jobs:
+  rotate:
+    name: Validate and rotate Lythaus Access service token
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: write
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+      GH_TOKEN: ${{ github.token }}
+      ROTATE_LYTHAUS_ACCESS_TOKEN: ${{ inputs.rotate }}
+      ACCESS_ROTATION_EVIDENCE_PATH: .artifacts/cloudflare/access-rotation.json
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '22'
+      - name: Validate and rotate the Lythaus Access service token
+        run: node scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+      - name: Mark protected credential rotation complete
+        if: ${{ inputs.rotate }}
+        run: gh variable set LYTHAUS_CREDENTIAL_ROTATION_COMPLETED --env production --repo "$GITHUB_REPOSITORY" --body true
+      - name: Upload sanitized rotation evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: lythaus-access-rotation-${{ github.sha }}
+          if-no-files-found: warn
+          path: .artifacts/cloudflare

--- a/scripts/cloudflare/execute-lythaus-pages-cutover.mjs
+++ b/scripts/cloudflare/execute-lythaus-pages-cutover.mjs
@@ -121,6 +121,10 @@ function safeProject(project) {
   };
 }
 
+function isAccessLoginPage(body) {
+  return /cloudflareaccess\.com\/cdn-cgi\/access\/(?:login|verify-code)|AuthFormLogin/i.test(body);
+}
+
 async function getProject(name) {
   const result = await request('GET', `${accountBase}/pages/projects/${encodeURIComponent(name)}`, undefined, { allow404: true });
   if (result.status === 404) return null;
@@ -313,6 +317,8 @@ async function verify() {
   if (authenticated.status !== 200) throw new Error(`Authenticated admin access returned HTTP ${authenticated.status}`);
   if (!authenticated.headers.get('content-security-policy')) throw new Error('Authenticated admin response omitted Content-Security-Policy');
   const body = (await authenticated.text()).slice(0, 2_000_000);
+  if (isAccessLoginPage(body)) throw new Error('Access service-token headers returned the Cloudflare login page instead of the Lythaus control panel');
+  if (!/<title[^>]*>Lythaus Control Panel<\/title>/i.test(body)) throw new Error('Authenticated admin response did not contain the Lythaus control-panel shell');
   if (/asora|asora-/i.test(body)) throw new Error('Active Asora branding was found in authenticated admin output');
 
   const next = {

--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -1,0 +1,255 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
+const cloudflareToken = process.env.CLOUDFLARE_API_TOKEN ?? '';
+const currentClientId = process.env.CF_ACCESS_CLIENT_ID ?? '';
+const currentClientSecret = process.env.CF_ACCESS_CLIENT_SECRET ?? '';
+const repository = process.env.GITHUB_REPOSITORY ?? '';
+const githubToken = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? '';
+const outputPath = process.env.ACCESS_ROTATION_EVIDENCE_PATH ?? '.artifacts/cloudflare/access-rotation.json';
+const rotate = process.env.ROTATE_LYTHAUS_ACCESS_TOKEN === 'true';
+const adminUiAppId = process.env.LYTHAUS_ADMIN_UI_ACCESS_APP_ID ?? '2d440b64-6cde-48d7-b3cb-132129ee036f';
+const adminApiAppId = process.env.LYTHAUS_ADMIN_API_ACCESS_APP_ID ?? 'fa6906cc-3daf-4beb-82b5-143e708eca0d';
+
+const apiBase = `https://api.cloudflare.com/client/v4/accounts/${accountId}`;
+
+function requireEnv(name, value) {
+  if (!value) throw new Error(`${name} is required`);
+}
+
+requireEnv('CLOUDFLARE_ACCOUNT_ID', accountId);
+requireEnv('CLOUDFLARE_API_TOKEN', cloudflareToken);
+requireEnv('CF_ACCESS_CLIENT_ID', currentClientId);
+requireEnv('CF_ACCESS_CLIENT_SECRET', currentClientSecret);
+
+function safeError(value) {
+  return String(value ?? '')
+    .replaceAll(currentClientId, '[redacted-client-id]')
+    .replaceAll(currentClientSecret, '[redacted-client-secret]')
+    .replaceAll(cloudflareToken, '[redacted-cloudflare-token]')
+    .replaceAll(/Bearer\s+[^\s]+/gi, 'Bearer [redacted]')
+    .slice(0, 500);
+}
+
+async function cloudflare(path, options = {}) {
+  const response = await fetch(`${apiBase}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${cloudflareToken}`,
+      'Content-Type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let payload = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`Cloudflare ${options.method ?? 'GET'} ${path} returned non-JSON HTTP ${response.status}`);
+  }
+  if (!response.ok || payload.success === false) {
+    const details = (payload.errors ?? []).map((error) => `${error.code ?? 'unknown'}:${error.message ?? 'error'}`).join('; ');
+    throw new Error(`Cloudflare ${options.method ?? 'GET'} ${path} failed HTTP ${response.status}${details ? ` (${safeError(details)})` : ''}`);
+  }
+  return payload.result;
+}
+
+async function listServiceTokens() {
+  const result = await cloudflare('/access/service_tokens?page=1&per_page=100');
+  return Array.isArray(result) ? result : [];
+}
+
+async function listPolicies(appId) {
+  const result = await cloudflare(`/access/apps/${appId}/policies?page=1&per_page=100`);
+  return Array.isArray(result) ? result : [];
+}
+
+function serviceTokenPolicy(policy, tokenId) {
+  return (policy.include ?? []).some((rule) => rule.service_token?.id === tokenId);
+}
+
+function isAccessLoginPage(body) {
+  return /cloudflareaccess\.com\/cdn-cgi\/access\/(?:login|verify-code)|AuthFormLogin/i.test(body);
+}
+
+async function probeAdmin(clientId, clientSecret) {
+  const response = await fetch('https://admin.lythaus.co/', {
+    redirect: 'manual',
+    headers: {
+      'CF-Access-Client-Id': clientId,
+      'CF-Access-Client-Secret': clientSecret,
+    },
+  });
+  const body = (await response.text()).slice(0, 2_000_000);
+  return {
+    status: response.status,
+    contentType: response.headers.get('content-type') ?? '',
+    bodyLength: body.length,
+    bodySha256: createHash('sha256').update(body).digest('hex'),
+    accessLoginDetected: isAccessLoginPage(body),
+    lythausControlPanelDetected: /<title[^>]*>Lythaus Control Panel<\/title>/i.test(body),
+    securityHeaders: {
+      contentSecurityPolicy: Boolean(response.headers.get('content-security-policy')),
+      xContentTypeOptions: response.headers.get('x-content-type-options')?.toLowerCase() === 'nosniff',
+    },
+  };
+}
+
+function requireValidAdminProbe(probe, label) {
+  if (probe.status !== 200 || probe.accessLoginDetected || !probe.lythausControlPanelDetected) {
+    throw new Error(`${label} did not reach the Lythaus control panel (HTTP ${probe.status}; accessLogin=${probe.accessLoginDetected}; panel=${probe.lythausControlPanelDetected})`);
+  }
+  if (!probe.securityHeaders.contentSecurityPolicy || !probe.securityHeaders.xContentTypeOptions) {
+    throw new Error(`${label} control panel response is missing required security headers`);
+  }
+}
+
+function writeEvidence(value) {
+  mkdirSync(outputPath.split(/[\\/]/).slice(0, -1).join('/') || '.', { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function setGitHubSecret(name, value) {
+  requireEnv('GITHUB_REPOSITORY', repository);
+  requireEnv('GH_TOKEN', githubToken);
+  const result = spawnSync('gh', ['secret', 'set', name, '--repo', repository, '--body-file', '-'], {
+    env: { ...process.env, GH_TOKEN: githubToken },
+    input: value,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`GitHub secret update for ${name} failed: ${safeError(result.stderr || result.stdout)}`);
+  }
+}
+
+function deleteGitHubSecret(name) {
+  const result = spawnSync('gh', ['secret', 'delete', name, '--repo', repository], {
+    env: { ...process.env, GH_TOKEN: githubToken },
+    encoding: 'utf8',
+  });
+  if (result.status !== 0 && !/not found|404/i.test(result.stderr || result.stdout || '')) {
+    throw new Error(`GitHub secret deletion for ${name} failed: ${safeError(result.stderr || result.stdout)}`);
+  }
+}
+
+async function createToken() {
+  return cloudflare('/access/service_tokens', {
+    method: 'POST',
+    body: JSON.stringify({
+      name: `Lythaus control-panel CI ${new Date().toISOString().replaceAll(/[^0-9]/g, '').slice(0, 14)}`,
+      duration: '8760h',
+      enabled: true,
+    }),
+  });
+}
+
+async function createPolicy(appId, tokenId, precedence) {
+  return cloudflare(`/access/apps/${appId}/policies`, {
+    method: 'POST',
+    body: JSON.stringify({
+      name: 'Lythaus control-panel CI service token',
+      decision: 'non_identity',
+      include: [{ service_token: { id: tokenId } }],
+      precedence,
+    }),
+  });
+}
+
+async function deletePolicy(appId, policyId) {
+  await cloudflare(`/access/apps/${appId}/policies/${policyId}`, { method: 'DELETE' });
+}
+
+async function deleteServiceToken(tokenId) {
+  await cloudflare(`/access/service_tokens/${tokenId}`, { method: 'DELETE' });
+}
+
+async function inspect() {
+  const tokens = await listServiceTokens();
+  const current = tokens.find((token) => token.client_id === currentClientId);
+  const [uiPolicies, apiPolicies] = await Promise.all([listPolicies(adminUiAppId), listPolicies(adminApiAppId)]);
+  const probe = await probeAdmin(currentClientId, currentClientSecret);
+  const evidence = {
+    schemaVersion: 1,
+    capturedAt: new Date().toISOString(),
+    mode: 'inspect',
+    status: 'observed',
+    currentCredentialMatchesCloudflareServiceToken: Boolean(current),
+    currentServiceToken: current ? { id: current.id, name: current.name, enabled: current.enabled, duration: current.duration } : null,
+    serviceTokenCount: tokens.length,
+    adminUiPolicyCount: uiPolicies.length,
+    adminApiPolicyCount: apiPolicies.length,
+    adminUiServiceTokenPolicyNames: uiPolicies.filter((policy) => policy.decision === 'non_identity').map((policy) => policy.name),
+    adminApiServiceTokenPolicyNames: apiPolicies.filter((policy) => policy.decision === 'non_identity').map((policy) => policy.name),
+    currentCredentialAdminProbe: probe,
+  };
+  writeEvidence(evidence);
+  console.log(JSON.stringify({ status: evidence.status, currentCredentialMatchesCloudflareServiceToken: evidence.currentCredentialMatchesCloudflareServiceToken, currentCredentialAdminStatus: probe.status, accessLoginDetected: probe.accessLoginDetected, lythausControlPanelDetected: probe.lythausControlPanelDetected }));
+}
+
+async function rotateCredentials() {
+  requireEnv('GITHUB_REPOSITORY', repository);
+  requireEnv('GH_TOKEN', githubToken);
+  const tokens = await listServiceTokens();
+  const previous = tokens.find((token) => token.client_id === currentClientId);
+  const created = await createToken();
+  if (!created?.id || !created.client_id || !created.client_secret) throw new Error('Cloudflare created a service token without complete credential metadata');
+
+  const addedPolicies = [];
+  let secretsUpdated = [];
+  try {
+    const uiPolicy = await createPolicy(adminUiAppId, created.id, 2);
+    addedPolicies.push([adminUiAppId, uiPolicy.id]);
+    const apiPolicy = await createPolicy(adminApiAppId, created.id, 2);
+    addedPolicies.push([adminApiAppId, apiPolicy.id]);
+
+    const probe = await probeAdmin(created.client_id, created.client_secret);
+    requireValidAdminProbe(probe, 'New Access service token');
+
+    setGitHubSecret('CF_ACCESS_CLIENT_ID', created.client_id);
+    secretsUpdated.push('CF_ACCESS_CLIENT_ID');
+    setGitHubSecret('CF_ACCESS_CLIENT_SECRET', created.client_secret);
+    secretsUpdated.push('CF_ACCESS_CLIENT_SECRET');
+
+    const previousPolicies = previous ? [
+      ...(await listPolicies(adminUiAppId)).filter((policy) => serviceTokenPolicy(policy, previous.id)).map((policy) => [adminUiAppId, policy.id]),
+      ...(await listPolicies(adminApiAppId)).filter((policy) => serviceTokenPolicy(policy, previous.id)).map((policy) => [adminApiAppId, policy.id]),
+    ] : [];
+    for (const [appId, policyId] of previousPolicies) await deletePolicy(appId, policyId);
+    let previousRevoked = false;
+    if (previous && previousPolicies.length >= 1) {
+      await deleteServiceToken(previous.id);
+      previousRevoked = true;
+    }
+
+    const evidence = {
+      schemaVersion: 1,
+      capturedAt: new Date().toISOString(),
+      mode: 'rotate',
+      status: 'verified',
+      newServiceToken: { id: created.id, name: created.name, duration: created.duration, enabled: created.enabled },
+      newPolicies: addedPolicies.map(([appId, policyId]) => ({ appId, policyId })),
+      previousServiceToken: previous ? { id: previous.id, name: previous.name, revoked: previousRevoked } : null,
+      previousCredentialMatched: Boolean(previous),
+      previousPoliciesRemoved: previous ? previousPolicies.length : 0,
+      githubSecretsUpdated: secretsUpdated,
+      credentialRotationCompleted: true,
+      adminProbe: probe,
+    };
+    writeEvidence(evidence);
+    console.log(JSON.stringify({ status: evidence.status, credentialRotationCompleted: true, previousCredentialRevoked: previousRevoked, newPolicyCount: addedPolicies.length }));
+  } catch (error) {
+    for (const name of secretsUpdated) {
+      try { setGitHubSecret(name, name === 'CF_ACCESS_CLIENT_ID' ? currentClientId : currentClientSecret); } catch { /* best effort restore */ }
+    }
+    for (const [appId, policyId] of addedPolicies.reverse()) {
+      try { await deletePolicy(appId, policyId); } catch { /* best effort rollback */ }
+    }
+    try { await deleteServiceToken(created.id); } catch { /* best effort rollback */ }
+    throw error;
+  }
+}
+
+if (rotate) await rotateCredentials();
+else await inspect();

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync(new URL('../../.github/workflows/cloudflare-rotate-lythaus-access-credentials.yml', import.meta.url), 'utf8');
+const script = readFileSync(new URL('../cloudflare/rotate-lythaus-access-service-token.mjs', import.meta.url), 'utf8');
+
+test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
+  assert.match(workflow, /environment: production/);
+  assert.match(workflow, /actions: write/);
+  assert.match(workflow, /actions\/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f/);
+  assert.match(script, /access\/service_tokens/);
+  assert.match(script, /Lythaus control-panel CI service token/);
+  assert.match(script, /gh', \['secret', 'set'/);
+  assert.match(script, /body-file/);
+  assert.match(script, /credentialRotationCompleted: true/);
+  assert.doesNotMatch(script, /console\.log\([^\n]*(client_secret|currentClientSecret)/);
+});

--- a/scripts/tests/cloudflare-pages-cutover.test.mjs
+++ b/scripts/tests/cloudflare-pages-cutover.test.mjs
@@ -32,5 +32,7 @@ test('legacy retirement is narrowly scoped to the known Lythaus preview Access a
   assert.match(script, /\*\.asora-6bi\.pages\.dev/);
   assert.match(script, /DELETE.*access\/apps/);
   assert.match(script, /legacyAsoraActiveResources: 0/);
+  assert.match(script, /Access service-token headers returned the Cloudflare login page/);
+  assert.match(script, /Lythaus Control Panel<\\\/title>/);
   assert.doesNotMatch(script, /nite-owl.*DELETE|DELETE.*nite-owl/i);
 });


### PR DESCRIPTION
## Summary\n- add protected, sanitized Lythaus Access service-token rotation\n- validate the authenticated control-panel shell instead of accepting the Access login page\n- retain rollback cleanup and regression coverage\n\n## Scope\nLythaus admin UI/API Access only. Nite Owl resources are not inspected or modified.\n\n## Validation\n- actionlint\n- immutable action pin validation\n- production-release contract validation\n- repository hygiene\n- retired-provider dependency validation\n- focused Cloudflare tests