### PR TITLE
fix: use the Access service token policy identifier

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -67,7 +67,9 @@ async function listPolicies(appId) {
 }
 
 function serviceTokenPolicy(policy, tokenId) {
-  return (policy.include ?? []).some((rule) => rule.service_token?.id === tokenId);
+  return (policy.include ?? []).some((rule) => (
+    rule.service_token?.token_id === tokenId || rule.service_token?.id === tokenId
+  ));
 }
 
 function isAccessLoginPage(body) {
@@ -139,7 +141,7 @@ async function createPolicy(appId, tokenId, precedence) {
     body: JSON.stringify({
       name: 'Lythaus control-panel CI service token',
       decision: 'non_identity',
-      include: [{ service_token: { id: tokenId } }],
+      include: [{ service_token: { token_id: tokenId } }],
       precedence,
     }),
   });

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -11,6 +11,7 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(workflow, /actions\/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f/);
   assert.match(script, /access\/service_tokens\/\$\{tokenId\}\/rotate/);
   assert.match(script, /previous_client_secret_expires_at/);
+  assert.match(script, /service_token: \{ token_id: tokenId \}/);
   assert.match(script, /Lythaus control-panel CI service token/);
   assert.match(script, /gh', \['secret', 'set'/);
   assert.match(script, /body-file/);


### PR DESCRIPTION
## Summary\n- use Cloudflare's service_token.token_id policy shape\n- recognize both API response shapes when matching existing policies\n- retain focused protected-rotation tests\n\n## Validation\n- actionlint\n- repository hygiene\n- retired-provider dependency validation\n- focused Cloudflare tests\n\nThis is Lythaus Admin UI/API scope only; Nite Owl is untouched.