### PR TITLE
fix: let Cloudflare assign Access policy precedence

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -135,14 +135,13 @@ async function rotateServiceToken(tokenId) {
   });
 }
 
-async function createPolicy(appId, tokenId, precedence) {
+async function createPolicy(appId, tokenId) {
   return cloudflare(`/access/apps/${appId}/policies`, {
     method: 'POST',
     body: JSON.stringify({
       name: 'Lythaus control-panel CI service token',
       decision: 'non_identity',
       include: [{ service_token: { token_id: tokenId } }],
-      precedence,
     }),
   });
 }
@@ -192,7 +191,7 @@ async function rotateCredentials() {
   try {
     const uiPolicies = await listPolicies(adminUiAppId);
     if (!uiPolicies.some((policy) => serviceTokenPolicy(policy, previous.id))) {
-      const uiPolicy = await createPolicy(adminUiAppId, previous.id, 2);
+      const uiPolicy = await createPolicy(adminUiAppId, previous.id);
       addedPolicies.push([adminUiAppId, uiPolicy.id]);
     }
 


### PR DESCRIPTION
## Summary\n- use the accepted service_token.token_id policy shape\n- let Cloudflare assign a unique Access policy precedence\n\n## Validation\n- actionlint\n- repository hygiene\n- retired-provider dependency validation\n- focused Cloudflare tests\n\nLythaus Admin UI/API only; Nite Owl is untouched.