### PR TITLE
fix: place Lythaus Access token policy before deny

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -142,6 +142,7 @@ async function createPolicy(appId, tokenId) {
       name: 'Lythaus control-panel CI service token',
       decision: 'non_identity',
       include: [{ service_token: { token_id: tokenId } }],
+      precedence: 0,
     }),
   });
 }

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -12,6 +12,7 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(script, /access\/service_tokens\/\$\{tokenId\}\/rotate/);
   assert.match(script, /previous_client_secret_expires_at/);
   assert.match(script, /service_token: \{ token_id: tokenId \}/);
+  assert.match(script, /precedence: 0/);
   assert.match(script, /Lythaus control-panel CI service token/);
   assert.match(script, /gh', \['secret', 'set'/);
   assert.match(script, /body-file/);


### PR DESCRIPTION
## Summary\n- assign the Lythaus service-token policy precedence 0 so it is evaluated before the deny-all policy\n- retain exact token-id matching and sanitized evidence\n\n## Validation\n- actionlint\n- repository hygiene\n- retired-provider dependency validation\n- focused Cloudflare tests\n\nLythaus Admin UI/API only; Nite Owl is untouched.