### PR TITLE
fix: publish rotated Access secret through stdin

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -116,7 +116,7 @@ function writeEvidence(value) {
 function setGitHubSecret(name, value) {
   requireEnv('GITHUB_REPOSITORY', repository);
   requireEnv('GH_TOKEN', githubToken);
-  const result = spawnSync('gh', ['secret', 'set', name, '--repo', repository, '--body-file', '-'], {
+  const result = spawnSync('gh', ['secret', 'set', name, '--repo', repository], {
     env: { ...process.env, GH_TOKEN: githubToken },
     input: value,
     encoding: 'utf8',

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -19,7 +19,7 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(script, /precedence: 0/);
   assert.match(script, /Lythaus control-panel CI service token/);
   assert.match(script, /gh', \['secret', 'set'/);
-  assert.match(script, /body-file/);
+  assert.doesNotMatch(script, /body-file/);
   assert.match(script, /credentialRotationCompleted: true/);
   assert.doesNotMatch(script, /console\.log\([^\n]*(client_secret|currentClientSecret)/);
 });


### PR DESCRIPTION
Use the supported GitHub CLI stdin contract when setting rotated Access secrets. The prior run proved Cloudflare rotation, policy binding, and authenticated admin smoke, then failed only on the unsupported --body-file flag.