### PR TITLE
fix: authorize Access secret rotation

### DIFF
--- a/.github/workflows/cloudflare-rotate-lythaus-access-credentials.yml
+++ b/.github/workflows/cloudflare-rotate-lythaus-access-credentials.yml
@@ -31,7 +31,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
       CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.LYTHAUS_GITHUB_ADMIN_TOKEN }}
       ROTATE_LYTHAUS_ACCESS_TOKEN: ${{ inputs.rotate }}
       ACCESS_ROTATION_EVIDENCE_PATH: .artifacts/cloudflare/access-rotation.json
     steps:

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -8,6 +8,8 @@ const script = readFileSync(new URL('../cloudflare/rotate-lythaus-access-service
 test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(workflow, /environment: production/);
   assert.match(workflow, /actions: write/);
+  assert.match(workflow, /LYTHAUS_GITHUB_ADMIN_TOKEN/);
+  assert.doesNotMatch(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(workflow, /actions\/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f/);
   assert.match(script, /access\/service_tokens\/\$\{tokenId\}\/rotate/);
   assert.match(script, /previous_client_secret_expires_at/);


### PR DESCRIPTION
Use the temporary owner-authorized repository administration secret for the rotation workflow because GITHUB_TOKEN cannot update repository secrets. The secret is temporary and will be removed immediately after the successful rotation.