### PR TITLE
fix: retire legacy Access token references

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -12,6 +12,7 @@ const outputPath = process.env.ACCESS_ROTATION_EVIDENCE_PATH ?? '.artifacts/clou
 const rotate = process.env.ROTATE_LYTHAUS_ACCESS_TOKEN === 'true';
 const adminUiAppId = process.env.LYTHAUS_ADMIN_UI_ACCESS_APP_ID ?? '2d440b64-6cde-48d7-b3cb-132129ee036f';
 const adminApiAppId = process.env.LYTHAUS_ADMIN_API_ACCESS_APP_ID ?? 'fa6906cc-3daf-4beb-82b5-143e708eca0d';
+const legacyPreviewAppId = process.env.LYTHAUS_LEGACY_PREVIEW_ACCESS_APP_ID ?? '6152f491-9f60-4c0b-8c0c-a3ddacdf9270';
 
 const apiBase = `https://api.cloudflare.com/client/v4/accounts/${accountId}`;
 
@@ -242,7 +243,7 @@ async function rotateCredentials() {
     const legacyTokens = tokens.filter((token) => token.id !== previous.id && /asora/i.test(token.name ?? ''));
     const legacyPolicies = [];
     for (const legacyToken of legacyTokens) {
-      for (const appId of [adminUiAppId, adminApiAppId]) {
+      for (const appId of [adminUiAppId, adminApiAppId, legacyPreviewAppId]) {
         const policies = await listPolicies(appId);
         for (const policy of policies.filter((candidate) => serviceTokenPolicy(candidate, legacyToken.id))) {
           await deletePolicy(appId, policy.id);

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -18,6 +18,8 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(script, /probeAdminWithRetry/);
   assert.match(script, /status: 'failed'/);
   assert.match(script, /replacedLegacyName/);
+  assert.match(script, /LYTHAUS_LEGACY_PREVIEW_ACCESS_APP_ID/);
+  assert.match(script, /6152f491-9f60-4c0b-8c0c-a3ddacdf9270/);
   assert.match(script, /precedence: 0/);
   assert.match(script, /Lythaus control-panel CI service token/);
   assert.match(script, /gh', \['secret', 'set'/);


### PR DESCRIPTION
Remove the known legacy Asora service-token references from the canonical UI, API, and Lythaus preview Access applications before deleting the legacy token. Nite Owl application IDs are not enumerated or touched.