### PR TITLE
chore: record Access SCIM inventory evidence

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -322,7 +322,19 @@ async function rotateCredentials() {
     for (const listedApp of accessApplications) {
       if (!listedApp?.id || isNiteOwlApplication(listedApp)) continue;
       const app = await getAccessApplication(listedApp.id);
-      accessApplicationInventory.push(accessApplicationEvidence(app, legacyClientIds));
+      const appEvidence = accessApplicationEvidence(app, legacyClientIds);
+      accessApplicationInventory.push(appEvidence);
+      if (appEvidence.legacyServiceTokenReferencePaths.length > 0 && !isLegacyLythausApplication(app)) {
+        throw new Error(`Legacy Access service token is still referenced by an unclassified Access application ${app.name ?? app.id}`);
+      }
+    }
+    const legacyPreviewListedApp = accessApplications.find((app) => app?.id === legacyPreviewAppId);
+    if (legacyPreviewListedApp) {
+      const legacyPreviewApp = await getAccessApplication(legacyPreviewAppId);
+      const references = legacyTokens.flatMap((token) => findClientIdReferences(legacyPreviewApp.scim_config, token.client_id, 'scim_config'));
+      await updateApplicationScimConfig(legacyPreviewApp, null);
+      updatedScimApps.push({ app: legacyPreviewApp, tokenId: null });
+      legacyScimApps.push({ appId: legacyPreviewApp.id, name: legacyPreviewApp.name, references, clearedExplicitly: true });
     }
     for (const legacyToken of legacyTokens) {
       for (const appId of [adminUiAppId, adminApiAppId, legacyPreviewAppId]) {
@@ -342,18 +354,6 @@ async function rotateCredentials() {
           await updateGroupWithoutServiceToken(group, legacyToken.id);
           updatedGroups.push({ group, tokenId: legacyToken.id });
         }
-      }
-      for (const listedApp of accessApplications) {
-        if (!listedApp?.id || isNiteOwlApplication(listedApp)) continue;
-        const app = await getAccessApplication(listedApp.id);
-        const references = findClientIdReferences(app.scim_config, legacyToken.client_id, 'scim_config');
-        if (references.length === 0) continue;
-        if (!isLegacyLythausApplication(app)) {
-          throw new Error(`Legacy Access service token is still referenced by an unclassified Access application ${app.name ?? app.id}`);
-        }
-        await updateApplicationScimConfig(app, null);
-        updatedScimApps.push({ app, tokenId: legacyToken.id });
-        legacyScimApps.push({ appId: app.id, name: app.name, references });
       }
     }
     for (const legacyToken of legacyTokens) await deleteServiceToken(legacyToken.id);

--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -100,6 +100,20 @@ function isLegacyLythausApplication(app) {
   return app.id === legacyPreviewAppId || /asora|legacy|preview/i.test(`${app.name ?? ''} ${app.domain ?? ''}`);
 }
 
+function accessApplicationEvidence(app, legacyClientIds) {
+  const references = legacyClientIds.flatMap((clientId) => findClientIdReferences(app.scim_config, clientId, 'scim_config'));
+  return {
+    id: app.id,
+    name: app.name,
+    domain: app.domain,
+    type: app.type,
+    niteOwl: isNiteOwlApplication(app),
+    scimConfigured: Boolean(app.scim_config),
+    scimEnabled: app.scim_config?.enabled ?? null,
+    legacyServiceTokenReferencePaths: references,
+  };
+}
+
 function serviceTokenPolicy(policy, tokenId) {
   return (policy.include ?? []).some((rule) => (
     rule.service_token?.token_id === tokenId || rule.service_token?.id === tokenId
@@ -269,6 +283,7 @@ async function rotateCredentials() {
   let secretsUpdated = [];
   let rotated = null;
   let lastProbe = null;
+  let accessApplicationInventory = [];
   try {
     rotated = await rotateServiceToken(previous.id);
     if (!rotated?.id || !rotated.client_id || !rotated.client_secret) throw new Error('Cloudflare rotated a service token without complete credential metadata');
@@ -303,6 +318,12 @@ async function rotateCredentials() {
     const legacyPolicies = [];
     const legacyScimApps = [];
     const accessApplications = await listAccessApplications();
+    const legacyClientIds = legacyTokens.map((token) => token.client_id);
+    for (const listedApp of accessApplications) {
+      if (!listedApp?.id || isNiteOwlApplication(listedApp)) continue;
+      const app = await getAccessApplication(listedApp.id);
+      accessApplicationInventory.push(accessApplicationEvidence(app, legacyClientIds));
+    }
     for (const legacyToken of legacyTokens) {
       for (const appId of [adminUiAppId, adminApiAppId, legacyPreviewAppId]) {
         const policies = await listPolicies(appId);
@@ -350,6 +371,7 @@ async function rotateCredentials() {
       legacyPoliciesRemoved: legacyPolicies,
       legacyGroupsUpdated: updatedGroups.map(({ group, tokenId }) => ({ groupId: group.id, name: group.name, tokenId })),
       legacyScimAppsCleared: legacyScimApps,
+      accessApplicationInventory,
       previousCredentialMatched: true,
       githubSecretsUpdated: secretsUpdated,
       credentialRotationCompleted: true,
@@ -396,6 +418,7 @@ async function rotateCredentials() {
       updatedPolicies: updatedPolicies.map(({ appId, policy }) => ({ appId, policyId: policy.id, replacedLegacyName: policy.name })),
       updatedGroups: updatedGroups.map(({ group, tokenId }) => ({ groupId: group.id, name: group.name, tokenId })),
       updatedScimApps: updatedScimApps.map(({ app, tokenId }) => ({ appId: app.id, name: app.name, tokenId })),
+      accessApplicationInventory,
       lastProbe,
       githubSecretsUpdated: secretsUpdated,
       rollbackAttempted: true,

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -29,6 +29,7 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(script, /isLegacyLythausApplication/);
   assert.match(script, /accessApplicationEvidence/);
   assert.match(script, /accessApplicationInventory/);
+  assert.match(script, /clearedExplicitly/);
   assert.match(script, /legacyScimApps/);
   assert.match(script, /updatedScimApps/);
   assert.match(script, /precedence: 0/);

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -27,6 +27,8 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(script, /listAccessApplications/);
   assert.match(script, /isNiteOwlApplication/);
   assert.match(script, /isLegacyLythausApplication/);
+  assert.match(script, /accessApplicationEvidence/);
+  assert.match(script, /accessApplicationInventory/);
   assert.match(script, /legacyScimApps/);
   assert.match(script, /updatedScimApps/);
   assert.match(script, /precedence: 0/);


### PR DESCRIPTION
Record sanitized non-Nite Owl Access application inventory and legacy service-token SCIM reference paths during authorized rotation. This preserves fail-closed cleanup while exposing the exact remaining dependency for safe retirement.