### PR TITLE
fix: preserve Access app type during SCIM cleanup

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -234,7 +234,12 @@ async function updateGroupWithoutServiceToken(group, tokenId) {
 async function updateApplicationScimConfig(app, scimConfig) {
   return cloudflare(`/access/apps/${app.id}`, {
     method: 'PUT',
-    body: JSON.stringify({ name: app.name, scim_config: scimConfig }),
+    body: JSON.stringify({
+      name: app.name,
+      domain: app.domain,
+      type: app.type,
+      scim_config: scimConfig,
+    }),
   });
 }
 

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -24,6 +24,8 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(script, /updatedGroups/);
   assert.match(script, /access\/apps\/\$\{appId\}/);
   assert.match(script, /findClientIdReferences/);
+  assert.match(script, /domain: app\.domain/);
+  assert.match(script, /type: app\.type/);
   assert.match(script, /listAccessApplications/);
   assert.match(script, /isNiteOwlApplication/);
   assert.match(script, /isLegacyLythausApplication/);


### PR DESCRIPTION
Preserve the known legacy preview Access application's domain and self-hosted type when clearing its SCIM configuration. This addresses Cloudflare error 12130 without changing canonical or Nite Owl resources.