### PR TITLE
fix: retry transient Access inventory reads

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -35,26 +35,40 @@ function safeError(value) {
 }
 
 async function cloudflare(path, options = {}) {
-  const response = await fetch(`${apiBase}${path}`, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${cloudflareToken}`,
-      'Content-Type': 'application/json',
-      ...(options.headers ?? {}),
-    },
-  });
-  const text = await response.text();
-  let payload = {};
-  try {
-    payload = text ? JSON.parse(text) : {};
-  } catch {
-    throw new Error(`Cloudflare ${options.method ?? 'GET'} ${path} returned non-JSON HTTP ${response.status}`);
+  const method = options.method ?? 'GET';
+  const retryReads = method === 'GET';
+  const maxAttempts = retryReads ? 5 : 1;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const response = await fetch(`${apiBase}${path}`, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${cloudflareToken}`,
+        'Content-Type': 'application/json',
+        ...(options.headers ?? {}),
+      },
+    });
+    const text = await response.text();
+    let payload = {};
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      if (retryReads && (response.status === 429 || response.status >= 500) && attempt + 1 < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * (2 ** attempt)));
+        continue;
+      }
+      throw new Error(`Cloudflare ${method} ${path} returned non-JSON HTTP ${response.status}`);
+    }
+    if (!response.ok || payload.success === false) {
+      const details = (payload.errors ?? []).map((error) => `${error.code ?? 'unknown'}:${error.message ?? 'error'}`).join('; ');
+      if (retryReads && (response.status === 429 || response.status >= 500) && attempt + 1 < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * (2 ** attempt)));
+        continue;
+      }
+      throw new Error(`Cloudflare ${method} ${path} failed HTTP ${response.status}${details ? ` (${safeError(details)})` : ''}`);
+    }
+    return payload.result;
   }
-  if (!response.ok || payload.success === false) {
-    const details = (payload.errors ?? []).map((error) => `${error.code ?? 'unknown'}:${error.message ?? 'error'}`).join('; ');
-    throw new Error(`Cloudflare ${options.method ?? 'GET'} ${path} failed HTTP ${response.status}${details ? ` (${safeError(details)})` : ''}`);
-  }
-  return payload.result;
+  throw new Error(`Cloudflare ${method} ${path} exhausted read retries`);
 }
 
 async function listServiceTokens() {

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -13,6 +13,9 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(workflow, /actions\/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f/);
   assert.match(script, /access\/service_tokens\/\$\{tokenId\}\/rotate/);
   assert.match(script, /previous_client_secret_expires_at/);
+  assert.match(script, /response\.status === 429/);
+  assert.match(script, /response\.status >= 500/);
+  assert.match(script, /maxAttempts = retryReads \? 5 : 1/);
   assert.match(script, /service_token: \{ token_id: tokenId \}/);
   assert.match(script, /policyPayloadForServiceToken/);
   assert.match(script, /probeAdminWithRetry/);


### PR DESCRIPTION
Retry only idempotent Cloudflare Access GETs for bounded 429/5xx responses. Mutating rotation, policy, group, SCIM, and token operations remain single-attempt so transient reads do not abort an otherwise safe credential rotation.