### PR TITLE
fix: tolerate retired preview policy absence

### DIFF
--- a/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
+++ b/scripts/cloudflare/rotate-lythaus-access-service-token.mjs
@@ -77,8 +77,15 @@ async function listServiceTokens() {
 }
 
 async function listPolicies(appId) {
-  const result = await cloudflare(`/access/apps/${appId}/policies?page=1&per_page=100`);
-  return Array.isArray(result) ? result : [];
+  try {
+    const result = await cloudflare(`/access/apps/${appId}/policies?page=1&per_page=100`);
+    return Array.isArray(result) ? result : [];
+  } catch (error) {
+    if (appId === legacyPreviewAppId && /failed HTTP 404 \(11021:access\.api\.error\.unknown_application/.test(error.message ?? '')) {
+      return [];
+    }
+    throw error;
+  }
 }
 
 async function listAccessGroups() {

--- a/scripts/tests/cloudflare-access-rotation.test.mjs
+++ b/scripts/tests/cloudflare-access-rotation.test.mjs
@@ -16,6 +16,8 @@ test('Access rotation is protected, Lythaus-scoped, and sanitized', () => {
   assert.match(script, /response\.status === 429/);
   assert.match(script, /response\.status >= 500/);
   assert.match(script, /maxAttempts = retryReads \? 5 : 1/);
+  assert.match(script, /unknown_application/);
+  assert.match(script, /appId === legacyPreviewAppId/);
   assert.match(script, /service_token: \{ token_id: tokenId \}/);
   assert.match(script, /policyPayloadForServiceToken/);
   assert.match(script, /probeAdminWithRetry/);


### PR DESCRIPTION
Treat the exact Cloudflare unknown_application response for the explicitly retired Lythaus preview Access app as an idempotent empty policy set. Other provider errors and all unrelated application 404s remain fatal.