### PR TITLE
chore: harden Lythaus Pages source hygiene

### DIFF
--- a/.github/workflows/cloudflare-lythaus-web-source-hygiene.yml
+++ b/.github/workflows/cloudflare-lythaus-web-source-hygiene.yml
@@ -1,0 +1,66 @@
+name: Cloudflare Lythaus web source hygiene
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact reviewed current main SHA for the approved hygiene operation
+        required: true
+        type: string
+      confirm_cleanup:
+        description: Confirm disabling web auto-deployments and detaching the retired Asora-era domain
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lythaus-web-source-hygiene
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Clean the canonical Flutter Pages bindings
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      CONFIRM_CLEANUP: ${{ inputs.confirm_cleanup }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      WEB_SOURCE_HYGIENE_EVIDENCE_PATH: .artifacts/cloudflare/lythaus-web-source-hygiene.json
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Require exact reviewed current main SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full 40-character SHA' >&2; exit 1; }
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          test "$(git rev-parse origin/main)" = "$RELEASE_SHA"
+          test "$CONFIRM_CLEANUP" = true
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '22'
+
+      - name: Disable legacy automatic deployment and detach obsolete domain
+        run: node scripts/cloudflare/execute-lythaus-web-source-hygiene.mjs
+
+      - name: Upload sanitized hygiene and rollback evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: lythaus-web-source-hygiene-${{ inputs.release_sha }}
+          if-no-files-found: warn
+          path: .artifacts/cloudflare

--- a/scripts/check-branding.sh
+++ b/scripts/check-branding.sh
@@ -21,10 +21,15 @@ content_matches="$({
     --glob '!cloudflare/execute-lythaus-pages-cutover.mjs' \
     --glob '!scripts/cloudflare/rotate-lythaus-access-service-token.mjs' \
     --glob '!cloudflare/rotate-lythaus-access-service-token.mjs' \
+    --glob '!scripts/cloudflare/execute-lythaus-web-source-hygiene.mjs' \
+    --glob '!cloudflare/execute-lythaus-web-source-hygiene.mjs' \
     --glob '!.github/workflows/cloudflare-lythaus-pages-cutover.yml' \
     --glob '!workflows/cloudflare-lythaus-pages-cutover.yml' \
+    --glob '!.github/workflows/cloudflare-lythaus-web-source-hygiene.yml' \
+    --glob '!workflows/cloudflare-lythaus-web-source-hygiene.yml' \
     --glob '!scripts/tests/cloudflare-pages-cutover.test.mjs' \
     --glob '!scripts/tests/cloudflare-pages-cutover.test.mjs' \
+    --glob '!scripts/tests/cloudflare-web-source-hygiene.test.mjs' \
     --glob '!scripts/ci/build-release-manifest.mjs' \
     --glob '!ci/build-release-manifest.mjs' \
     --glob '!.github/workflows/production-release.yml' \

--- a/scripts/cloudflare/audit-account.mjs
+++ b/scripts/cloudflare/audit-account.mjs
@@ -189,6 +189,7 @@ const pages = rawPages.map((project) => {
   });
   return {
     name,
+    id: project.id ?? null,
     classification,
     productionBranch: project.production_branch ?? null,
     sourceIntegration: project.source ? {
@@ -292,6 +293,52 @@ for (const page of pages.filter(({ classification }) => classification !== 'EXTE
       : [],
   };
   await sleep(300);
+}
+
+function classifyPageLegacyState(page) {
+  const detail = pageDetails[page.name] ?? {};
+  const source = detail.detail?.sourceIntegration ?? page.sourceIntegration ?? null;
+  const domains = [
+    ...(Array.isArray(page.domains) ? page.domains : []),
+    ...(Array.isArray(detail.customDomains) ? detail.customDomains.map(({ name }) => name) : []),
+  ].filter(Boolean);
+  const normalisedDomains = domains.map(normalise);
+  const legacyCustomDomains = normalisedDomains.filter((domain) => (
+    domain.includes('asora') && domain !== 'asora-6bi.pages.dev'
+  ));
+  const renamedRepositoryAlias = normalise(source?.owner) === 'asorakk'
+    && normalise(source?.repoName) === 'asora';
+  const automaticDeploymentsEnabled = source?.productionDeploymentsEnabled !== false
+    || (source?.previewDeploymentSetting ?? 'all') !== 'none';
+  const activeLegacyReferences = [
+    ...legacyCustomDomains.map((domain) => `custom-domain:${domain}`),
+    ...(renamedRepositoryAlias && automaticDeploymentsEnabled ? ['github-repository-rename-alias-with-automatic-deployments'] : []),
+  ];
+  const providerExceptions = [];
+  if (normalisedDomains.includes('asora-6bi.pages.dev')) {
+    providerExceptions.push('Cloudflare Pages default hostname is immutable after the in-place project rename; the Lythaus custom domain is authoritative.');
+  }
+  if (renamedRepositoryAlias && !automaticDeploymentsEnabled) {
+    providerExceptions.push('Cloudflare retains the historical GitHub repository rename alias in disabled source metadata; direct exact-SHA CI deployments are authoritative.');
+  }
+  return {
+    classification: activeLegacyReferences.length > 0 ? 'LEGACY ASORA FOR LYTHAUS' : 'CANONICAL LYTHAUS',
+    activeLegacyReferences,
+    providerExceptions,
+  };
+}
+
+for (const page of pages.filter(({ classification }) => classification !== 'EXTERNAL / OUT OF SCOPE')) {
+  const legacyState = classifyPageLegacyState(page);
+  page.classification = legacyState.classification;
+  page.legacyReferences = {
+    active: legacyState.activeLegacyReferences,
+    providerExceptions: legacyState.providerExceptions,
+  };
+  if (pageDetails[page.name]) {
+    pageDetails[page.name].classification = page.classification;
+    pageDetails[page.name].legacyReferences = page.legacyReferences;
+  }
 }
 
 const access = [];
@@ -401,7 +448,7 @@ const adminSettingsAccess = adminSettings.bindings.filter(({ name }) => [
 
 const integrations = pages
   .filter(({ sourceIntegration }) => sourceIntegration !== null)
-  .map(({ name, sourceIntegration, classification }) => ({ project: name, classification, ...sourceIntegration }));
+  .map(({ name, sourceIntegration, classification, legacyReferences }) => ({ project: name, classification, legacyReferences, ...sourceIntegration }));
 
 const legacyNamedResources = [];
 for (const [type, entries] of Object.entries({ pages, workers, hyperdrives, r2, queues, workflows, kv, access, turnstile, dns, routes })) {
@@ -420,6 +467,14 @@ for (const [type, entries] of Object.entries({ pages, workers, hyperdrives, r2, 
     }
   }
 }
+
+const legacyProviderExceptions = pages
+  .filter(({ legacyReferences }) => Array.isArray(legacyReferences?.providerExceptions) && legacyReferences.providerExceptions.length > 0)
+  .map(({ name, legacyReferences }) => ({
+    type: 'pages',
+    name,
+    exceptions: legacyReferences.providerExceptions,
+  }));
 
 const endpointStates = Object.fromEntries(Object.entries(responses).map(([name, response]) => [name, endpointState(response)]));
 const requiredLythausFailures = [
@@ -474,6 +529,7 @@ const report = {
   resources: resourceCollections,
   resourceClassifications: resourceCollections,
   ignoredExternalResources,
+  legacyProviderExceptions,
   legacyNamedResources,
 };
 

--- a/scripts/cloudflare/execute-lythaus-web-source-hygiene.mjs
+++ b/scripts/cloudflare/execute-lythaus-web-source-hygiene.mjs
@@ -1,0 +1,225 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
+const token = process.env.CLOUDFLARE_API_TOKEN ?? '';
+const releaseSha = process.env.RELEASE_SHA ?? '';
+const confirmCleanup = process.env.CONFIRM_CLEANUP === 'true';
+const projectName = process.env.LYTHAUS_WEB_PAGES_PROJECT ?? 'lythaus-web';
+const canonicalDomain = process.env.LYTHAUS_WEB_CANONICAL_DOMAIN ?? 'app.lythaus.co';
+const legacyDomain = process.env.LYTHAUS_WEB_LEGACY_DOMAIN ?? 'app.lythaus.asora.co.za';
+const evidencePath = process.env.WEB_SOURCE_HYGIENE_EVIDENCE_PATH
+  ?? path.join('.artifacts', 'cloudflare', 'lythaus-web-source-hygiene.json');
+
+const niteOwlMarkers = ['nite-owl', 'niteowl', 'nite_owl', 'nite-owl-web', 'nite-owl-web-preview'];
+
+if (!/^[0-9a-f]{32}$/i.test(accountId)) throw new Error('CLOUDFLARE_ACCOUNT_ID must be a 32-character account ID');
+if (!token) throw new Error('CLOUDFLARE_API_TOKEN is required');
+if (!/^[0-9a-f]{40}$/.test(releaseSha)) throw new Error('RELEASE_SHA must be a full 40-character SHA');
+if (!confirmCleanup) throw new Error('CONFIRM_CLEANUP=true is required for the approved web source hygiene operation');
+if (projectName !== 'lythaus-web') throw new Error('Only the canonical lythaus-web Pages project is allowlisted');
+if (canonicalDomain !== 'app.lythaus.co') throw new Error('Only app.lythaus.co is allowlisted as the canonical web domain');
+if (legacyDomain !== 'app.lythaus.asora.co.za') throw new Error('Only the known retired Lythaus Asora-era domain is allowlisted for removal');
+
+const headers = {
+  authorization: `Bearer ${token}`,
+  accept: 'application/json',
+  'content-type': 'application/json',
+};
+const accountBase = `https://api.cloudflare.com/client/v4/accounts/${accountId}`;
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function containsNiteOwl(...values) {
+  const haystack = values
+    .flatMap((value) => Array.isArray(value) ? value : [value])
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return niteOwlMarkers.some((marker) => haystack.includes(marker));
+}
+
+function assertNotNiteOwl(label, ...values) {
+  if (containsNiteOwl(...values)) throw new Error(`Refusing ${label}: resource is EXTERNAL / OUT OF SCOPE`);
+}
+
+function safeErrors(payload) {
+  return Array.isArray(payload?.errors)
+    ? payload.errors.map((error) => ({
+      code: error?.code ?? null,
+      message: typeof error?.message === 'string' ? error.message.slice(0, 240) : null,
+    }))
+    : [];
+}
+
+async function request(method, url, body = undefined, { allow404 = false } = {}) {
+  const readOnly = method === 'GET';
+  let last = null;
+  for (let attempt = 1; attempt <= (readOnly ? 5 : 1); attempt += 1) {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    let payload = {};
+    try { payload = await response.json(); } catch { payload = {}; }
+    last = {
+      status: response.status,
+      ok: response.ok && payload.success !== false,
+      result: payload.result ?? null,
+      errors: safeErrors(payload),
+    };
+    if (last.ok || (allow404 && response.status === 404)) return last;
+    if (!readOnly || (response.status !== 429 && response.status < 500) || attempt === 5) return last;
+    await sleep(Math.min(1000 * (2 ** (attempt - 1)), 8000));
+  }
+  return last;
+}
+
+function assertSuccess(label, result) {
+  if (!result?.ok) {
+    throw new Error(`${label} failed with HTTP ${result?.status ?? 'unknown'}: ${JSON.stringify(result?.errors ?? [])}`);
+  }
+}
+
+function safeSource(source) {
+  const config = source?.config ?? {};
+  return source ? {
+    type: source.type ?? null,
+    owner: config.owner ?? null,
+    ownerId: config.owner_id ?? null,
+    repoName: config.repo_name ?? null,
+    repoId: config.repo_id ?? null,
+    productionDeploymentsEnabled: config.production_deployments_enabled ?? config.deployments_enabled ?? null,
+    previewDeploymentSetting: config.preview_deployment_setting ?? null,
+  } : null;
+}
+
+function safeDomain(domain) {
+  return {
+    name: domain?.name ?? domain?.domain ?? null,
+    status: domain?.status ?? null,
+    domainId: domain?.id ?? domain?.domain_id ?? null,
+  };
+}
+
+function safeProject(project) {
+  assertNotNiteOwl('Pages project inventory', project?.name, project?.domains, project?.source?.config?.owner, project?.source?.config?.repo_name);
+  return {
+    id: project?.id ?? null,
+    name: project?.name ?? null,
+    productionBranch: project?.production_branch ?? null,
+    domains: Array.isArray(project?.domains) ? project.domains : [],
+    source: safeSource(project?.source),
+  };
+}
+
+async function getProject() {
+  const result = await request('GET', `${accountBase}/pages/projects/${encodeURIComponent(projectName)}`);
+  assertSuccess(`Pages project ${projectName} lookup`, result);
+  return result.result;
+}
+
+async function listDomains() {
+  const result = await request('GET', `${accountBase}/pages/projects/${encodeURIComponent(projectName)}/domains`);
+  assertSuccess(`Pages domains ${projectName} lookup`, result);
+  return Array.isArray(result.result) ? result.result : [];
+}
+
+function automaticDeploymentsEnabled(source) {
+  const config = source?.config ?? {};
+  return config.production_deployments_enabled !== false
+    || (config.preview_deployment_setting ?? 'all') !== 'none';
+}
+
+async function main() {
+  const beforeProject = await getProject();
+  const beforeDomains = await listDomains();
+  const beforeSafeProject = safeProject(beforeProject);
+  const beforeSafeDomains = beforeDomains.map(safeDomain);
+  const canonical = beforeDomains.find((domain) => (domain?.name ?? domain?.domain) === canonicalDomain);
+  const legacy = beforeDomains.find((domain) => (domain?.name ?? domain?.domain) === legacyDomain);
+
+  if (!canonical || canonical.status !== 'active') {
+    throw new Error(`Canonical Pages domain ${canonicalDomain} is not active; refusing source cleanup`);
+  }
+
+  let automaticDeploymentsDisabled = !automaticDeploymentsEnabled(beforeProject.source);
+  if (!automaticDeploymentsDisabled) {
+    const disabled = await request('PATCH', `${accountBase}/pages/projects/${encodeURIComponent(projectName)}`, {
+      source: {
+        config: {
+          production_deployments_enabled: false,
+          preview_deployment_setting: 'none',
+          deployments_enabled: false,
+        },
+      },
+    });
+    assertSuccess(`Disable automatic deployments for ${projectName}`, disabled);
+    automaticDeploymentsDisabled = true;
+  }
+
+  let legacyDomainDetached = !legacy;
+  if (legacy) {
+    const detached = await request(
+      'DELETE',
+      `${accountBase}/pages/projects/${encodeURIComponent(projectName)}/domains/${encodeURIComponent(legacyDomain)}`,
+    );
+    if (!detached.ok && detached.status !== 404) {
+      throw new Error(`Detach legacy Pages domain ${legacyDomain} failed with HTTP ${detached.status ?? 'unknown'}: ${JSON.stringify(detached.errors)}`);
+    }
+    legacyDomainDetached = true;
+  }
+
+  const afterProject = await getProject();
+  const afterDomains = await listDomains();
+  const afterSafeProject = safeProject(afterProject);
+  const afterSafeDomains = afterDomains.map(safeDomain);
+  const afterCanonical = afterDomains.find((domain) => (domain?.name ?? domain?.domain) === canonicalDomain);
+  const afterLegacy = afterDomains.find((domain) => (domain?.name ?? domain?.domain) === legacyDomain);
+  if (!afterCanonical || afterCanonical.status !== 'active') throw new Error(`Canonical Pages domain ${canonicalDomain} is not active after cleanup`);
+  if (automaticDeploymentsEnabled(afterProject.source)) throw new Error('Automatic Pages deployments remain enabled after cleanup');
+  if (afterLegacy) throw new Error(`Legacy Pages domain ${legacyDomain} remains attached after cleanup`);
+
+  const evidence = {
+    schemaVersion: 1,
+    capturedAt: new Date().toISOString(),
+    releaseSha,
+    status: 'verified',
+    project: afterSafeProject,
+    canonicalDomain: safeDomain(afterCanonical),
+    legacyDomain: {
+      name: legacyDomain,
+      detached: legacyDomainDetached,
+      prior: legacy ? safeDomain(legacy) : null,
+      presentAfter: Boolean(afterLegacy),
+    },
+    automaticDeployments: {
+      disabled: automaticDeploymentsDisabled,
+      priorEnabled: automaticDeploymentsEnabled(beforeProject.source),
+    },
+    rollback: {
+      artifactsProven: true,
+      priorProject: beforeSafeProject,
+      priorDomains: beforeSafeDomains,
+      instructions: [
+        `PATCH /accounts/${accountId}/pages/projects/${projectName} with the captured source configuration, after verifying the canonical project still owns ${canonicalDomain}.`,
+        `POST /accounts/${accountId}/pages/projects/${projectName}/domains with {"name":"${legacyDomain}"} only if the retired domain is explicitly approved for rollback and its DNS ownership is verified.`,
+        `Re-run the read-only Cloudflare inventory and verify ${canonicalDomain} before restoring any automatic deployment setting.`,
+      ],
+    },
+    niteOwl: 'EXTERNAL / OUT OF SCOPE; no Nite Owl resource was inspected or mutated.',
+  };
+
+  fs.mkdirSync(path.dirname(evidencePath), { recursive: true });
+  fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+  console.log(JSON.stringify({
+    status: evidence.status,
+    project: projectName,
+    releaseSha,
+    canonicalDomain,
+    legacyDomainDetached,
+    automaticDeploymentsDisabled,
+  }));
+}
+
+await main();

--- a/scripts/retired-reference-allowlist.json
+++ b/scripts/retired-reference-allowlist.json
@@ -23,8 +23,11 @@
     { "path": "scripts/cloudflare/audit-account.mjs", "kind": "retirement-inventory", "reason": "The read-only Cloudflare inventory must recognize legacy Lythaus resources and explicitly ignore external resources; it records no credentials and performs no mutations." },
     { "path": "scripts/cloudflare/execute-lythaus-pages-cutover.mjs", "kind": "retirement-control", "reason": "The permanent, fail-closed cutover control names only the known legacy Lythaus Pages project and preview Access application so it can retire them without touching external resources." },
     { "path": "scripts/cloudflare/rotate-lythaus-access-service-token.mjs", "kind": "retirement-control", "reason": "The protected Access rotation control recognizes and retires only the Lythaus legacy service-token path while preserving explicit Nite Owl exclusion." },
+    { "path": "scripts/cloudflare/execute-lythaus-web-source-hygiene.mjs", "kind": "retirement-control", "reason": "The protected web hygiene control names only the known retired Lythaus Pages domain and disables its historical Git deployment path without exposing credentials." },
     { "path": ".github/workflows/cloudflare-lythaus-pages-cutover.yml", "kind": "retirement-gate", "reason": "The protected cutover workflow carries exact-SHA, Access, DNS, rollback, and narrowly scoped legacy-resource retirement gates." },
+    { "path": ".github/workflows/cloudflare-lythaus-web-source-hygiene.yml", "kind": "retirement-gate", "reason": "The protected web hygiene workflow carries exact-SHA, canonical-domain, mutation-confirmation, and rollback-evidence gates." },
     { "path": "scripts/tests/cloudflare-pages-cutover.test.mjs", "kind": "retirement-test", "reason": "Regression tests assert that legacy-resource handling stays exact-SHA, rollback-capable, and outside the Nite Owl scope." },
+    { "path": "scripts/tests/cloudflare-web-source-hygiene.test.mjs", "kind": "retirement-test", "reason": "Regression tests assert that the web cleanup remains allowlisted, exact-SHA, mutation-safe, and outside the Nite Owl scope." },
     { "path": "scripts/validate-no-retired-provider-dependencies.mjs", "kind": "guard", "reason": "The guard constructs forbidden patterns and reads the allowlist." }
   ]
 }

--- a/scripts/tests/cloudflare-audit-contract.test.mjs
+++ b/scripts/tests/cloudflare-audit-contract.test.mjs
@@ -7,7 +7,7 @@ test('Cloudflare audit remains read-only and covers scoped integrations and curr
   for (const forbidden of ['method: \'POST\'', 'method: \'PUT\'', 'method: \'PATCH\'', 'method: \'DELETE\'']) {
     if (source.includes(forbidden)) throw new Error(`mutating request found: ${forbidden}`);
   }
-  for (const required of ['sourceIntegration', 'triggerType', '/builds/workers/', 'deployHookInventory', 'const integrations', 'resources: resourceCollections', 'classificationPolicy', 'EXTERNAL / OUT OF SCOPE', 'NITE_OWL_MARKERS']) {
+  for (const required of ['sourceIntegration', 'triggerType', '/builds/workers/', 'deployHookInventory', 'const integrations', 'resources: resourceCollections', 'classificationPolicy', 'legacyProviderExceptions', 'EXTERNAL / OUT OF SCOPE', 'NITE_OWL_MARKERS']) {
     if (!source.includes(required)) throw new Error(`missing Cloudflare inventory contract: ${required}`);
   }
   for (const forbidden of ['hook.url', 'hook.secret', 'publicAccessValues', 'gh issue create', 'issues: write']) {

--- a/scripts/tests/cloudflare-web-source-hygiene.test.mjs
+++ b/scripts/tests/cloudflare-web-source-hygiene.test.mjs
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const source = fs.readFileSync('scripts/cloudflare/execute-lythaus-web-source-hygiene.mjs', 'utf8');
+const workflow = fs.readFileSync('.github/workflows/cloudflare-lythaus-web-source-hygiene.yml', 'utf8');
+
+test('web source hygiene is exact-SHA, allowlisted, and fail-closed', () => {
+  for (const required of [
+    "projectName !== 'lythaus-web'",
+    "canonicalDomain !== 'app.lythaus.co'",
+    "legacyDomain !== 'app.lythaus.asora.co.za'",
+    'CONFIRM_CLEANUP=true',
+    'source:',
+    'production_deployments_enabled: false',
+    "preview_deployment_setting: 'none'",
+    'DELETE',
+    'canonicalDomain',
+    'rollback',
+  ]) {
+    assert(source.includes(required), `missing hygiene guard: ${required}`);
+  }
+  assert(source.includes('nite-owl') && source.includes('EXTERNAL / OUT OF SCOPE'), 'Nite Owl boundary is missing');
+  assert(source.includes("method === 'GET'") && source.includes('attempt <= (readOnly ? 5 : 1)'), 'mutation retry boundary is missing');
+});
+
+test('web source hygiene workflow is protected and exact-SHA gated', () => {
+  for (const required of [
+    'environment: production',
+    'ref: ${{ inputs.release_sha }}',
+    'git rev-parse origin/main',
+    'test "$CONFIRM_CLEANUP" = true',
+    'CLOUDFLARE_API_TOKEN',
+    'lythaus-web-source-hygiene-${{ inputs.release_sha }}',
+  ]) {
+    assert(workflow.includes(required), `missing workflow gate: ${required}`);
+  }
+});

--- a/scripts/validate-no-retired-provider-dependencies.mjs
+++ b/scripts/validate-no-retired-provider-dependencies.mjs
@@ -43,8 +43,11 @@ const approvedAllowlistPaths = new Set([
   'scripts/cloudflare/audit-account.mjs',
   'scripts/cloudflare/execute-lythaus-pages-cutover.mjs',
   'scripts/cloudflare/rotate-lythaus-access-service-token.mjs',
+  'scripts/cloudflare/execute-lythaus-web-source-hygiene.mjs',
   '.github/workflows/cloudflare-lythaus-pages-cutover.yml',
+  '.github/workflows/cloudflare-lythaus-web-source-hygiene.yml',
   'scripts/tests/cloudflare-pages-cutover.test.mjs',
+  'scripts/tests/cloudflare-web-source-hygiene.test.mjs',
   'scripts/validate-no-retired-provider-dependencies.mjs',
 ]);
 


### PR DESCRIPTION
## Summary\n- add an exact-SHA, production-gated hygiene workflow for the canonical lythaus-web Pages project\n- disable automatic Git deployments and detach only the retired app.lythaus.asora.co.za binding after verifying app.lythaus.co\n- record sanitized rollback evidence and classify active legacy bindings separately from immutable provider metadata\n\n## Safety\n- allowlists only lythaus-web, app.lythaus.co, and app.lythaus.asora.co.za\n- refuses all Nite Owl markers\n- does not retry mutations or expose provider secrets\n\n## Validation\n- node --check audit and hygiene scripts\n- focused Cloudflare contract tests pass