### PR TITLE
security: audit Cloudflare token control safely

### DIFF
--- a/.github/workflows/cloudflare-lythaus-token-control-audit.yml
+++ b/.github/workflows/cloudflare-lythaus-token-control-audit.yml
@@ -1,0 +1,43 @@
+name: Cloudflare Lythaus token-control audit
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-lythaus-token-control-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Sanitized Cloudflare token-control audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    permissions:
+      contents: read
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_TOKEN_CONTROL_OUTPUT: .artifacts/provider-inventory/cloudflare-token-control.json
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '22'
+      - name: Capture read-only token-control capability
+        run: node scripts/cloudflare/audit-lythaus-token-control.mjs
+      - name: Require sanitized evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s .artifacts/provider-inventory/cloudflare-token-control.json
+          jq -e '.mutationPerformed == false and .capabilities.githubSecretWriteAttempted == false' .artifacts/provider-inventory/cloudflare-token-control.json >/dev/null
+      - name: Upload sanitized token-control evidence
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: cloudflare-lythaus-token-control-${{ github.sha }}
+          if-no-files-found: error
+          path: .artifacts/provider-inventory/cloudflare-token-control.json

--- a/scripts/cloudflare/audit-lythaus-token-control.mjs
+++ b/scripts/cloudflare/audit-lythaus-token-control.mjs
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const token = process.env.CLOUDFLARE_API_TOKEN ?? '';
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? '';
+const outputPath = process.env.CLOUDFLARE_TOKEN_CONTROL_OUTPUT ?? '.artifacts/provider-inventory/cloudflare-token-control.json';
+
+if (!token) throw new Error('CLOUDFLARE_API_TOKEN is required');
+if (!/^[a-f0-9]{32}$/.test(accountId)) throw new Error('CLOUDFLARE_ACCOUNT_ID must be a 32-character account ID');
+
+const base = 'https://api.cloudflare.com/client/v4';
+const headers = { Authorization: `Bearer ${token}`, Accept: 'application/json' };
+
+function safeError(payload, status) {
+  const errors = Array.isArray(payload?.errors) ? payload.errors : [];
+  const first = errors[0] ?? {};
+  return {
+    status,
+    code: first.code ?? null,
+    message: String(first.message ?? payload?.message ?? '').slice(0, 240),
+  };
+}
+
+function safeResult(payload) {
+  const result = payload?.result;
+  if (Array.isArray(result)) return { kind: 'array', count: result.length };
+  if (!result || typeof result !== 'object') return { kind: typeof result };
+  return {
+    kind: 'object',
+    keys: Object.keys(result).filter((key) => !/token|secret|value|credential/i.test(key)).sort(),
+  };
+}
+
+async function request(label, endpoint) {
+  const url = `${base}${endpoint}`;
+  let response;
+  let payload = {};
+  try {
+    response = await fetch(url, { headers });
+    try { payload = await response.json(); } catch { payload = {}; }
+  } catch (error) {
+    return { label, endpoint, ok: false, error: { status: null, code: 'NETWORK_ERROR', message: String(error?.message ?? error).slice(0, 240) } };
+  }
+  if (!response.ok || payload.success === false) return { label, endpoint, ok: false, error: safeError(payload, response.status) };
+  return { label, endpoint, ok: true, result: safeResult(payload) };
+}
+
+const checks = await Promise.all([
+  request('user-token-verify', '/user/tokens/verify'),
+  request('account-token-verify', `/accounts/${accountId}/tokens/verify`),
+  request('account-token-list', `/accounts/${accountId}/tokens`),
+  request('account-token-write-permission', `/accounts/${accountId}/tokens/permission_groups?name=${encodeURIComponent('Account API Tokens Write')}`),
+  request('account-token-read-permission', `/accounts/${accountId}/tokens/permission_groups?name=${encodeURIComponent('Account API Tokens Read')}`),
+]);
+
+const byLabel = Object.fromEntries(checks.map((check) => [check.label, check]));
+const accountManagement = [byLabel['account-token-verify'], byLabel['account-token-list'], byLabel['account-token-write-permission']];
+const report = {
+  schemaVersion: 1,
+  capturedAt: new Date().toISOString(),
+  reviewedSha: process.env.GITHUB_SHA ?? null,
+  accountId,
+  scope: 'Lythaus Cloudflare account and lythaus.co zone only; no Nite Owl resource enumeration or mutation',
+  mutationPerformed: false,
+  checks,
+  capabilities: {
+    currentTokenVerification: checks.some((check) => check.ok),
+    accountTokenManagementRead: accountManagement.slice(0, 2).every((check) => check.ok),
+    accountTokenWritePermissionEndpointReadable: byLabel['account-token-write-permission'].ok,
+    accountTokenWritePermissionGranted: byLabel['account-token-write-permission'].ok && (byLabel['account-token-write-permission'].result?.count ?? 0) > 0,
+    githubSecretWriteAttempted: false,
+  },
+};
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+console.log(`Wrote sanitized Cloudflare token-control evidence to ${outputPath}.`);

--- a/scripts/tests/cloudflare-token-control-audit.test.mjs
+++ b/scripts/tests/cloudflare-token-control-audit.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const script = fs.readFileSync(new URL('../cloudflare/audit-lythaus-token-control.mjs', import.meta.url), 'utf8');
+const workflow = fs.readFileSync(new URL('../../.github/workflows/cloudflare-lythaus-token-control-audit.yml', import.meta.url), 'utf8');
+
+test('Cloudflare token-control audit is read-only and sanitized', () => {
+  assert.match(script, /\/user\/tokens\/verify/);
+  assert.match(script, /\/accounts\/\$\{accountId\}\/tokens\/verify/);
+  assert.match(script, /mutationPerformed: false/);
+  assert.match(script, /filter\(\(key\) => !\/token\|secret\|value\|credential\/i/);
+  assert.doesNotMatch(script, /method:\s*['"](?:POST|PUT|PATCH|DELETE)['"]/);
+  assert.match(workflow, /environment: production/);
+  assert.match(workflow, /githubSecretWriteAttempted == false/);
+});


### PR DESCRIPTION
Add a permanent protected, read-only Cloudflare token-control capability audit. It records only sanitized endpoint capability/error metadata, explicitly performs no provider mutation, excludes Nite Owl resource handling, and prevents false credential-rotation attestations.